### PR TITLE
24 disclosure of ownership q1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2957,11 +2957,10 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3714,11 +3713,10 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5745,11 +5743,10 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }

--- a/src/app/form/(formSteps)/disclosures/DisclosureStep.test.tsx
+++ b/src/app/form/(formSteps)/disclosures/DisclosureStep.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { getValue } from "../../_utils/sessionStorage";
+import DisclosuresStep from "./page";
+
+describe("<DisclosuresStep />", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("saves natureOfDisclosingEntity as null when user selects no", async () => {
+    const user = userEvent.setup();
+    render(<DisclosuresStep />);
+    const noButton = screen.getByRole("radio", {
+      name: "No, my doula business is not a sole proprietorship",
+    });
+    const yesButton = screen.getByRole("radio", {
+      name: "Yes, my doula business is a sole proprietorship",
+    });
+    await user.click(yesButton);
+    expect(getValue("natureOfDisclosingEntity")).toBe("SoleProprietorship");
+    await user.click(noButton);
+    expect(noButton).toBeChecked();
+    expect(getValue("natureOfDisclosingEntity")).toBe(null);
+  });
+
+  it("saves natureOfDisclosingEntity as SoleProprietorship when user selects yes", async () => {
+    const user = userEvent.setup();
+    render(<DisclosuresStep />);
+    const noButton = screen.getByRole("radio", {
+      name: "No, my doula business is not a sole proprietorship",
+    });
+    const yesButton = screen.getByRole("radio", {
+      name: "Yes, my doula business is a sole proprietorship",
+    });
+    expect(yesButton).not.toBeChecked();
+    expect(noButton).not.toBeChecked();
+    expect(getValue("natureOfDisclosingEntity")).toBe(null);
+    await user.click(yesButton);
+    expect(yesButton).toBeChecked();
+    expect(getValue("natureOfDisclosingEntity")).toBe("SoleProprietorship");
+  });
+});

--- a/src/app/form/(formSteps)/disclosures/page.tsx
+++ b/src/app/form/(formSteps)/disclosures/page.tsx
@@ -1,9 +1,34 @@
 "use client";
 
+import { Fieldset, Form, Radio } from "@trussworks/react-uswds";
 import React from "react";
+import { removeKey, setKeyValue } from "../../_utils/sessionStorage";
 
-const FormStep: React.FC = () => {
-  return <div>hi</div>;
+const DisclosuresStep: React.FC = () => {
+  return (
+    <div>
+      <Form
+        onSubmit={() => {
+          throw "Not implemented";
+        }}
+      >
+        <Fieldset legend="Is your doula business a sole proprietorship?" legendStyle="large">
+          <Radio
+            id="soleProprietorshipYes"
+            name="setSoleProprietorship"
+            label="Yes, my doula business is a sole proprietorship"
+            onChange={() => setKeyValue("natureOfDisclosingEntity", "SoleProprietorship")}
+          />
+          <Radio
+            id="soleProprietorshipNo"
+            name="setSoleProprietorship"
+            label="No, my doula business is not a sole proprietorship"
+            onChange={() => removeKey("natureOfDisclosingEntity")}
+          />
+        </Fieldset>
+      </Form>
+    </div>
+  );
 };
 
-export default FormStep;
+export default DisclosuresStep;

--- a/src/app/form/(formSteps)/personal-information/page.tsx
+++ b/src/app/form/(formSteps)/personal-information/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@trussworks/react-uswds";
 import React, { useEffect, useState } from "react";
 import { formatDateOfBirthDefaultValue } from "../../_utils/inputFields/dateOfBirth";
-import { AddressState } from "../../_utils/inputFields/types";
+import { AddressState } from "../../_utils/inputFields/enums";
 import { getValue, setKeyValue } from "../../_utils/sessionStorage";
 
 interface PersonalInformationData {

--- a/src/app/form/(formSteps)/review/page.tsx
+++ b/src/app/form/(formSteps)/review/page.tsx
@@ -3,7 +3,7 @@
 import { zipForms } from "@/app/utils/zip";
 import React, { useEffect, useState } from "react";
 import { fillAllForms, FormData } from "../../_utils/fillPdf/form";
-import { AddressState } from "../../_utils/inputFields/types";
+import { AddressState, DisclosingEntity } from "../../_utils/inputFields/enums";
 import { getValue } from "../../_utils/sessionStorage";
 
 const getFormData = (): FormData => {
@@ -12,6 +12,9 @@ const getFormData = (): FormData => {
 
   const stateString = (getValue("state") as keyof typeof AddressState) || null;
   const state = stateString ? AddressState[stateString] : null;
+  const disclosingEntityString =
+    (getValue("natureOfDisclosingEntity") as keyof typeof DisclosingEntity) || null;
+  const disclosingEntity = disclosingEntityString ? DisclosingEntity[disclosingEntityString] : null;
 
   return {
     firstName: getValue("firstName"),
@@ -26,6 +29,7 @@ const getFormData = (): FormData => {
     city: getValue("city"),
     state: state,
     zip: getValue("zip"),
+    natureOfDisclosingEntity: disclosingEntity,
   };
 };
 

--- a/src/app/form/_utils/fillPdf/ffsIndividual.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual.ts
@@ -1,42 +1,24 @@
 import { type FormData, fillForm } from "./form";
+import { DisclosingEntity } from "../inputFields/enums";
 import { formatDateOfBirth } from "./formatters";
 
 export const FFS_INDIVIDUAL_PDF_NAME = "ffs_individual_filled.pdf";
 export const FFS_INDIVIDUAL_PDF_PATH = "/pdf/ffs_individual.pdf";
 
-export const mapFfsIndividualFields = (formData: FormData): { [key: string]: string } => {
-  const legalName = `${formData.firstName}${formData.middleName ? " " + formData.middleName : ""} ${formData.lastName}`;
-  const dateOfBirth = formatDateOfBirth(formData.dateOfBirth);
+export interface PDFData {
+  [key: string]: string | boolean;
+}
 
-  return {
-    // Page 3 - doula qualifications form
-    fd427LegalName: legalName,
-    fd427dateofbirthDate1_af_date: dateOfBirth,
-
-    // Page 5 - authorization agreement for automated deposits of state payments
-    fd443telephoneno: formData.phoneNumber || "",
-    fd443npino: formData.npiNumber || "",
-
-    // Page 7 - individual doula provider application section I provider identification
-    fd425legalname: legalName,
-    fd452dobfdate_af_date: dateOfBirth,
-    fd425npinumber: formData.npiNumber || "",
-    fd425telephoneno: formData.phoneNumber || "",
-    fd425emailaddress: formData.email || "",
-
-    fd425mailtoaddressstreet: `${formData.streetAddress1}${formData.streetAddress2 ? " " + formData.streetAddress2 : ""}`,
-    fd425mailtoaddresscity: formData.city || "",
-    fd425mailtoaddressstate: formData.state || "", // input validation not yet implemented
-    fd425mailtoaddresszip: formData.zip || "",
-
-    // Page 12 - request for paper updates
-    "fd455aREQPAPER_Provider Name": legalName,
-    "fd455aREQPAPER_Provider Number": formData.npiNumber || "",
-    "fd455aREQPAPER_Telephone Number": formData.phoneNumber || "",
-    "fd455aREQPAPER_Mail To Address 1": formData.streetAddress1 || "",
-    "fd455aREQPAPER_Mail To Address 2": formData.streetAddress2 || "",
-    "fd455aREQPAPER_Mail To Address 3": `${formData.city}, ${formData.state} ${formData.zip}`,
+export const mapFfsIndividualFields = (formData: FormData): PDFData => {
+  const fieldsToFill: PDFData = {
+    ...getPage3Fields(formData),
+    ...getPage5Fields(formData),
+    ...getPage7Fields(formData),
+    ...getPage12Fields(formData),
+    ...getPage16Fields(formData),
   };
+
+  return fieldsToFill;
 };
 
 export const fillFfsIndividualForm = (formData: FormData) => {
@@ -45,4 +27,79 @@ export const fillFfsIndividualForm = (formData: FormData) => {
     FFS_INDIVIDUAL_PDF_PATH,
     FFS_INDIVIDUAL_PDF_NAME,
   );
+};
+
+const getPage3Fields = (formData: FormData): PDFData => {
+  // Page 3 - doula qualifications form
+  return {
+    fd427dateofbirthDate1_af_date: formatDateOfBirth(formData.dateOfBirth),
+    fd427LegalName: formatName(formData),
+  };
+};
+
+const getPage5Fields = (formData: FormData): PDFData => {
+  // Page 5 - authorization agreement for automated deposits of state payments
+  return {
+    fd443telephoneno: formData.phoneNumber || "",
+    fd443npino: formData.npiNumber || "",
+  };
+};
+
+const getPage7Fields = (formData: FormData): PDFData => {
+  // Page 7 - individual doula provider application section I provider identification
+  return {
+    fd425legalname: formatName(formData),
+    fd452dobfdate_af_date: formatDateOfBirth(formData.dateOfBirth),
+    fd425npinumber: formData.npiNumber || "",
+    fd425telephoneno: formData.phoneNumber || "",
+    fd425emailaddress: formData.email || "",
+
+    fd425mailtoaddressstreet: `${formData.streetAddress1}${formData.streetAddress2 ? " " + formData.streetAddress2 : ""}`,
+    fd425mailtoaddressstate: formData.state || "", // input validation not yet implemented
+    fd425mailtoaddresscity: formData.city || "", 
+    fd425mailtoaddresszip: formData.zip || "",
+  };
+};
+
+const getPage12Fields = (formData: FormData): PDFData => {
+  // Page 12 - request for paper updates
+  return {
+    "fd455aREQPAPER_Provider Name": formatName(formData),
+    "fd455aREQPAPER_Provider Number": formData.npiNumber || "",
+    "fd455aREQPAPER_Telephone Number": formData.phoneNumber || "",
+    "fd455aREQPAPER_Mail To Address 1": formData.streetAddress1 || "",
+    "fd455aREQPAPER_Mail To Address 2": formData.streetAddress2 || "",
+    "fd455aREQPAPER_Mail To Address 3": formatAddressLine3(formData),
+  };
+};
+
+const getPage16Fields = (formData: FormData): PDFData => {
+  // Page 16 - disclosing entity sole proprietorship
+  if (formData.natureOfDisclosingEntity == DisclosingEntity.SoleProprietorship) {
+    return {
+      "fd452disclosingentitySole Proprietorship": true,
+      fd452nameofdisclosingentity: formatName(formData),
+      fd452telephonenumber: formData.phoneNumber || "",
+      fd452providernumbandornpi: formData.npiNumber || "",
+    };
+  }
+  
+  return {};
+  
+};
+
+const formatAddressLine3 = (formData: FormData): string => {
+  return `${formData.city}, ${formData.state} ${formData.zip}`;
+};
+
+const formatName = (formData: FormData): string => {
+  if (!formData.firstName || !formData.lastName) {
+    throw new Error("First name and last name are required to fill the name field.");
+  }
+
+  if (formData.middleName) {
+    return `${formData.firstName} ${formData.middleName} ${formData.lastName}`;
+  }
+
+  return `${formData.firstName} ${formData.lastName}`;
 };

--- a/src/app/form/_utils/inputFields/enums.ts
+++ b/src/app/form/_utils/inputFields/enums.ts
@@ -1,3 +1,7 @@
+export enum DisclosingEntity {
+  "SoleProprietorship" = "SoleProprietorship",
+}
+
 export enum AddressState {
   "AL" = "AL",
   "AK" = "AK",

--- a/src/app/form/_utils/sessionStorage.ts
+++ b/src/app/form/_utils/sessionStorage.ts
@@ -5,3 +5,7 @@ export function setKeyValue(key: string, value: string): void {
 export function getValue(key: string): string | null {
   return window.sessionStorage.getItem(key);
 }
+
+export function removeKey(key: string): void {
+  window.sessionStorage.removeItem(key);
+}


### PR DESCRIPTION
## Link to issue
https://github.com/newjersey/doula-pm/issues/24

## What was done?

This commit adds the Disclosure of Ownership page. We added a frontend component with the page and logic to take fields from Personal Information and add them to the pdf when individuals are sole proprietors. We only handle section 1 of the Disclosure of Ownership page. There will be more fields and disclosing entity types to follow.

## Accessibility

- [X] I have made sure this works with a screenreader!
- [X] I have checked this with the WAVE extension.

## How should a reviewer test?

Get the branch, run `npm run dev` and run through the process with yes for the sole proprietorship question and verify that it fills the pdf (page 16 for the ffs individual form). Then run through the process with no for the sole proprietorship question and verify that it does not fill the pdf. 

The reviewer can also run `npm run test` to run the tests written for the Disclosures page.

## Screenshots (for visual changes)

- Before
![image (1)](https://github.com/user-attachments/assets/22a0fea4-cfc1-401e-b61b-2aa3d623ed11)


- After
<img width="605" alt="Screenshot 2025-06-26 at 7 57 22 AM" src="https://github.com/user-attachments/assets/627e12d9-7e09-48bf-bec9-463f6604aa18" />
<img width="998" alt="Screenshot 2025-06-26 at 7 58 04 AM" src="https://github.com/user-attachments/assets/24d6cf69-15c0-46be-90dd-4efacfc85b71" />
