### PR TITLE
[#82] Break layout and pages into sections and steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ npm test
 # Run test in specific file path, matching test description
 npm test -- --runTestsByPath "<path to file>" -t "<included in test block name>"
 # e.g.
-npm test -- --runTestsByPath "src/app/form/(formSteps)/personal-information/PersonalInformationStep.test.tsx" -t "updates first name"
+npm test -- --runTestsByPath "src/app/form/(formSteps)/personal-information/PersonalInformationStep1.test.tsx" -t "updates first name"
 ```

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/",
-        destination: "/form/personal-information",
+        destination: "/form/personal-details/1",
         permanent: false,
       },
     ];

--- a/src/app/form/(formSteps)/FormLayout.test.tsx
+++ b/src/app/form/(formSteps)/FormLayout.test.tsx
@@ -1,0 +1,61 @@
+import { within } from "@testing-library/dom";
+import { render, screen } from "@testing-library/react";
+import { FormLayout } from "./layout";
+
+describe("<FormLayout />", () => {
+  it("shows the section progress bar", () => {
+    render(
+      <FormLayout pathname="/form/disclosures/1">
+        <div>Test content</div>
+      </FormLayout>,
+    );
+    const progressSection = screen.getByRole("generic", { name: /progress/i });
+    const sections = within(progressSection).getAllByRole("listitem");
+    expect(sections.length).toEqual(3);
+    expect(sections[0]).toHaveTextContent("Personal details");
+    expect(sections[0]).toHaveTextContent("completed");
+    expect(sections[1]).toHaveTextContent("Disclosures");
+    expect(sections[1].getAttribute("aria-current")).toEqual("true");
+    expect(sections[2]).toHaveTextContent("Download forms");
+    expect(sections[2]).toHaveTextContent("not completed");
+  });
+
+  it("shows heading 1 with the step indicator and section title when the title is different from the section name", () => {
+    render(
+      <FormLayout pathname="/form/disclosures/1">
+        <div>Test content</div>
+      </FormLayout>,
+    );
+    const sectionName = "Disclosures";
+    const sectionTitle = "Disclosure of ownership";
+
+    const progressSection = screen.getByRole("generic", { name: /progress/i });
+    const sectionNames = within(progressSection)
+      .getAllByRole("listitem")
+      .map((section) => section.textContent);
+    expect(sectionNames.includes(sectionName)).toBe(true);
+
+    const heading1 = screen.getByRole("heading", { level: 1 });
+    expect(heading1).toHaveTextContent(`1 of 1 ${sectionTitle}`);
+  });
+
+  it("shows heading 1 with only section title when the section has multiple steps", () => {
+    render(
+      <FormLayout pathname="/form/personal-details/2">
+        <div>Test content</div>
+      </FormLayout>,
+    );
+    const heading1 = screen.getByRole("heading", { level: 1 });
+    expect(heading1).toHaveTextContent("2 of 3 Personal details");
+  });
+
+  it("shows heading 1 with the step indicator and section title when the section does not have steps", () => {
+    render(
+      <FormLayout pathname="/form/download">
+        <div>Test content</div>
+      </FormLayout>,
+    );
+    const heading1 = screen.getByRole("heading", { level: 1 });
+    expect(heading1).toHaveTextContent("Download forms");
+  });
+});

--- a/src/app/form/(formSteps)/components/ProgressButtons.test.tsx
+++ b/src/app/form/(formSteps)/components/ProgressButtons.test.tsx
@@ -1,0 +1,246 @@
+import { within } from "@testing-library/dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import { RouterPathnameProvider } from "../../_utils/testUtils";
+import ProgressButtons, { formatStepUrl, getNextStep, getPreviousStep } from "./ProgressButtons";
+
+const getProgressButtonsList = () => {
+  const allLists = screen.getAllByRole("list");
+  const progressButtonsList = allLists.find((list) => {
+    let foundNextOrPrevious = false;
+    const previousButton = within(list).queryByRole("link", { name: "Previous" });
+    const nextButton = within(list).queryByRole("button", { name: "Next" });
+    if (previousButton !== null || nextButton !== null) {
+      foundNextOrPrevious = true;
+    }
+    return foundNextOrPrevious;
+  });
+  expect(progressButtonsList).toBeDefined();
+  return progressButtonsList as HTMLElement;
+};
+
+describe("getNextStep", () => {
+  it("returns null when the current section has no steps and is the last one", () => {
+    const section = { id: "section1", sectionName: "Section 1", heading: "Section 1" };
+    const allSections = [section];
+    const currentStep = {
+      section,
+      stepNum: null,
+    };
+    expect(getNextStep(currentStep, allSections)).toEqual(null);
+  });
+
+  it("returns null when the current section has steps and is the last one", () => {
+    const section = {
+      id: "section1",
+      sectionName: "Section 1",
+      heading: "Section 1",
+      numSteps: 2,
+    };
+    const allSections = [section];
+    const currentStep = {
+      section,
+      stepNum: 2,
+    };
+    expect(getNextStep(currentStep, allSections)).toEqual(null);
+  });
+});
+
+describe("getPreviousStep", () => {
+  it("returns null when the current section has no steps and is the first one", () => {
+    const section = { id: "section1", sectionName: "Section 1", heading: "Section 1" };
+    const allSections = [section];
+    const currentStep = {
+      section,
+      stepNum: null,
+    };
+    expect(getPreviousStep(currentStep, allSections)).toEqual(null);
+  });
+
+  it("returns null when the current section has steps and is the first one", () => {
+    const section = {
+      id: "section1",
+      sectionName: "Section 1",
+      heading: "Section 1",
+      numSteps: 2,
+    };
+    const allSections = [section];
+    const currentStep = {
+      section,
+      stepNum: 1,
+    };
+    expect(getPreviousStep(currentStep, allSections)).toEqual(null);
+  });
+});
+
+describe("getNextStep and getPreviousStep", () => {
+  it("gets the correct next and previous steps when transitioning within a section", () => {
+    const section = {
+      id: "section1",
+      sectionName: "Section 1",
+      heading: "Section 1",
+      numSteps: 2,
+    };
+    const allSections = [section];
+    const firstStep = {
+      section,
+      stepNum: 1,
+    };
+    const secondStep = {
+      section,
+      stepNum: 2,
+    };
+
+    expect(getNextStep(firstStep, allSections)).toEqual(secondStep);
+    expect(getPreviousStep(secondStep, allSections)).toEqual(firstStep);
+  });
+
+  it.each([
+    {
+      name: "both the first and second sections have no steps",
+      firstStep: {
+        section: { id: "section1", sectionName: "Section 1", heading: "Section 1" },
+        stepNum: null,
+      },
+      secondStep: {
+        section: { id: "section2", sectionName: "Section 2", heading: "Section 2" },
+        stepNum: null,
+      },
+    },
+    {
+      name: "the first section has no steps and the second section has steps",
+      firstStep: {
+        section: { id: "section1", sectionName: "Section 1", heading: "Section 1" },
+        stepNum: null,
+      },
+      secondStep: {
+        section: { id: "section2", sectionName: "Section 2", heading: "Section 2", numSteps: 3 },
+        stepNum: 1,
+      },
+    },
+    {
+      name: "the first section has steps and the second section has no steps",
+      firstStep: {
+        section: { id: "section1", sectionName: "Section 1", heading: "Section 1", numSteps: 3 },
+        stepNum: 3,
+      },
+      secondStep: {
+        section: { id: "section2", sectionName: "Section 2", heading: "Section 2" },
+        stepNum: null,
+      },
+    },
+    {
+      name: "both the first and second section have steps",
+      firstStep: {
+        section: { id: "section1", sectionName: "Section 1", heading: "Section 1", numSteps: 3 },
+        stepNum: 3,
+      },
+      secondStep: {
+        section: { id: "section2", sectionName: "Section 2", heading: "Section 2", numSteps: 3 },
+        stepNum: 1,
+      },
+    },
+  ])(
+    "gets the correct next and previous steps when transitioning between sections and $name",
+    ({ firstStep, secondStep }) => {
+      const allSections = [firstStep.section, secondStep.section];
+      expect(getNextStep(firstStep, allSections)).toEqual(secondStep);
+      expect(getPreviousStep(secondStep, allSections)).toEqual(firstStep);
+    },
+  );
+});
+
+describe("formatStepUrl", () => {
+  it("formats the URL correctly when the section has no steps", () => {
+    const step = {
+      section: { id: "section1", sectionName: "Section 1", heading: "Section 1" },
+      stepNum: null,
+    };
+    expect(formatStepUrl(step)).toEqual("/form/section1");
+  });
+  it("formats the URL correctly when the section has steps", () => {
+    const step = {
+      section: { id: "section1", sectionName: "Section 1", heading: "Section 1", numSteps: 3 },
+      stepNum: 2,
+    };
+    expect(formatStepUrl(step)).toEqual("/form/section1/2");
+  });
+});
+
+describe("<ProgressButtons />", () => {
+  it("shows only the next button when on the first step", async () => {
+    const mockPush = jest.fn();
+    const mockRefresh = jest.fn();
+    const router: Partial<AppRouterInstance> = {
+      push: mockPush,
+      refresh: mockRefresh,
+    };
+    const user = userEvent.setup();
+    render(
+      <RouterPathnameProvider
+        pathname="/form/personal-details/1"
+        router={router as AppRouterInstance}
+      >
+        <ProgressButtons />
+      </RouterPathnameProvider>,
+    );
+
+    const progressButtonGroup = getProgressButtonsList();
+    expect(within(progressButtonGroup).getAllByRole("listitem").length).toEqual(1);
+
+    expect(screen.queryByRole("link", { name: "Previous" })).not.toBeInTheDocument();
+    const nextButton = screen.getByRole("button", { name: "Next" });
+    expect(nextButton).toBeInTheDocument();
+    await user.click(nextButton);
+    expect(mockPush).toHaveBeenCalledWith("/form/personal-details/2");
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("shows both previous and next buttons when on a middle step", async () => {
+    const mockPush = jest.fn();
+    const mockRefresh = jest.fn();
+    const router: Partial<AppRouterInstance> = {
+      push: mockPush,
+      refresh: mockRefresh,
+    };
+    const user = userEvent.setup();
+    render(
+      <RouterPathnameProvider
+        pathname="/form/personal-details/2"
+        router={router as AppRouterInstance}
+      >
+        <ProgressButtons />
+      </RouterPathnameProvider>,
+    );
+
+    const progressButtonGroup = getProgressButtonsList();
+    expect(within(progressButtonGroup).getAllByRole("listitem").length).toEqual(2);
+
+    expect(screen.getByRole("link", { name: "Previous" })).toHaveAttribute(
+      "href",
+      "/form/personal-details/1",
+    );
+    const nextButton = screen.getByRole("button", { name: "Next" });
+    expect(nextButton).toBeInTheDocument();
+    await user.click(nextButton);
+    expect(mockPush).toHaveBeenCalledWith("/form/personal-details/3");
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("shows only the previous button when on the last step", () => {
+    render(
+      <RouterPathnameProvider pathname="/form/download">
+        <ProgressButtons />
+      </RouterPathnameProvider>,
+    );
+
+    const progressButtonGroup = getProgressButtonsList();
+    expect(within(progressButtonGroup).getAllByRole("listitem").length).toEqual(1);
+
+    expect(screen.getByRole("link", { name: "Previous" })).toHaveAttribute(
+      "href",
+      "/form/disclosures/1",
+    );
+  });
+});

--- a/src/app/form/(formSteps)/components/ProgressButtons.tsx
+++ b/src/app/form/(formSteps)/components/ProgressButtons.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Button, ButtonGroup, Link } from "@trussworks/react-uswds";
+import { usePathname, useRouter } from "next/navigation";
+import { allSections, getCurrentStep, type Section, type Step } from "../../_utils/sections";
+
+export const getNextStep = (currentStep: Step, allSteps: Array<Section>): Step | null => {
+  if (
+    currentStep.section.numSteps !== undefined &&
+    currentStep.stepNum !== null &&
+    currentStep.stepNum < currentStep.section.numSteps
+  ) {
+    // Increment step
+    return {
+      section: currentStep.section,
+      stepNum: currentStep.stepNum + 1,
+    };
+  } else {
+    // Increment section
+    const currentSectionIndex = allSteps.findIndex(
+      (section) => section.id === currentStep.section.id,
+    );
+    const isFinalStep = currentSectionIndex === allSteps.length - 1;
+    if (isFinalStep) {
+      return null;
+    }
+    const nextSectionIndex = currentSectionIndex + 1;
+    return {
+      section: allSteps[nextSectionIndex],
+      stepNum: allSteps[nextSectionIndex].numSteps === undefined ? null : 1,
+    };
+  }
+};
+
+export const getPreviousStep = (currentStep: Step, allSections: Array<Section>): Step | null => {
+  if (
+    currentStep.section.numSteps !== undefined &&
+    currentStep.stepNum !== null &&
+    currentStep.stepNum > 1
+  ) {
+    // Decrement step
+    return {
+      section: currentStep.section,
+      stepNum: currentStep.stepNum - 1,
+    };
+  } else {
+    // Decrement section
+    const currentSectionIndex = allSections.findIndex(
+      (section) => section.id === currentStep.section.id,
+    );
+    const isFirstStep = currentSectionIndex === 0;
+    if (isFirstStep) {
+      return null;
+    }
+    const nextStepIndex = currentSectionIndex - 1;
+    return {
+      section: allSections[nextStepIndex],
+      stepNum:
+        allSections[nextStepIndex].numSteps === undefined
+          ? null
+          : allSections[nextStepIndex].numSteps,
+    };
+  }
+};
+
+export const formatStepUrl = (step: Step) => {
+  if (step.stepNum !== null) {
+    return `/form/${step.section.id}/${step.stepNum}`;
+  } else {
+    return `/form/${step.section.id}`;
+  }
+};
+
+const ProgressButtons: React.FC = () => {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const currentStep = getCurrentStep(pathname);
+  const nextStep = getNextStep(currentStep, allSections);
+  const previousStep = getPreviousStep(currentStep, allSections);
+
+  const buttons: Array<React.ReactNode> = [];
+  if (previousStep) {
+    buttons.push(
+      <Link
+        key="previous"
+        href={formatStepUrl(previousStep)}
+        className="usa-button  usa-button--outline"
+      >
+        Previous
+      </Link>,
+    );
+  }
+  if (nextStep) {
+    buttons.push(
+      <Button
+        key="next"
+        type="button"
+        onClick={() => {
+          router.push(formatStepUrl(nextStep));
+          router.refresh();
+        }}
+      >
+        Next
+      </Button>,
+    );
+  }
+
+  return (
+    <>
+      <div className="margin-top-4 display-flex flex-column flex-align-end">
+        <ButtonGroup type="default">{buttons}</ButtonGroup>
+      </div>
+    </>
+  );
+};
+
+export default ProgressButtons;

--- a/src/app/form/(formSteps)/disclosures/1/DisclosuresStep1.test.tsx
+++ b/src/app/form/(formSteps)/disclosures/1/DisclosuresStep1.test.tsx
@@ -1,16 +1,21 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { getValue } from "../../_utils/sessionStorage";
-import DisclosuresStep from "./page";
+import { getValue } from "../../../_utils/sessionStorage";
+import { RouterPathnameProvider } from "../../../_utils/testUtils";
+import DisclosuresStep1 from "./page";
 
-describe("<DisclosuresStep />", () => {
+describe("<DisclosuresStep1 />", () => {
   beforeEach(() => {
     sessionStorage.clear();
   });
 
   it("saves natureOfDisclosingEntity as null when user selects no", async () => {
     const user = userEvent.setup();
-    render(<DisclosuresStep />);
+    render(
+      <RouterPathnameProvider pathname="/form/disclosures/1">
+        <DisclosuresStep1 />
+      </RouterPathnameProvider>,
+    );
     const noButton = screen.getByRole("radio", {
       name: "No, my doula business is not a sole proprietorship",
     });
@@ -26,7 +31,11 @@ describe("<DisclosuresStep />", () => {
 
   it("saves natureOfDisclosingEntity as SoleProprietorship when user selects yes", async () => {
     const user = userEvent.setup();
-    render(<DisclosuresStep />);
+    render(
+      <RouterPathnameProvider pathname="/form/disclosures/1">
+        <DisclosuresStep1 />
+      </RouterPathnameProvider>,
+    );
     const noButton = screen.getByRole("radio", {
       name: "No, my doula business is not a sole proprietorship",
     });
@@ -43,7 +52,11 @@ describe("<DisclosuresStep />", () => {
 
   it("saves separateBusinessAddress as true when user selects yes", async () => {
     const user = userEvent.setup();
-    render(<DisclosuresStep />);
+    render(
+      <RouterPathnameProvider pathname="/form/disclosures/1">
+        <DisclosuresStep1 />
+      </RouterPathnameProvider>,
+    );
     const yesSPButton = screen.getByRole("radio", {
       name: "Yes, my doula business is a sole proprietorship",
     });
@@ -65,7 +78,11 @@ describe("<DisclosuresStep />", () => {
 
   it("saves separateBusinessAddress as false when user selects no", async () => {
     const user = userEvent.setup();
-    render(<DisclosuresStep />);
+    render(
+      <RouterPathnameProvider pathname="/form/disclosures/1">
+        <DisclosuresStep1 />
+      </RouterPathnameProvider>,
+    );
     const yesSPButton = screen.getByRole("radio", {
       name: "Yes, my doula business is a sole proprietorship",
     });

--- a/src/app/form/(formSteps)/disclosures/1/page.tsx
+++ b/src/app/form/(formSteps)/disclosures/1/page.tsx
@@ -2,8 +2,9 @@
 
 import { Fieldset, Form, Label, Radio, Select, TextInput } from "@trussworks/react-uswds";
 import React, { useState } from "react";
-import { AddressState } from "../../_utils/inputFields/enums";
-import { removeKey, setKeyValue } from "../../_utils/sessionStorage";
+import { AddressState } from "../../../_utils/inputFields/enums";
+import { removeKey, setKeyValue } from "../../../_utils/sessionStorage";
+import ProgressButtons from "../../components/ProgressButtons";
 
 interface DisclosureBusinessAddressData {
   businessStreetAddress1: string | null;
@@ -13,7 +14,7 @@ interface DisclosureBusinessAddressData {
   businessZip: string | null;
 }
 
-const DisclosuresStep: React.FC = () => {
+const DisclosuresStep1: React.FC = () => {
   const [isSoleProprietorship, setIsSoleProprietorship] = useState<boolean | null>(null);
 
   const [hasSeparateBusinessAddress, setHasSeparateBusinessAddress] = useState<boolean | null>(
@@ -162,8 +163,9 @@ const DisclosuresStep: React.FC = () => {
           </Fieldset>
         )}
       </Form>
+      <ProgressButtons />
     </div>
   );
 };
 
-export default DisclosuresStep;
+export default DisclosuresStep1;

--- a/src/app/form/(formSteps)/download/page.tsx
+++ b/src/app/form/(formSteps)/download/page.tsx
@@ -6,6 +6,7 @@ import type { FormData } from "../../_utils/fillPdf/form";
 import { fillAllForms } from "../../_utils/fillPdf/form";
 import { AddressState, DisclosingEntity } from "../../_utils/inputFields/enums";
 import { getValue } from "../../_utils/sessionStorage";
+import ProgressButtons from "../components/ProgressButtons";
 
 const getFormData = (): FormData => {
   const dateOfBirthString = getValue("dateOfBirth");
@@ -65,6 +66,7 @@ const FormStep: React.FC = () => {
           Download your forms
         </a>
       )}
+      <ProgressButtons />
     </div>
   );
 };

--- a/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import PersonalInformationStep from "./page";
+import { RouterPathnameProvider } from "../../../_utils/testUtils";
+import PersonalDetailsStep1 from "./page";
 
-describe("<PersonalInformationStep />", () => {
+describe("<PersonalDetailsStep1 />", () => {
   afterEach(() => {
     window.sessionStorage.clear();
   });
@@ -20,7 +21,11 @@ describe("<PersonalInformationStep />", () => {
     { name: "ZIP code", key: "zip", testValue: "12345" },
   ])("updates the $name text input", async ({ name, key, testValue }) => {
     const user = userEvent.setup();
-    render(<PersonalInformationStep />);
+    render(
+      <RouterPathnameProvider pathname="/form/personal-details/1">
+        <PersonalDetailsStep1 />
+      </RouterPathnameProvider>,
+    );
     const inputField = screen.getByRole("textbox", {
       name: name,
     });
@@ -34,7 +39,11 @@ describe("<PersonalInformationStep />", () => {
 
   it("updates phone number", async () => {
     const user = userEvent.setup();
-    render(<PersonalInformationStep />);
+    render(
+      <RouterPathnameProvider pathname="/form/personal-details/1">
+        <PersonalDetailsStep1 />
+      </RouterPathnameProvider>,
+    );
     const inputField = screen.getByRole("textbox", {
       name: "Phone number",
     });
@@ -48,7 +57,11 @@ describe("<PersonalInformationStep />", () => {
 
   it("updates ssn", async () => {
     const user = userEvent.setup();
-    render(<PersonalInformationStep />);
+    render(
+      <RouterPathnameProvider pathname="/form/personal-details/1">
+        <PersonalDetailsStep1 />
+      </RouterPathnameProvider>,
+    );
     const inputField = screen.getByRole("textbox", {
       name: "Social security number",
     });
@@ -62,7 +75,11 @@ describe("<PersonalInformationStep />", () => {
 
   it("updates address state", async () => {
     const user = userEvent.setup();
-    render(<PersonalInformationStep />);
+    render(
+      <RouterPathnameProvider pathname="/form/personal-details/1">
+        <PersonalDetailsStep1 />
+      </RouterPathnameProvider>,
+    );
     const combobox = screen.getByRole("combobox", {
       name: "State",
     });

--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -10,9 +10,10 @@ import {
   TextInputMask,
 } from "@trussworks/react-uswds";
 import React, { useEffect, useState } from "react";
-import { formatDateOfBirthDefaultValue } from "../../_utils/inputFields/dateOfBirth";
-import { AddressState } from "../../_utils/inputFields/enums";
-import { getValue, setKeyValue } from "../../_utils/sessionStorage";
+import { formatDateOfBirthDefaultValue } from "../../../_utils/inputFields/dateOfBirth";
+import { AddressState } from "../../../_utils/inputFields/enums";
+import { getValue, setKeyValue } from "../../../_utils/sessionStorage";
+import ProgressButtons from "../../components/ProgressButtons";
 
 interface PersonalInformationData {
   firstName: string | null;
@@ -37,7 +38,7 @@ const dateIsValid = (date: string): boolean => {
   return !!found;
 };
 
-const PersonalInformationStep: React.FC = () => {
+const PersonalDetailsStep1: React.FC = () => {
   const [dataHasLoaded, setDataHasLoaded] = useState<boolean>(false);
   const [personalInformationData, setPersonalInformationData] = useState<PersonalInformationData>({
     firstName: null,
@@ -290,8 +291,9 @@ const PersonalInformationStep: React.FC = () => {
           </Fieldset>
         </Form>
       )}
+      <ProgressButtons />
     </div>
   );
 };
 
-export default PersonalInformationStep;
+export default PersonalDetailsStep1;

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import React from "react";
+import ProgressButtons from "../../components/ProgressButtons";
+
+const PersonalDetailsStep2: React.FC = () => {
+  return (
+    <div>
+      hi
+      <ProgressButtons />
+    </div>
+  );
+};
+
+export default PersonalDetailsStep2;

--- a/src/app/form/(formSteps)/personal-details/3/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import React from "react";
+import ProgressButtons from "../../components/ProgressButtons";
+
+const PersonalDetailsStep3: React.FC = () => {
+  return (
+    <div>
+      hi
+      <ProgressButtons />
+    </div>
+  );
+};
+
+export default PersonalDetailsStep3;

--- a/src/app/form/_utils/sections.test.ts
+++ b/src/app/form/_utils/sections.test.ts
@@ -1,0 +1,24 @@
+import { getCurrentStep } from "./sections";
+
+describe("getCurrentStep", () => {
+  it("returns the correct step when the path has no steps", () => {
+    const currentStep = getCurrentStep("/form/download");
+    expect(currentStep).toEqual({
+      section: { id: "download", sectionName: "Download forms", heading: "Download forms" },
+      stepNum: null,
+    });
+  });
+
+  it("returns the correct step when the path has steps", () => {
+    const currentStep = getCurrentStep("/form/personal-details/2");
+    expect(currentStep).toEqual({
+      section: {
+        id: "personal-details",
+        sectionName: "Personal details",
+        heading: "Personal details",
+        numSteps: 3,
+      },
+      stepNum: 2,
+    });
+  });
+});

--- a/src/app/form/_utils/sections.ts
+++ b/src/app/form/_utils/sections.ts
@@ -1,0 +1,54 @@
+export interface Section {
+  id: string;
+  sectionName: string;
+  heading: string;
+  numSteps?: number;
+}
+
+export interface Step {
+  section: Section;
+  stepNum: number | null;
+}
+
+export const allSections: Array<Section> = [
+  {
+    id: "personal-details",
+    sectionName: "Personal details",
+    heading: "Personal details",
+    numSteps: 3,
+  },
+  {
+    id: "disclosures",
+    sectionName: "Disclosures",
+    heading: "Disclosure of ownership",
+    numSteps: 1,
+  },
+  {
+    id: "download",
+    sectionName: "Download forms",
+    heading: "Download forms",
+  },
+];
+
+export const getCurrentStep = (pathname: string): Step => {
+  const pathParts = pathname.split("/");
+  if (pathParts[0] !== "" || pathParts[1] !== "form") {
+    throw new Error(`Unexpected route ${pathname}`);
+  }
+  const currentSection = allSections.find((section) => pathParts[2].endsWith(section.id));
+  if (currentSection === undefined) {
+    throw new Error(`Section not found for ${pathname}`);
+  }
+
+  let stepNum = null;
+  if (currentSection.numSteps !== undefined) {
+    const pathStep = Number(pathParts[3]);
+
+    if (new Set([...Array(currentSection.numSteps + 1).keys()].slice(1)).has(pathStep)) {
+      stepNum = pathStep;
+    } else {
+      throw new Error(`Substep not found for ${pathname}`);
+    }
+  }
+  return { section: currentSection, stepNum: stepNum };
+};

--- a/src/app/form/_utils/testUtils.tsx
+++ b/src/app/form/_utils/testUtils.tsx
@@ -1,0 +1,17 @@
+import {
+  AppRouterContext,
+  type AppRouterInstance,
+} from "next/dist/shared/lib/app-router-context.shared-runtime";
+import { PathnameContext } from "next/dist/shared/lib/hooks-client-context.shared-runtime";
+
+export const RouterPathnameProvider = (props: {
+  pathname: string;
+  router?: AppRouterInstance;
+  children: React.ReactNode;
+}) => {
+  return (
+    <AppRouterContext.Provider value={props.router ?? ({} as AppRouterInstance)}>
+      <PathnameContext.Provider value={props.pathname}>{props.children}</PathnameContext.Provider>
+    </AppRouterContext.Provider>
+  );
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Doula Common App",
+  title: { template: "%s | Doula Common App", default: "Doula Common App" },
   description: "Prototype",
 };
 
@@ -58,9 +58,7 @@ export default function RootLayout({
           </div>
         </header>
         <div className="usa-section">
-          <div className="grid-container">
-            <div className="grid-row">{children}</div>
-          </div>
+          <div className="grid-container">{children}</div>
         </div>
       </body>
     </html>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export const middleware = (request: NextRequest) => {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-pathname", request.nextUrl.pathname);
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+};


### PR DESCRIPTION
## Link to issue

This commit resolves #[82](https://github.com/newjersey/doula-pm/issues/82) and #[89](https://github.com/newjersey/doula-pm/issues/89).

## What was done?
Previously, all form fields for e.g. personal information were on one page. Per the [lastest design](https://www.figma.com/design/2R3VxYvZQYsaIxBcWoA1kL/Doula-Prototypes?node-id=1694-33132&p=f&t=xl0OZwM1eQr6pZw6-0), the personal information (now personal details) and disclosures fields should be broken into separate pages. There is to be a top-level progress bar that indicates which section the user is currently in, and a secondary-level progress indicator that indicates what step the user is in within the top-level section.

This commit
- Break the form layout and form pages into first-level sections and second-level steps, and adds the second-level progress indicator (e.g. `1 of 3 Personal details`) to relevant pages
- Adds stub pages for personal information and disclosure sections
- Correctly specifies the page title

It also
- Renames Personal information to Personal details, to match the design
- Renames the progress buttons to match the design, and right aligns them
- Refactors the progress buttons out of layout and into the form page, so that the triggering onSubmit button can live with the form it submits

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the WAVE extension.

## How should a reviewer test?

- Locally, run \`npm install\` then \`npm run dev\`.
- Go to http://localhost:3000/, which should redirect to http://localhost:3000/form/personal-details/1
- Use screen reader to navigate the progress bars and previous/next buttons

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

<img width="1664" height="824" alt="image" src="https://github.com/user-attachments/assets/f3245331-2c19-479f-aded-abafc21d1cc0" />

<img width="2568" height="2966" alt="main d20cvhuc4595ep amplifyapp com_form_personal-information (3)" src="https://github.com/user-attachments/assets/c0160184-157c-4940-8ba1-6516fc3e2294" />

<img width="2598" height="1590" alt="main d20cvhuc4595ep amplifyapp com_form_disclosures" src="https://github.com/user-attachments/assets/59908729-b8e1-4363-8017-4157a0ec7ba4" />


</details>


<details>
<summary>After</summary>

<img width="2246" height="2814" alt="localhost_3000_form_personal-details_1 (1)" src="https://github.com/user-attachments/assets/9ba8ac35-e502-4a8f-a830-ef222a0afc7f" />

New stub pages for additional personal details steps:

<img width="2176" height="1112" alt="image" src="https://github.com/user-attachments/assets/aff0a049-35da-47a2-a77e-c3bbaa4564ae" />

<img width="1073" height="402" alt="image" src="https://github.com/user-attachments/assets/0a6a28a6-80f8-44e6-98e7-830be13e44b1" />

<img width="2276" height="1524" alt="localhost_3000_form_personal-details_1 (2)" src="https://github.com/user-attachments/assets/7dc8fb57-3180-4268-bc61-e0aa057ddde2" />


</details