### PR TITLE
Await tests and clean up session storage

### DIFF
--- a/src/app/form/(formSteps)/personal-information/PersonalInformationStep.test.tsx
+++ b/src/app/form/(formSteps)/personal-information/PersonalInformationStep.test.tsx
@@ -15,31 +15,35 @@ async function checkTextField(fieldName: string, expectedValue: string) {
 }
 
 describe("<PersonalInformationStep />", () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
   it("updates first name", async () => {
-    checkTextField("First name", "Test first name");
+    await checkTextField("First name", "Test first name");
   });
 
   it("updates middle name", async () => {
-    checkTextField("Middle name (optional)", "Test middle name");
+    await checkTextField("Middle name (optional)", "Test middle name");
   });
 
   it("updates last name", async () => {
-    checkTextField("Last name", "Test last name");
+    await checkTextField("Last name", "Test last name");
   });
 
   it("updates street address 1", async () => {
-    checkTextField("Street address 1", "Test address 1");
+    await checkTextField("Street address 1", "Test address 1");
   });
 
   it("updates street address 2", async () => {
-    checkTextField("Street address 2 (optional)", "Test address 2");
+    await checkTextField("Street address 2 (optional)", "Test address 2");
   });
 
   it("updates city", async () => {
-    checkTextField("City", "Test city");
+    await checkTextField("City", "Test city");
   });
 
   it("updates zip code", async () => {
-    checkTextField("ZIP", "12345");
+    await checkTextField("ZIP", "12345");
   });
 });


### PR DESCRIPTION
Without the await, the test is done once the promise is created, and does not actually wait for the promise to resolve.

One can test this by adding a `expect(false).toBe(true);` to the end of `checkTextField`. The tests will pass anyway.

## Link to issue

## What was done?

- Explain the implementation goals being solved or the feature with the reviewer in mind
- Mention any relevant issues or insights to be shared with the reviewer.
- Alternatives considered

## Accessibility

- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the WAVE extension.

## How should a reviewer test?

- Describe the testing approach taken to verify the changes, including:
  - Unit/integration/manual tests
  - Test data used

## Screenshots (for visual changes)

- Before
- After
