### PR TITLE
#88 Add explainer and required fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "pdf-lib": "1.17.1",
         "react": "19.0.0",
         "react-dom": "19.0.0",
-        "react-hook-form": "^7.60.0",
+        "react-hook-form": "7.60.0",
         "tesseract.js": "6.0.0"
       },
       "devDependencies": {

--- a/src/app/form/(formSteps)/FormLayout.test.tsx
+++ b/src/app/form/(formSteps)/FormLayout.test.tsx
@@ -58,4 +58,16 @@ describe("<FormLayout />", () => {
     const heading1 = screen.getByRole("heading", { level: 1 });
     expect(heading1).toHaveTextContent("Download forms");
   });
+
+  it("shows required field indicator text with an asterisk", () => {
+    render(
+      <FormLayout pathname="/form/disclosures/1">
+        <div>Test content</div>
+      </FormLayout>,
+    );
+
+    expect(screen.getByText(/A red asterisk.*indicates a required field/)).toBeInTheDocument();
+
+    expect(screen.getByText("*")).toBeInTheDocument();
+  });
 });

--- a/src/app/form/(formSteps)/FormLayout.tsx
+++ b/src/app/form/(formSteps)/FormLayout.tsx
@@ -1,3 +1,4 @@
+import { RequiredMarker } from "@trussworks/react-uswds";
 import { allSections, getCurrentStep } from "../_utils/sections";
 
 type CompletionState = "complete" | "current" | "incomplete";
@@ -56,7 +57,7 @@ export const FormLayout = (props: { children?: React.ReactNode; pathname: string
           })}
         </ol>
 
-        <div className="usa-step-indicator__header">
+        <div className="usa-step-indicator__header display-flex flex-justify">
           <h1 className="font-heading-lg">
             {currentStepNum !== null && (
               <span className="usa-step-indicator__heading-counter">
@@ -71,6 +72,10 @@ export const FormLayout = (props: { children?: React.ReactNode; pathname: string
             )}
             <span className="usa-step-indicator__heading-text">{currentSection.heading}</span>
           </h1>
+          <div className="text-right">
+            {" "}
+            A red asterisk (<RequiredMarker />) indicates a required field.
+          </div>
         </div>
       </div>
       <div className="margin-top-4">{props.children}</div>

--- a/src/app/form/(formSteps)/disclosures/1/page.tsx
+++ b/src/app/form/(formSteps)/disclosures/1/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fieldset, Form, Label, Radio, Select, TextInput } from "@trussworks/react-uswds";
+import { Fieldset, Form, Label, Radio, RequiredMarker, Select, TextInput } from "@trussworks/react-uswds";
 import React, { useEffect } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { AddressState, DisclosingEntity } from "../../../_utils/inputFields/enums";
@@ -64,7 +64,14 @@ const DisclosuresStep1: React.FC = () => {
           );
         }}
       >
-        <Fieldset legend="Is your doula business a sole proprietorship?" legendStyle="large">
+        <Fieldset
+          legend={
+            <span>
+              Is your doula business a sole proprietorship? <RequiredMarker />
+            </span>
+          }
+          legendStyle="large"
+        >
           <Radio
             id="soleProprietorshipYes"
             label="Yes, my doula business is a sole proprietorship"
@@ -81,7 +88,12 @@ const DisclosuresStep1: React.FC = () => {
 
         {isSoleProprietorship === "yes" && (
           <Fieldset
-            legend="Do you have a separate business address that's different from your mailing address?"
+            legend={
+              <span>
+                Do you have a separate business address that&apos;s different from your mailing
+                address? <RequiredMarker />
+              </span>
+            }
             legendStyle="large"
           >
             <Radio
@@ -101,7 +113,9 @@ const DisclosuresStep1: React.FC = () => {
 
         {hasSeparateBusinessAddress === "yes" && (
           <Fieldset legend="Business address" legendStyle="srOnly">
-            <Label htmlFor="businessStreetAddress1">Street address 1</Label>
+            <Label htmlFor="businessStreetAddress1">
+              Street address 1 <RequiredMarker />
+            </Label>
             <TextInput
               id="businessStreetAddress1"
               type="text"
@@ -121,7 +135,9 @@ const DisclosuresStep1: React.FC = () => {
 
             <div className="grid-row grid-gap">
               <div className="mobile-lg:grid-col-8">
-                <Label htmlFor="businessCity">City</Label>
+                <Label htmlFor="businessCity">
+                  City <RequiredMarker />
+                </Label>
                 <TextInput
                   className="usa-input"
                   id="businessCity"
@@ -131,7 +147,9 @@ const DisclosuresStep1: React.FC = () => {
                 />
               </div>
               <div className="mobile-lg:grid-col-4">
-                <Label htmlFor="businessState">State</Label>
+                <Label htmlFor="businessState">
+                  State <RequiredMarker />
+                </Label>
                 <Select
                   className="usa-select"
                   id="businessState"
@@ -147,7 +165,9 @@ const DisclosuresStep1: React.FC = () => {
               </div>
             </div>
 
-            <Label htmlFor="businessZip">ZIP code</Label>
+            <Label htmlFor="businessZip">
+              ZIP code <RequiredMarker />
+            </Label>
             <TextInput
               className="usa-input usa-input--medium"
               id="businessZip"

--- a/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
@@ -27,23 +27,23 @@ describe("<PersonalDetailsStep1 />", () => {
   };
 
   it.each([
-    { name: "First name", key: "firstName", testValue: "Test first name" },
+    { name: "First name *", key: "firstName", testValue: "Test first name" },
     { name: "Middle name (optional)", key: "middleName", testValue: "Test middle name" },
-    { name: "Last name", key: "lastName", testValue: "Test last name" },
-    { name: "Date of birth", key: "dateOfBirth", testValue: "01/01/1990" },
+    { name: "Last name *", key: "lastName", testValue: "Test last name" },
+    { name: "Date of birth *", key: "dateOfBirth", testValue: "01/01/1990" },
     {
-      name: "Social security number",
+      name: "Social security number *",
       key: "socialSecurityNumber",
       testValue: "123456789",
       type: "ssn",
     },
-    { name: "Email address", key: "email", testValue: "test@test.com" },
-    { name: "NPI number", key: "npiNumber", testValue: "2222222222" },
-    { name: "Phone number", key: "phoneNumber", testValue: "1111111111", type: "tel" },
-    { name: "Street address 1", key: "streetAddress1", testValue: "Test address 1" },
+    { name: "Email address *", key: "email", testValue: "test@test.com" },
+    { name: "NPI number *", key: "npiNumber", testValue: "2222222222" },
+    { name: "Phone number *", key: "phoneNumber", testValue: "1111111111", type: "tel" },
+    { name: "Street address 1 *", key: "streetAddress1", testValue: "Test address 1" },
     { name: "Street address 2 (optional)", key: "streetAddress2", testValue: "Test address 2" },
-    { name: "City", key: "city", testValue: "Test city" },
-    { name: "ZIP code", key: "zip", testValue: "12345" },
+    { name: "City *", key: "city", testValue: "Test city" },
+    { name: "ZIP code *", key: "zip", testValue: "12345" },
   ])("updates the $name text input", async ({ name, key, testValue, type }) => {
     const user = userEvent.setup();
     renderWithRouter();
@@ -75,7 +75,7 @@ describe("<PersonalDetailsStep1 />", () => {
     renderWithRouter();
     const nextButton = screen.getByRole("button", { name: "Next" });
     const combobox = screen.getByRole("combobox", {
-      name: "State",
+      name: "State *",
     });
     expect(combobox).toHaveValue("NJ");
 
@@ -101,24 +101,47 @@ describe("<PersonalDetailsStep1 />", () => {
     window.sessionStorage.setItem("state", "NJ");
     window.sessionStorage.setItem("zip", "12345");
     renderWithRouter();
-    window.location.reload();
 
-    expect(screen.getByRole("textbox", { name: "First name" })).toHaveValue("Jane");
+    expect(screen.getByRole("textbox", { name: "First name *" })).toHaveValue("Jane");
     expect(screen.getByRole("textbox", { name: "Middle name (optional)" })).toHaveValue("A");
-    expect(screen.getByRole("textbox", { name: "Last name" })).toHaveValue("Doe");
-    expect(screen.getByRole("textbox", { name: "Date of birth" })).toHaveValue("01/01/1990");
-    expect(screen.getByRole("textbox", { name: "Social security number" })).toHaveValue(
+    expect(screen.getByRole("textbox", { name: "Last name *" })).toHaveValue("Doe");
+    expect(screen.getByRole("textbox", { name: "Date of birth *" })).toHaveValue("01/01/1990");
+    expect(screen.getByRole("textbox", { name: "Social security number *" })).toHaveValue(
       "123-45-6789",
     );
-    expect(screen.getByRole("textbox", { name: "Email address" })).toHaveValue("example@test.com");
-    expect(screen.getByRole("textbox", { name: "NPI number" })).toHaveValue("1234567890");
-    expect(screen.getByRole("textbox", { name: "Phone number" })).toHaveValue("123-456-7890");
-    expect(screen.getByRole("textbox", { name: "Street address 1" })).toHaveValue("123 Main St");
+    expect(screen.getByRole("textbox", { name: "Email address *" })).toHaveValue("example@test.com");
+    expect(screen.getByRole("textbox", { name: "NPI number *" })).toHaveValue("1234567890");
+    expect(screen.getByRole("textbox", { name: "Phone number *" })).toHaveValue("123-456-7890");
+    expect(screen.getByRole("textbox", { name: "Street address 1 *" })).toHaveValue("123 Main St");
     expect(screen.getByRole("textbox", { name: "Street address 2 (optional)" })).toHaveValue(
       "Apt 4B",
     );
-    expect(screen.getByRole("textbox", { name: "City" })).toHaveValue("Newark");
-    expect(screen.getByRole("combobox", { name: "State" })).toHaveValue("NJ");
-    expect(screen.getByRole("textbox", { name: "ZIP code" })).toHaveValue("12345");
+    expect(screen.getByRole("textbox", { name: "City *" })).toHaveValue("Newark");
+    expect(screen.getByRole("combobox", { name: "State *" })).toHaveValue("NJ");
+    expect(screen.getByRole("textbox", { name: "ZIP code *" })).toHaveValue("12345");
+  });
+
+  describe("<PersonalDetailsStep1 /> required fields", () => {
+    it.each([
+      { label: "First name *", role: "textbox" },
+      { label: "Last name *", role: "textbox" },
+      { label: "Date of birth *", role: "textbox" },
+      { label: "Phone number *", role: "textbox" },
+      { label: "Email address *", role: "textbox" },
+      { label: "Social security number *", role: "textbox" },
+      { label: "NPI number *", role: "textbox" },
+      { label: "Street address 1 *", role: "textbox" },
+      { label: "City *", role: "textbox" },
+      { label: "ZIP code *", role: "textbox" },
+      { label: "State *", role: "combobox" },
+    ])("checks that $label is marked as required", ({ label, role }) => {
+      renderWithRouter();
+
+      const input = screen.getByRole(role, {
+        name: label,
+      });
+
+      expect(input).toBeRequired();
+    });
   });
 });

--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -5,6 +5,7 @@ import {
   Fieldset,
   Form,
   Label,
+  RequiredMarker,
   Select,
   TextInput,
   TextInputMask,
@@ -82,7 +83,7 @@ const PersonalDetailsStep1: React.FC = () => {
         >
           <Fieldset legend="Name" legendStyle="srOnly" className="grid-row grid-gap">
             <div className="tablet:grid-col-4">
-              <Label htmlFor="firstName">First name</Label>
+              <Label htmlFor="firstName">First name <RequiredMarker /> </Label>
               <TextInput id="firstName" type="text" required {...register("firstName")} />
             </div>
             <div className="tablet:grid-col-4">
@@ -92,7 +93,7 @@ const PersonalDetailsStep1: React.FC = () => {
               <TextInput id="middleName" type="text" {...register("middleName")} />
             </div>
             <div className="tablet:grid-col-4">
-              <Label htmlFor="lastName">Last name</Label>
+              <Label htmlFor="lastName">Last name <RequiredMarker /> </Label>
               <TextInput id="lastName" type="text" required {...register("lastName")} />
             </div>
           </Fieldset>
@@ -100,7 +101,7 @@ const PersonalDetailsStep1: React.FC = () => {
           <hr />
 
           <Label id="dateOfBirthLabel" htmlFor="dateOfBirth">
-            Date of birth
+            Date of birth <RequiredMarker />
           </Label>
           <div className="usa-hint" id="dateOfBirthHint">
             mm/dd/yyyy
@@ -115,6 +116,7 @@ const PersonalDetailsStep1: React.FC = () => {
                 aria-describedby="dateOfBirthHint"
                 aria-labelledby="dateOfBirthLabel"
                 value={field.value || ""}
+                required
                 onChange={(value) => {
                   if (value === undefined || !dateIsValid(value)) {
                     return;
@@ -129,7 +131,7 @@ const PersonalDetailsStep1: React.FC = () => {
               />
             )}
           />
-          <Label htmlFor="phoneNumber">Phone number</Label>
+          <Label htmlFor="phoneNumber">Phone number <RequiredMarker /> </Label>
           <TextInputMask
             id="phoneNumber"
             type="tel"
@@ -140,7 +142,9 @@ const PersonalDetailsStep1: React.FC = () => {
             {...register("phoneNumber")}
           />
 
-          <Label htmlFor="email">Email address</Label>
+          <Label htmlFor="email">
+            Email address <RequiredMarker />
+          </Label>
           <TextInput
             id="email"
             type="email"
@@ -150,7 +154,9 @@ const PersonalDetailsStep1: React.FC = () => {
             {...register("email")}
           />
 
-          <Label htmlFor="npiNumber">NPI number</Label>
+          <Label htmlFor="npiNumber">
+            NPI number <RequiredMarker />
+          </Label>
           <TextInputMask
             id="npiNumber"
             type="tel"
@@ -161,7 +167,9 @@ const PersonalDetailsStep1: React.FC = () => {
             {...register("npiNumber")}
           />
 
-          <Label htmlFor="socialSecurityNumber">Social security number</Label>
+          <Label htmlFor="socialSecurityNumber">
+            Social security number <RequiredMarker />
+          </Label>
           <TextInputMask
             id="socialSecurityNumber"
             type="text"
@@ -175,7 +183,9 @@ const PersonalDetailsStep1: React.FC = () => {
           <hr />
 
           <Fieldset legend="Mail to address" legendStyle="srOnly">
-            <Label htmlFor="streetAddress1">Street address 1</Label>
+            <Label htmlFor="streetAddress1">
+              Street address 1 <RequiredMarker />
+            </Label>
             <TextInput
               id="streetAddress1"
               type="text"
@@ -191,7 +201,9 @@ const PersonalDetailsStep1: React.FC = () => {
 
             <div className="grid-row grid-gap">
               <div className="mobile-lg:grid-col-8">
-                <Label htmlFor="city">City</Label>
+                <Label htmlFor="city">
+                  City <RequiredMarker />
+                </Label>
                 <TextInput
                   className="usa-input"
                   id="city"
@@ -201,7 +213,7 @@ const PersonalDetailsStep1: React.FC = () => {
                 />
               </div>
               <div className="mobile-lg:grid-col-4">
-                <Label htmlFor="state">State</Label>
+                <Label htmlFor="state">State <RequiredMarker /> </Label>
                 <Select className="usa-select" id="state" required {...register("state")}>
                   {Object.keys(AddressState).map((state) => (
                     <option key={state} value={state}>
@@ -212,7 +224,9 @@ const PersonalDetailsStep1: React.FC = () => {
               </div>
             </div>
 
-            <Label htmlFor="zip">ZIP code</Label>
+            <Label htmlFor="zip">
+              ZIP code <RequiredMarker />
+            </Label>
             <TextInput
               className="usa-input usa-input--medium"
               id="zip"


### PR DESCRIPTION
## Link to issue
https://github.com/newjersey/doula-pm/issues/88

## What was done?
- Added red asterisks and explainer text to top right to provide visual feedback that fields are required
- This does not enforce the required fields being filled out, that is out of scope

## Accessibility

- [X] I have made sure this works with a screenreader!
- [X] I have checked this with the WAVE extension.

## How should a reviewer test?

`npm run test`

## Screenshots (for visual changes)

- Before
<img width="496" height="777" alt="Screenshot 2025-07-16 at 11 22 42 AM" src="https://github.com/user-attachments/assets/698c0727-2bc4-4a2b-92e7-f412f882e33c" />

- After
<img width="756" height="786" alt="Screenshot 2025-07-16 at 11 13 01 AM" src="https://github.com/user-attachments/assets/c2342f2f-8a5c-4d02-822b-1e81a4f56817" />
