### PR TITLE
Update readme, add how to run a single test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,23 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with
-[`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Doula Medicaid
 
 ## Getting Started
 
 First, run the development server:
 
-```bash
+```sh
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-`localhost:3000/checker` is where the PDF checker is visible
+To tests:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the
-file.
+```sh
+# Run all tests
+npm test
 
-This project uses
-[`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to
-automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback
-and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the
-[Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme)
-from the creators of Next.js.
-
-Check out our
-[Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying)
-for more details.
+# Run test in specific file path, matching test description
+npm test -- --runTestsByPath "<path to file>" -t "<included in test block name>"
+# e.g.
+npm test -- --runTestsByPath "src/app/form/(formSteps)/personal-information/PersonalInformationStep.test.tsx" -t "updates first name"
+```


### PR DESCRIPTION
Include example for running a single test. This is technically in jest/other testing framework documentation, but I've found it useful to put in the readme because I've had multiple coworkers who didn't realize that you could run a single test (especially without changing the code, and forgetting to undo a `.only`).