### PR TITLE
[#30] Validate personal information pt1

### DIFF
--- a/src/app/form/(formSteps)/disclosures/1/DisclosuresStep1.test.tsx
+++ b/src/app/form/(formSteps)/disclosures/1/DisclosuresStep1.test.tsx
@@ -73,9 +73,9 @@ describe("<DisclosuresStep1 />", () => {
 
   const clickNoSameAddressButton = async () => {
     const user = userEvent.setup();
-    const noSeperateAddressButton = getNoSameAddressButton();
-    await user.click(noSeperateAddressButton);
-    return { user, noSeperateAddressButton };
+    const noSameAddressButton = getNoSameAddressButton();
+    await user.click(noSameAddressButton);
+    return { user, noSameAddressButton };
   };
 
   it("saves isSoleProprietorship as false when user selects no for sole proprietorship and submits", async () => {
@@ -159,7 +159,7 @@ describe("<DisclosuresStep1 />", () => {
     }
 
     const combobox = screen.getByRole("combobox", {
-      name: "State, territory, or military post *",
+      name: "State *",
     });
     expect(combobox).toHaveValue("NJ");
     await user.selectOptions(combobox, "PA");
@@ -185,7 +185,7 @@ describe("<DisclosuresStep1 />", () => {
     { label: "Street address 1 *", role: "textbox" },
     { label: "City *", role: "textbox" },
     { label: "ZIP code *", role: "textbox" },
-    { label: "State, territory, or military post *", role: "combobox" },
+    { label: "State *", role: "combobox" },
   ])("input is marked as required", async ({ label, role }) => {
     renderWithRouter();
 

--- a/src/app/form/(formSteps)/disclosures/1/page.tsx
+++ b/src/app/form/(formSteps)/disclosures/1/page.tsx
@@ -133,7 +133,6 @@ const DisclosuresStep1: React.FC = () => {
                     <TextInput
                       id="businessStreetAddress1"
                       type="text"
-                      inputMode="numeric"
                       required
                       {...register("businessStreetAddress1")}
                     />
@@ -164,7 +163,7 @@ const DisclosuresStep1: React.FC = () => {
                 <div className="grid-row grid-gap">
                   <div className="mobile-lg:grid-col-6">
                     <Label requiredMarker htmlFor="businessState">
-                      State, territory, or military post
+                      State
                     </Label>
                     <Select
                       className="usa-select"

--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
+import { type PersonalDetails1Data } from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
-import { type PersonalInformationData } from "@form/(formSteps)/personal-details/PersonalInformationData";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { formatDateOfBirthDefaultValue } from "@form/_utils/inputFields/dateOfBirth";
 import { getValue, setKeyValue } from "@form/_utils/sessionStorage";
 import { DatePicker, Fieldset, Form, Label, TextInput } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
-import React, { useEffect, useState } from "react";
-import { type SubmitHandler, Controller, useForm } from "react-hook-form";
+import React, { useEffect, useRef, useState } from "react";
+import { Controller, type SubmitErrorHandler, type SubmitHandler, useForm } from "react-hook-form";
 
 const MM_DD_YYYY = /(\d{1,2})\/(\d{1,2})\/(\d{4})/;
 
@@ -17,11 +17,28 @@ const dateIsValid = (date: string): boolean => {
   return !!found;
 };
 
+const orderedInputNameToLabel: { [key in keyof PersonalDetails1Data]: string } = {
+  firstName: "First name",
+  middleName: "Middle name",
+  lastName: "Last name",
+  dateOfBirth: "Date of birth",
+  socialSecurityNumber: "Social security number",
+  email: "Email address",
+  phoneNumber: "Phone number",
+};
+
 const PersonalDetailsStep1: React.FC = () => {
   const router = useRouter();
   const formProgressPosition = useFormProgressPosition();
   const [dataHasLoaded, setDataHasLoaded] = useState<boolean>(false);
-  const { register, handleSubmit, control } = useForm<PersonalInformationData>({
+  const [shouldSummarizeErrors, setShouldSummarizeErrors] = useState(false);
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+    setFocus,
+    control,
+  } = useForm<PersonalDetails1Data>({
     defaultValues: {
       firstName: getValue("firstName") || "",
       middleName: getValue("middleName") || "",
@@ -31,14 +48,32 @@ const PersonalDetailsStep1: React.FC = () => {
       email: getValue("email") || "",
       phoneNumber: getValue("phoneNumber") || "",
     },
+    shouldFocusError: false,
   });
+  const errorSummaryRef = useRef<HTMLInputElement>(null);
 
-  const onSubmit: SubmitHandler<PersonalInformationData> = (data) => {
+  const onSubmit: SubmitHandler<PersonalDetails1Data> = (data) => {
     for (const key in data) {
-      const value = data[key as keyof PersonalInformationData] ?? "";
+      const value = data[key as keyof PersonalDetails1Data] ?? "";
       setKeyValue(key, value);
     }
     routeToNextStep(router, formProgressPosition);
+  };
+  const onError: SubmitErrorHandler<PersonalDetails1Data> = (errors) => {
+    if (Object.keys(errors).length >= 3) {
+      setShouldSummarizeErrors(true);
+      errorSummaryRef.current?.focus();
+    } else {
+      setShouldSummarizeErrors(false);
+      for (const inputName of Object.keys(orderedInputNameToLabel) as Array<
+        keyof PersonalDetails1Data
+      >) {
+        if (errors[inputName] !== undefined) {
+          setFocus(inputName);
+          break;
+        }
+      }
+    }
   };
 
   useEffect(() => {
@@ -48,29 +83,88 @@ const PersonalDetailsStep1: React.FC = () => {
   return (
     <div>
       {dataHasLoaded && (
-        <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full">
+        <Form onSubmit={handleSubmit(onSubmit, onError)} className="maxw-full" noValidate>
           <div className="maxw-tablet">
+            <div tabIndex={-1} ref={errorSummaryRef}>
+              {shouldSummarizeErrors && Object.keys(errors).length >= 1 && (
+                <div
+                  className="usa-alert usa-alert--error margin-bottom-3 border-05 border-top-105 border-secondary-dark"
+                  role="alert"
+                  aria-labelledby="error-summary-heading"
+                >
+                  <div className="usa-alert__body">
+                    <h2 className="usa-alert__heading" id="error-summary-heading">
+                      There is a problem
+                    </h2>
+
+                    <ul className="usa-list usa-list--unstyled">
+                      {Object.entries(errors).map(([field, error]) => {
+                        return <li key={field}>{error.message}</li>;
+                      })}
+                    </ul>
+                  </div>
+                </div>
+              )}
+            </div>
             <h2 className="font-heading-md">Personal identification</h2>
             <Fieldset legend="Name" legendStyle="srOnly" className="grid-row grid-gap">
               <div className="tablet:grid-col-4">
                 <Label htmlFor="firstName" requiredMarker>
-                  First name
+                  {orderedInputNameToLabel["firstName"]}
                 </Label>
-                <TextInput id="firstName" type="text" required {...register("firstName")} />
+                <TextInput
+                  id="firstName"
+                  type="text"
+                  required
+                  validationStatus={errors.firstName ? "error" : undefined}
+                  aria-invalid={errors.firstName ? "true" : "false"}
+                  aria-describedby={errors.firstName && "firstNameErrorMessage"}
+                  {...register("firstName", {
+                    required: `${orderedInputNameToLabel["firstName"]} is required`,
+                  })}
+                />
+                {errors.firstName && (
+                  <span
+                    id="firstNameErrorMessage"
+                    className="usa-error-message"
+                    {...(shouldSummarizeErrors ? {} : { role: "alert" })}
+                  >
+                    {errors.firstName.message}
+                  </span>
+                )}
               </div>
               <div className="tablet:grid-col-4">
-                <Label htmlFor="middleName">Middle name</Label>
+                <Label htmlFor="middleName">{orderedInputNameToLabel["middleName"]}</Label>
                 <TextInput id="middleName" type="text" {...register("middleName")} />
               </div>
               <div className="tablet:grid-col-4">
                 <Label htmlFor="lastName" requiredMarker>
-                  Last name
+                  {orderedInputNameToLabel["lastName"]}
                 </Label>
-                <TextInput id="lastName" type="text" required {...register("lastName")} />
+                <TextInput
+                  id="lastName"
+                  type="text"
+                  required
+                  validationStatus={errors.lastName ? "error" : undefined}
+                  aria-invalid={errors.lastName ? "true" : "false"}
+                  aria-describedby={errors.lastName && "lastNameErrorMessage"}
+                  {...register("lastName", {
+                    required: `${orderedInputNameToLabel["lastName"]} is required`,
+                  })}
+                />
+                {errors.lastName && (
+                  <span
+                    id="lastNameErrorMessage"
+                    className="usa-error-message"
+                    {...(shouldSummarizeErrors ? {} : { role: "alert" })}
+                  >
+                    {errors.lastName.message}
+                  </span>
+                )}
               </div>
             </Fieldset>
             <Label id="dateOfBirthLabel" htmlFor="dateOfBirth" requiredMarker>
-              Date of birth
+              {orderedInputNameToLabel["dateOfBirth"]}
             </Label>
             <div className="usa-hint" id="dateOfBirthHint">
               <p className="usa-hint">For example: 03/31/1986</p>
@@ -79,14 +173,17 @@ const PersonalDetailsStep1: React.FC = () => {
             <Controller
               name="dateOfBirth"
               control={control}
+              rules={{ required: `${orderedInputNameToLabel["dateOfBirth"]} is required` }}
               render={({ field }) => (
                 <DatePicker
                   name="dateOfBirth"
                   id="dateOfBirth"
-                  aria-describedby="dateOfBirthHint"
+                  required
+                  validationStatus={errors.dateOfBirth ? "error" : undefined}
+                  aria-invalid={errors.dateOfBirth ? "true" : "false"}
+                  aria-describedby={`${errors.dateOfBirth ? "dateOfBirthErrorMessage" : ""} dateOfBirthHint`}
                   aria-labelledby="dateOfBirthLabel"
                   value={field.value || ""}
-                  required
                   onChange={(value) => {
                     if (value === undefined || !dateIsValid(value)) {
                       return;
@@ -101,9 +198,17 @@ const PersonalDetailsStep1: React.FC = () => {
                 />
               )}
             />
-
+            {errors.dateOfBirth && (
+              <span
+                id="dateOfBirthErrorMessage"
+                className="usa-error-message"
+                {...(shouldSummarizeErrors ? {} : { role: "alert" })}
+              >
+                {errors.dateOfBirth.message}
+              </span>
+            )}
             <Label htmlFor="socialSecurityNumber" requiredMarker>
-              Social security number
+              {orderedInputNameToLabel["socialSecurityNumber"]}
             </Label>
             <p id="socialSecurityNumberHint" className="usa-hint">
               Format XXX-XX-XXXX
@@ -112,30 +217,80 @@ const PersonalDetailsStep1: React.FC = () => {
               id="socialSecurityNumber"
               type="text"
               required
-              aria-describedby="socialSecurityNumberHint"
-              {...register("socialSecurityNumber")}
+              validationStatus={errors.socialSecurityNumber ? "error" : undefined}
+              aria-invalid={errors.socialSecurityNumber ? "true" : "false"}
+              aria-describedby={`${errors.socialSecurityNumber ? "socialSecurityNumberErrorMessage" : ""} socialSecurityNumberHint`}
+              {...register("socialSecurityNumber", {
+                required: `${orderedInputNameToLabel["socialSecurityNumber"]} is required`,
+              })}
             />
+            {errors.socialSecurityNumber && (
+              <span
+                id="socialSecurityNumberErrorMessage"
+                className="usa-error-message"
+                role="alert"
+              >
+                {errors.socialSecurityNumber.message}
+              </span>
+            )}
           </div>
           <hr className="margin-top-5 margin-bottom-5" />
           <div className="maxw-tablet">
             <h2 className="font-heading-md">Contact information</h2>
             <p>This is where we&lsquo;ll send official updates and communications.</p>
             <Label htmlFor="email" requiredMarker>
-              Email address
+              {orderedInputNameToLabel["email"]}
             </Label>
             <TextInput
               id="email"
-              type="email"
               autoCorrect="off"
               autoCapitalize="off"
               required
-              {...register("email")}
+              validationStatus={errors.email ? "error" : undefined}
+              aria-invalid={errors.email ? "true" : "false"}
+              aria-describedby={errors.email && "emailErrorMessage"}
+              {...register("email", {
+                required: `${orderedInputNameToLabel["email"]} is required`,
+                pattern: {
+                  value: /\S+@\S+\.\S+/,
+                  message: "Entered value does not match email format",
+                },
+              })}
+              type="email"
             />
+            {errors.email && (
+              <span
+                id="emailErrorMessage"
+                className="usa-error-message"
+                {...(shouldSummarizeErrors ? {} : { role: "alert" })}
+              >
+                {errors.email.message}
+              </span>
+            )}
 
             <Label htmlFor="phoneNumber" requiredMarker>
-              Phone number
+              {orderedInputNameToLabel["phoneNumber"]}
             </Label>
-            <TextInput id="phoneNumber" type="tel" required {...register("phoneNumber")} />
+            <TextInput
+              id="phoneNumber"
+              type="tel"
+              required
+              validationStatus={errors.phoneNumber ? "error" : undefined}
+              aria-invalid={errors.phoneNumber ? "true" : "false"}
+              aria-describedby={errors.phoneNumber && "phoneNumberErrorMessage"}
+              {...register("phoneNumber", {
+                required: `${orderedInputNameToLabel["phoneNumber"]} is required`,
+              })}
+            />
+            {errors.phoneNumber && (
+              <span
+                id="phoneNumberErrorMessage"
+                className="usa-error-message"
+                {...(shouldSummarizeErrors ? {} : { role: "alert" })}
+              >
+                {errors.phoneNumber.message}
+              </span>
+            )}
           </div>
           <FormProgressButtons />
         </Form>

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -1,20 +1,33 @@
 "use client";
 
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
-import { type PersonalInformationData } from "@form/(formSteps)/personal-details/PersonalInformationData";
+import { type PersonalDetails2Data } from "@form/(formSteps)/personal-details/PersonalDetailsData";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState } from "@form/_utils/inputFields/enums";
 import { getValue, setKeyValue } from "@form/_utils/sessionStorage";
 import { Fieldset, Form, Label, Select, TextInput } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
-import React, { useEffect, useState } from "react";
-import { useForm, type SubmitHandler } from "react-hook-form";
+import React, { useEffect, useRef, useState } from "react";
+import { useForm, type SubmitErrorHandler, type SubmitHandler } from "react-hook-form";
+
+const orderedInputNameToLabel: { [key in keyof PersonalDetails2Data]: string } = {
+  streetAddress1: "Street address 1",
+  streetAddress2: "Street address line 2",
+  city: "City",
+  state: "State",
+  zip: "ZIP code",
+};
 
 const PersonalDetailsStep2: React.FC = () => {
   const [dataHasLoaded, setDataHasLoaded] = useState<boolean>(false);
   const router = useRouter();
   const formProgressPosition = useFormProgressPosition();
-  const { register, handleSubmit } = useForm<PersonalInformationData>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setFocus,
+  } = useForm<PersonalDetails2Data>({
     defaultValues: {
       streetAddress1: getValue("streetAddress1") || "",
       streetAddress2: getValue("streetAddress2") || "",
@@ -22,14 +35,33 @@ const PersonalDetailsStep2: React.FC = () => {
       state: getValue("state") || "NJ",
       zip: getValue("zip") || "",
     },
+    shouldFocusError: false,
   });
+  const [shouldSummarizeErrors, setShouldSummarizeErrors] = useState(false);
+  const errorSummaryRef = useRef<HTMLInputElement>(null);
 
-  const onSubmit: SubmitHandler<PersonalInformationData> = (data) => {
+  const onSubmit: SubmitHandler<PersonalDetails2Data> = (data) => {
     for (const key in data) {
-      const value = data[key as keyof PersonalInformationData] ?? "";
+      const value = data[key as keyof PersonalDetails2Data] ?? "";
       setKeyValue(key, value);
     }
     routeToNextStep(router, formProgressPosition);
+  };
+  const onError: SubmitErrorHandler<PersonalDetails2Data> = (errors) => {
+    if (Object.keys(errors).length >= 3) {
+      setShouldSummarizeErrors(true);
+      errorSummaryRef.current?.focus();
+    } else {
+      setShouldSummarizeErrors(false);
+      for (const inputName of Object.keys(orderedInputNameToLabel) as Array<
+        keyof PersonalDetails2Data
+      >) {
+        if (errors[inputName] !== undefined) {
+          setFocus(inputName);
+          break;
+        }
+      }
+    }
   };
 
   useEffect(() => {
@@ -39,8 +71,28 @@ const PersonalDetailsStep2: React.FC = () => {
   return (
     <div>
       {dataHasLoaded && (
-        <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full">
+        <Form onSubmit={handleSubmit(onSubmit, onError)} className="maxw-full" noValidate>
           <div className="maxw-tablet">
+            <div tabIndex={-1} ref={errorSummaryRef}>
+              {shouldSummarizeErrors && Object.keys(errors).length >= 1 && (
+                <div
+                  className="usa-alert usa-alert--error margin-bottom-3 border-05 border-top-105 border-secondary-dark"
+                  role="alert"
+                  aria-labelledby="error-summary-heading"
+                >
+                  <div className="usa-alert__body">
+                    <h2 className="usa-alert__heading" id="error-summary-heading">
+                      There is a problem
+                    </h2>
+                    <ul className="usa-list usa-list--unstyled">
+                      {Object.entries(errors).map(([field, error]) => (
+                        <li key={field}>{error.message}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              )}
+            </div>
             <h2 className="font-heading-md">Mailing address</h2>
             <p className="usa-hint">
               This is the location where you want to receive official mail.
@@ -49,39 +101,63 @@ const PersonalDetailsStep2: React.FC = () => {
               <div className="grid-row grid-gap">
                 <div className="mobile-lg:grid-col-6">
                   <Label htmlFor="streetAddress1" requiredMarker>
-                    Street address 1
+                    {orderedInputNameToLabel["streetAddress1"]}
                   </Label>
                   <TextInput
                     id="streetAddress1"
                     type="text"
-                    inputMode="numeric"
                     required
-                    {...register("streetAddress1")}
+                    validationStatus={errors.streetAddress1 ? "error" : undefined}
+                    aria-invalid={errors.streetAddress1 ? "true" : "false"}
+                    aria-describedby={errors.streetAddress1 && "streetAddress1ErrorMessage"}
+                    {...register("streetAddress1", {
+                      required: `${orderedInputNameToLabel["streetAddress1"]} is required`,
+                    })}
                   />
+                  {errors.streetAddress1 && (
+                    <span
+                      id="streetAddress1ErrorMessage"
+                      className="usa-error-message"
+                      role="alert"
+                    >
+                      {errors.streetAddress1.message}
+                    </span>
+                  )}
                 </div>
                 <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="streetAddress2">Street address line 2</Label>
+                  <Label htmlFor="streetAddress2">
+                    {orderedInputNameToLabel["streetAddress2"]}
+                  </Label>
                   <TextInput id="streetAddress2" type="text" {...register("streetAddress2")} />
                 </div>
               </div>
               <div className="grid-row grid-gap">
                 <div className="mobile-lg:grid-col-6">
                   <Label htmlFor="city" requiredMarker>
-                    City
+                    {orderedInputNameToLabel["city"]}
                   </Label>
                   <TextInput
-                    className="usa-input"
                     id="city"
                     type="text"
                     required
-                    {...register("city")}
+                    validationStatus={errors.city ? "error" : undefined}
+                    aria-invalid={errors.city ? "true" : "false"}
+                    aria-describedby={errors.city && "cityErrorMessage"}
+                    {...register("city", {
+                      required: `${orderedInputNameToLabel["city"]} is required`,
+                    })}
                   />
+                  {errors.city && (
+                    <span id="cityErrorMessage" className="usa-error-message" role="alert">
+                      {errors.city.message}
+                    </span>
+                  )}
                 </div>
               </div>
               <div className="grid-row grid-gap">
                 <div className="mobile-lg:grid-col-6">
                   <Label htmlFor="state" requiredMarker>
-                    State, territory, or military post
+                    {orderedInputNameToLabel["state"]}
                   </Label>
                   <Select className="usa-select" id="state" required {...register("state")}>
                     {Object.keys(AddressState).map((state) => (
@@ -91,19 +167,27 @@ const PersonalDetailsStep2: React.FC = () => {
                     ))}
                   </Select>
                 </div>
-
                 <div className="mobile-lg:grid-col-4">
                   <Label htmlFor="zip" requiredMarker>
-                    ZIP code
+                    {orderedInputNameToLabel["zip"]}
                   </Label>
                   <TextInput
-                    className="usa-input usa-input--medium"
+                    className="usa-input--medium"
                     id="zip"
                     type="text"
-                    pattern="[\d]{5}(-[\d]{4})?"
                     required
-                    {...register("zip")}
+                    validationStatus={errors.zip ? "error" : undefined}
+                    aria-invalid={errors.zip ? "true" : "false"}
+                    aria-describedby={errors.zip && "zipErrorMessage"}
+                    {...register("zip", {
+                      required: `${orderedInputNameToLabel["zip"]} is required`,
+                    })}
                   />
+                  {errors.zip && (
+                    <span id="zipErrorMessage" className="usa-error-message" role="alert">
+                      {errors.zip.message}
+                    </span>
+                  )}
                 </div>
               </div>
             </Fieldset>

--- a/src/app/form/(formSteps)/personal-details/3/PersonalDetailsStep3.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/PersonalDetailsStep3.test.tsx
@@ -8,8 +8,8 @@ const textInputFields = [
   { name: "NPI number *", key: "npiNumber", testValue: "1111111111" },
   { name: "UPIN number (if applicable)", key: "upinNumber", testValue: "12345" },
   {
-    name: "Medicaid provider ID (if applicable)",
-    key: "medicaidProviderId",
+    name: "Medicare provider ID (if applicable)",
+    key: "medicareProviderId",
     testValue: "ABC12345",
   },
 ];
@@ -71,7 +71,7 @@ describe("<PersonalDetailsStep3 />", () => {
   it("fills fields from session storage when page is loaded", () => {
     window.sessionStorage.setItem("npiNumber", "1234567890");
     window.sessionStorage.setItem("upinNumber", "12345");
-    window.sessionStorage.setItem("medicaidProviderId", "ABC12345");
+    window.sessionStorage.setItem("medicareProviderId", "ABC12345");
     renderWithRouter();
 
     expect(screen.getByRole("textbox", { name: "NPI number *" })).toHaveValue("1234567890");
@@ -79,22 +79,23 @@ describe("<PersonalDetailsStep3 />", () => {
       "12345",
     );
     expect(
-      screen.getByRole("textbox", { name: "Medicaid provider ID (if applicable)" }),
+      screen.getByRole("textbox", { name: "Medicare provider ID (if applicable)" }),
     ).toHaveValue("ABC12345");
   });
 
-  describe("<PersonalDetailsStep3 /> required fields", () => {
-    it.each([{ label: "NPI number *", role: "textbox" }])(
-      "checks that $label is marked as required",
-      ({ label, role }) => {
-        renderWithRouter();
+  it("marks NPI as required and displays error messages if it is not filled in", async () => {
+    const user = userEvent.setup();
+    renderWithRouter();
 
-        const input = screen.getByRole(role, {
-          name: label,
-        });
+    const input = screen.getByRole("textbox", {
+      name: "NPI number *",
+    });
+    expect(input).toBeRequired();
 
-        expect(input).toBeRequired();
-      },
-    );
+    const nextButton = screen.getByRole("button", { name: "Next" });
+    await user.click(nextButton);
+
+    expect(input).toHaveAccessibleDescription(expect.stringContaining(`NPI number is required`));
+    expect(input).toHaveAttribute("aria-invalid", "true");
   });
 });

--- a/src/app/form/(formSteps)/personal-details/3/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import type { PersonalDetails3Data } from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
-import { type PersonalInformationData } from "@form/(formSteps)/personal-details/PersonalInformationData";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { getValue, setKeyValue } from "@form/_utils/sessionStorage";
 import { Form, Label, TextInput } from "@trussworks/react-uswds";
@@ -9,21 +9,31 @@ import { useRouter } from "next/navigation";
 import React, { useEffect, useState } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 
+const inputNameToLabel: { [key in keyof PersonalDetails3Data]: string } = {
+  npiNumber: "NPI number",
+  upinNumber: "UPIN number",
+  medicareProviderId: "Medicare provider ID",
+};
+
 const PersonalDetailsStep3: React.FC = () => {
   const [dataHasLoaded, setDataHasLoaded] = useState<boolean>(false);
   const router = useRouter();
   const formProgressPosition = useFormProgressPosition();
-  const { register, handleSubmit } = useForm<PersonalInformationData>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<PersonalDetails3Data>({
     defaultValues: {
       npiNumber: getValue("npiNumber") || "",
       upinNumber: getValue("upinNumber") || "",
-      medicaidProviderId: getValue("medicaidProviderId") || "",
+      medicareProviderId: getValue("medicareProviderId") || "",
     },
   });
 
-  const onSubmit: SubmitHandler<PersonalInformationData> = (data) => {
+  const onSubmit: SubmitHandler<PersonalDetails3Data> = (data) => {
     for (const key in data) {
-      const value = data[key as keyof PersonalInformationData] ?? "";
+      const value = data[key as keyof PersonalDetails3Data] ?? "";
       setKeyValue(key, value);
     }
     routeToNextStep(router, formProgressPosition);
@@ -36,12 +46,12 @@ const PersonalDetailsStep3: React.FC = () => {
   return (
     <div>
       {dataHasLoaded && (
-        <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full">
+        <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full" noValidate>
           <div className="maxw-tablet">
             <h2 className="font-heading-md">Provider IDs</h2>
             <p>This is a general instruction if needed for the user to answer correctly.</p>
             <Label htmlFor="npiNumber" requiredMarker>
-              NPI number
+              {inputNameToLabel["npiNumber"]}
             </Label>
             <p id="npiNumberHint" className="usa-hint">
               Format ABCD1234
@@ -50,10 +60,19 @@ const PersonalDetailsStep3: React.FC = () => {
               id="npiNumber"
               type="text"
               required
-              aria-describedby="npiNumberHint"
-              {...register("npiNumber")}
+              aria-invalid={errors.npiNumber ? "true" : "false"}
+              className={errors.npiNumber ? "usa-input--error" : ""}
+              aria-describedby={`${errors.npiNumber ? "npiNumberErrorMessage" : ""} npiNumberHint`}
+              {...register("npiNumber", {
+                required: `${inputNameToLabel["npiNumber"]} is required`,
+              })}
             />
-            <Label htmlFor="upinNumber">UPIN number (if applicable)</Label>
+            {errors.npiNumber && (
+              <span id="npiNumberErrorMessage" className="usa-error-message" role="alert">
+                {errors.npiNumber.message}
+              </span>
+            )}
+            <Label htmlFor="upinNumber">{inputNameToLabel["upinNumber"]} (if applicable)</Label>
             <p id="upinNumberHint" className="usa-hint">
               Format ABCD1234
             </p>
@@ -64,16 +83,18 @@ const PersonalDetailsStep3: React.FC = () => {
               aria-describedby="upinNumberHint"
               {...register("upinNumber")}
             />
-            <Label htmlFor="medicaidProviderId">Medicaid provider ID (if applicable)</Label>
-            <p id="medicaidProviderIdHint" className="usa-hint">
+            <Label htmlFor="medicareProviderId">
+              {inputNameToLabel["medicareProviderId"]} (if applicable)
+            </Label>
+            <p id="medicareProviderIdHint" className="usa-hint">
               Format ABCD1234
             </p>
             <TextInput
               type="text"
-              id="medicaidProviderId"
+              id="medicareProviderId"
               inputMode="text"
-              aria-describedby="medicaidProviderIdHint"
-              {...register("medicaidProviderId")}
+              aria-describedby="medicareProviderIdHint"
+              {...register("medicareProviderId")}
             />
           </div>
           <FormProgressButtons />

--- a/src/app/form/(formSteps)/personal-details/PersonalDetailsData.ts
+++ b/src/app/form/(formSteps)/personal-details/PersonalDetailsData.ts
@@ -1,4 +1,4 @@
-export interface PersonalInformationData {
+export interface PersonalDetails1Data {
   firstName: string | null;
   middleName: string | null;
   lastName: string | null;
@@ -6,12 +6,23 @@ export interface PersonalInformationData {
   socialSecurityNumber: string | null;
   email: string | null;
   phoneNumber: string | null;
+}
+
+export interface PersonalDetails2Data {
   streetAddress1: string | null;
   streetAddress2: string | null;
   city: string | null;
   state: string | null;
   zip: string | null;
+}
+
+export interface PersonalDetails3Data {
   npiNumber: string | null;
-  medicaidProviderId: string | null;
+  medicareProviderId: string | null;
   upinNumber: string | null;
 }
+
+export interface PersonalDetailsData
+  extends PersonalDetails1Data,
+    PersonalDetails2Data,
+    PersonalDetails3Data {}


### PR DESCRIPTION
## Link to issue

This partially resolves #[30](https://github.com/newjersey/doula-pm/issues/30).

## What was done?
I'm cutting an arbitrary line here, for a smaller PR that still delivers value and can be reviewed sooner and more easily. The following work still needs to be done (see https://github.com/newjersey/doula-medicaid/pull/38 for a wip peek):
- Replace `PersonalDetailsData` with a type for all the form data, including disclosures
- Validate/otherwise handling the formats for date of birth, phone number, and SSN
- Enable DatePicker to recieve focus
- Make the error summary items links to the inputs

What this commit does do, in personal information:
- Enforces required via react-hook-form instead of native HTML forms
- Adds error messages for inputs that are required, and if the email is mis-formatted
- Summarizes the errors if there are more than 3

It also:
- Renames and breaks out `PersonalInformationData` into `PersonalDetails1Data`, 2, 3
- Corrects the address lines 1 to not be `inputMode="numeric"`
- Removes unneeded `"usa-input"` classes, as that is already built into `TextInput`
- Fixes the input on personal information step 3, it should be Medicare instead of Medicaid
- Renames "State, territory, or military post" in step 2 to just "State", since we only have states

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the WAVE extension.

## How should a reviewer test?

- Locally, run \`npm install\` then \`npm run dev\`.
- On all of pages `http://localhost:3000/form/personal-details/1`, `/2`, and `/3`, clicking "Next" without filling the required fields should show error messages that the field is required
- On `http://localhost:3000/form/personal-details/1`, submitting a mis-formatted email should show the error message "Entered value does not match email format"
- If there are more than three errors, in error summary is shown
- On clicking submit, the focus moves to the error summary if shown, or the first input with an error if not
   - Accordingly, test these via Voiceover, and the information read out should make sense.

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

Native HTML validation that only flagged the first field:
<img width="2116" height="2478" alt="main d20cvhuc4595ep amplifyapp com_form_personal-details_1 (1)" src="https://github.com/user-attachments/assets/1ae4190e-ee26-4f3d-bb06-5e726e9d9b68" />

<img width="2146" height="1694" alt="main d20cvhuc4595ep amplifyapp com_form_personal-details_2" src="https://github.com/user-attachments/assets/da5565d7-4abe-41d5-8519-8ccda7d1e898" />

<img width="2116" height="1920" alt="main d20cvhuc4595ep amplifyapp com_form_personal-details_3" src="https://github.com/user-attachments/assets/ccae98d1-c4c7-4059-af77-90f178d202ee" />

</details>


<details>
<summary>After</summary>

<img width="2116" height="3214" alt="localhost_3000_form_personal-details_1 (3)" src="https://github.com/user-attachments/assets/d526775b-a91b-4fd4-8ca3-2dc2af4d3ec1" />


<img width="2116" height="2176" alt="localhost_3000_form_personal-details_2" src="https://github.com/user-attachments/assets/2a4694a2-654a-465d-a5c3-f72cb7ca802c" />

<img width="2116" height="1964" alt="localhost_3000_form_personal-details_3" src="https://github.com/user-attachments/assets/2af40d20-3e5b-4181-8ef3-9a4b589dae1e" />
</details>