### PR TITLE
[#114] Fix typescript error from violating next layout file type expectations

### DIFF
--- a/src/app/form/(formSteps)/FormLayout.test.tsx
+++ b/src/app/form/(formSteps)/FormLayout.test.tsx
@@ -1,6 +1,6 @@
 import { within } from "@testing-library/dom";
 import { render, screen } from "@testing-library/react";
-import { FormLayout } from "./layout";
+import { FormLayout } from "./FormLayout";
 
 describe("<FormLayout />", () => {
   it("shows the section progress bar", () => {

--- a/src/app/form/(formSteps)/FormLayout.tsx
+++ b/src/app/form/(formSteps)/FormLayout.tsx
@@ -1,0 +1,79 @@
+import { allSections, getCurrentStep } from "../_utils/sections";
+
+type CompletionState = "complete" | "current" | "incomplete";
+
+// Separated this into a separate testable component because as of writing, Jest does not support testing NextJs asynchronous server components (https://nextjs.org/docs/app/guides/testing/jest)
+export const FormLayout = (props: { children?: React.ReactNode; pathname: string }) => {
+  const { section: currentSection, stepNum: currentStepNum } = getCurrentStep(props.pathname);
+  const currentSectionIndex = allSections.findIndex(
+    (sections) => sections.id === currentSection.id,
+  );
+
+  return (
+    <>
+      <div className="usa-step-indicator" aria-label="progress">
+        <ol className="usa-step-indicator__segments">
+          {allSections.map((sections, sectionIndex) => {
+            let completionState: CompletionState;
+            switch (true) {
+              case sectionIndex < currentSectionIndex:
+                completionState = "complete";
+                break;
+              case sectionIndex === currentSectionIndex:
+                completionState = "current";
+                break;
+              case sectionIndex > currentSectionIndex:
+                completionState = "incomplete";
+                break;
+              default:
+                throw new Error(`Unexpected logic path: ${sectionIndex}, ${currentSectionIndex}`);
+                break;
+            }
+
+            const liSegmentClassSuffix = {
+              complete: "complete",
+              current: "current",
+              incomplete: null,
+            }[completionState];
+            const screenreaderStatus = {
+              complete: "completed",
+              current: null,
+              incomplete: "not completed",
+            }[completionState];
+
+            return (
+              <li
+                key={sections.id}
+                className={`usa-step-indicator__segment ${liSegmentClassSuffix ? `usa-step-indicator__segment--${liSegmentClassSuffix}` : ""}`}
+                {...(completionState === "current" && { "aria-current": "true" })}
+              >
+                <span className="usa-step-indicator__segment-label">
+                  {sections.sectionName}
+                  {screenreaderStatus && <span className="usa-sr-only">{screenreaderStatus}</span>}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+
+        <div className="usa-step-indicator__header">
+          <h1 className="font-heading-lg">
+            {currentStepNum !== null && (
+              <span className="usa-step-indicator__heading-counter">
+                <span className="usa-sr-only" data-testid="step-text">
+                  Step
+                </span>
+                <span className="usa-step-indicator__current-step">{currentStepNum}</span>
+                &nbsp;
+                <span className="usa-step-indicator__total-steps">{`of ${currentSection.numSteps}`}</span>
+                &nbsp;
+              </span>
+            )}
+            <span className="usa-step-indicator__heading-text">{currentSection.heading}</span>
+          </h1>
+        </div>
+      </div>
+      <div className="margin-top-4">{props.children}</div>
+    </>
+  );
+};

--- a/src/app/form/(formSteps)/layout.tsx
+++ b/src/app/form/(formSteps)/layout.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import React from "react";
-import { allSections, getCurrentStep } from "../_utils/sections";
-
-type CompletionState = "complete" | "current" | "incomplete";
+import { getCurrentStep } from "../_utils/sections";
+import { FormLayout } from "./FormLayout";
 
 export const generateMetadata = async (): Promise<Metadata> => {
   const headersList = await headers();
@@ -18,82 +17,6 @@ export const generateMetadata = async (): Promise<Metadata> => {
   };
 };
 
-export const FormLayout = (props: { children?: React.ReactNode; pathname: string }) => {
-  const { section: currentSection, stepNum: currentStepNum } = getCurrentStep(props.pathname);
-  const currentSectionIndex = allSections.findIndex(
-    (sections) => sections.id === currentSection.id,
-  );
-
-  return (
-    <>
-      <div className="usa-step-indicator" aria-label="progress">
-        <ol className="usa-step-indicator__segments">
-          {allSections.map((sections, sectionIndex) => {
-            let completionState: CompletionState;
-            switch (true) {
-              case sectionIndex < currentSectionIndex:
-                completionState = "complete";
-                break;
-              case sectionIndex === currentSectionIndex:
-                completionState = "current";
-                break;
-              case sectionIndex > currentSectionIndex:
-                completionState = "incomplete";
-                break;
-              default:
-                throw new Error(`Unexpected logic path: ${sectionIndex}, ${currentSectionIndex}`);
-                break;
-            }
-
-            const liSegmentClassSuffix = {
-              complete: "complete",
-              current: "current",
-              incomplete: null,
-            }[completionState];
-            const screenreaderStatus = {
-              complete: "completed",
-              current: null,
-              incomplete: "not completed",
-            }[completionState];
-
-            return (
-              <li
-                key={sections.id}
-                className={`usa-step-indicator__segment ${liSegmentClassSuffix ? `usa-step-indicator__segment--${liSegmentClassSuffix}` : ""}`}
-                {...(completionState === "current" && { "aria-current": "true" })}
-              >
-                <span className="usa-step-indicator__segment-label">
-                  {sections.sectionName}
-                  {screenreaderStatus && <span className="usa-sr-only">{screenreaderStatus}</span>}
-                </span>
-              </li>
-            );
-          })}
-        </ol>
-
-        <div className="usa-step-indicator__header">
-          <h1 className="font-heading-lg">
-            {currentStepNum !== null && (
-              <span className="usa-step-indicator__heading-counter">
-                <span className="usa-sr-only" data-testid="step-text">
-                  Step
-                </span>
-                <span className="usa-step-indicator__current-step">{currentStepNum}</span>
-                &nbsp;
-                <span className="usa-step-indicator__total-steps">{`of ${currentSection.numSteps}`}</span>
-                &nbsp;
-              </span>
-            )}
-            <span className="usa-step-indicator__heading-text">{currentSection.heading}</span>
-          </h1>
-        </div>
-      </div>
-      <div className="margin-top-4">{props.children}</div>
-    </>
-  );
-};
-
-// Separated this into a wrapper because as of writing, Jest does not support testing NextJs asynchronous server components (https://nextjs.org/docs/app/guides/testing/jest)
 const FormLayoutWithRequestContext = async ({ children }: { children?: React.ReactNode }) => {
   const headersList = await headers();
   const pathname = headersList.get("x-pathname") as string;


### PR DESCRIPTION
## Link to issue

This commit hopefully resolves #[114](https://github.com/newjersey/doula-pm/issues/114).

It's a hopefully, but the bug is vague enough and this attempted fix innocent enough that I think it's fine to merge this then see if it still happens.

## What was done?
I'm not entirely sure what combination of running `next build` and `tsc --noemit` causes this, and why it doesn't seem to repro without some git action (rebase?) in between.

However, I think there's something going on that's like
- There is potentially a state where `.next/` files have not been generated, or not fully generated
- When `npm run build` (`next build`) it is run, it generates the type file `.next/types/app/form/(formSteps)/layout.ts`
- Some git action that may or may not be necessary happens
- Running `npm run typecheck` (`tsc --noemit`) finds the generated `.next/types/app/form/(formSteps)/layout.ts` which specifies a defined set of properties that are expected/allowed on a NextJS Layout page. However, the actual `app/form/(formSteps)/layout.tsx` layout file also exports an additional `FormLayout` which was broken out and exported for testing purposes. tsc errors that `FormLayout` is not a valid thing to be exported

In theory, it seems like NextJS should have thrown an [invalid-segment-export](https://nextjs.org/docs/messages/invalid-segment-export) error. But we haven't seen that; not sure where we should have seen it.

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the WAVE extension.

## How should a reviewer test?

- Locally, run \`npm install\` then \`npm run dev\`.
-

## Screenshots (for visual changes)

<details>
<summary>Before</summary>



</details>


<details>
<summary>After</summary>



</details