### PR TITLE
[#87] Proof of concept for horizontal form fields

### DIFF
--- a/src/app/form/(formSteps)/personal-information/page.tsx
+++ b/src/app/form/(formSteps)/personal-information/page.tsx
@@ -95,38 +95,43 @@ const PersonalInformationStep: React.FC = () => {
           onSubmit={() => {
             throw new Error("Not implemented");
           }}
+          className="maxw-tablet"
         >
-          <Fieldset legend="Name" legendStyle="srOnly">
-            <Label htmlFor="firstName">First name</Label>
-            <TextInput
-              id="firstName"
-              name="firstName"
-              type="text"
-              required
-              value={personalInformationData.firstName || ""}
-              onChange={handleChange}
-            />
-
-            <Label htmlFor="middleName" hint=" (optional)">
-              Middle name
-            </Label>
-            <TextInput
-              id="middleName"
-              name="middleName"
-              type="text"
-              value={personalInformationData.middleName || ""}
-              onChange={handleChange}
-            />
-
-            <Label htmlFor="lastName">Last name</Label>
-            <TextInput
-              id="lastName"
-              name="lastName"
-              type="text"
-              required
-              value={personalInformationData.lastName || ""}
-              onChange={handleChange}
-            />
+          <Fieldset legend="Name" legendStyle="srOnly" className="grid-row grid-gap">
+            <div className="tablet:grid-col-4">
+              <Label htmlFor="firstName">First name</Label>
+              <TextInput
+                id="firstName"
+                name="firstName"
+                type="text"
+                required
+                value={personalInformationData.firstName || ""}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="tablet:grid-col-4">
+              <Label htmlFor="middleName" hint=" (optional)">
+                Middle name
+              </Label>
+              <TextInput
+                id="middleName"
+                name="middleName"
+                type="text"
+                value={personalInformationData.middleName || ""}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="tablet:grid-col-4">
+              <Label htmlFor="lastName">Last name</Label>
+              <TextInput
+                id="lastName"
+                name="lastName"
+                type="text"
+                required
+                value={personalInformationData.lastName || ""}
+                onChange={handleChange}
+              />
+            </div>
           </Fieldset>
 
           <hr />


### PR DESCRIPTION
## Link to issue

This commit resolves #[87](https://github.com/newjersey/doula-pm/issues/87).

## What was done?
This commit demonstrates that we can have horizontally side-by-side form fields as shown in [various mockups](https://www.figma.com/design/2R3VxYvZQYsaIxBcWoA1kL/Doula-Prototypes?node-id=1137-10632&p=f&t=GkVzUeJURmTeZdai-0).

It does so by
- Setting the max width of the form to be tablet width
- Setting each form field to be 1/3 of the width, with a gap in between, while the screen width is at least tablet size

Note that this is not pixel perfect with the current mockups. It also makes the other fields wider, but leaving them as is until we handle https://github.com/newjersey/doula-pm/issues/82.

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the WAVE extension.

## How should a reviewer test?

- Locally, run \`npm install\` then \`npm run dev\`.
- Visit http://localhost:3000/form/personal-information

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/f187a9f4-97cc-44f7-ba72-3c37dbda455e)



</details>


<details>
<summary>After</summary>

<img width="895" alt="image" src="https://github.com/user-attachments/assets/f0f91e21-f5a1-446d-bbdc-b6e2919199b9" />

Width comparison with current WIP mockup (below)

<img width="787" alt="image" src="https://github.com/user-attachments/assets/8fcbd308-8844-4f28-afdd-867998e4dce0" />


</details