### PR TITLE
[#30] Validate personal information pt2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 ## Accessibility
 
 - [ ] I have made sure this works with a screenreader!
-- [ ] I have checked this with the WAVE extension.
+- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).
 
 ## How should a reviewer test?
 

--- a/src/app/form/(formSteps)/FormLayout.tsx
+++ b/src/app/form/(formSteps)/FormLayout.tsx
@@ -73,7 +73,6 @@ export const FormLayout = (props: { children?: React.ReactNode; pathname: string
             <span className="usa-step-indicator__heading-text">{currentSection.heading}</span>
           </h1>
           <div className="text-right">
-            {" "}
             A red asterisk (<RequiredMarker />) indicates a required field.
           </div>
         </div>

--- a/src/app/form/(formSteps)/disclosures/1/DisclosuresStep1.test.tsx
+++ b/src/app/form/(formSteps)/disclosures/1/DisclosuresStep1.test.tsx
@@ -86,8 +86,7 @@ describe("<DisclosuresStep1 />", () => {
     await user.click(noSoleProprietorButton);
     expect(noSoleProprietorButton).toBeChecked();
 
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    await user.click(nextButton);
+    await user.click(screen.getByRole("button", { name: "Next" }));
     expect(getValue("isSoleProprietorship")).toBe("false");
 
     expect(mockRouter.push).toHaveBeenCalledWith("/form/section-3");
@@ -122,8 +121,7 @@ describe("<DisclosuresStep1 />", () => {
     await user.click(yesSameAddressButton);
     expect(yesSameAddressButton).toBeChecked();
 
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    await user.click(nextButton);
+    await user.click(screen.getByRole("button", { name: "Next" }));
 
     expect(getValue("isSoleProprietorship")).toBe("true");
     expect(getValue("hasSameBusinessAddress")).toBe("true");
@@ -151,11 +149,11 @@ describe("<DisclosuresStep1 />", () => {
     ];
 
     for (const addressTextInputField of addressTextInputFields) {
-      const inputField = screen.getByRole("textbox", {
+      const input = screen.getByRole("textbox", {
         name: addressTextInputField.name,
       });
-      await user.type(inputField, addressTextInputField.testValue);
-      expect(inputField).toHaveValue(addressTextInputField.testValue);
+      await user.type(input, addressTextInputField.testValue);
+      expect(input).toHaveValue(addressTextInputField.testValue);
     }
 
     const combobox = screen.getByRole("combobox", {
@@ -165,8 +163,7 @@ describe("<DisclosuresStep1 />", () => {
     await user.selectOptions(combobox, "PA");
     expect(combobox).toHaveValue("PA");
 
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    await user.click(nextButton);
+    await user.click(screen.getByRole("button", { name: "Next" }));
 
     expect(getValue("isSoleProprietorship")).toBe("true");
     expect(getValue("hasSameBusinessAddress")).toBe("false");

--- a/src/app/form/(formSteps)/disclosures/1/page.tsx
+++ b/src/app/form/(formSteps)/disclosures/1/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Disclosure1Data } from "@/app/form/(formSteps)/disclosures/DisclosureData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState } from "@form/_utils/inputFields/enums";
@@ -17,21 +18,11 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 
-interface DisclosureBusinessAddressData {
-  isSoleProprietorship: "true" | "false" | "";
-  hasSameBusinessAddress: "true" | "false" | "";
-  businessStreetAddress1: string | null;
-  businessStreetAddress2: string | null;
-  businessCity: string | null;
-  businessState: string | null;
-  businessZip: string | null;
-}
-
 const DisclosuresStep1 = () => {
   const [dataHasLoaded, setDataHasLoaded] = useState<boolean>(false);
   const router = useRouter();
   const formProgressPosition = useFormProgressPosition();
-  const { register, handleSubmit, watch } = useForm<DisclosureBusinessAddressData>({
+  const { register, handleSubmit, watch } = useForm<Disclosure1Data>({
     defaultValues: {
       isSoleProprietorship: "",
       hasSameBusinessAddress: "",
@@ -45,9 +36,10 @@ const DisclosuresStep1 = () => {
 
   const hasSameBusinessAddress = watch("hasSameBusinessAddress");
 
-  const onSubmit: SubmitHandler<DisclosureBusinessAddressData> = (data) => {
-    for (const key in data) {
-      const value = data[key as keyof DisclosureBusinessAddressData] ?? "";
+  const onSubmit: SubmitHandler<Disclosure1Data> = (data) => {
+    let key: keyof Disclosure1Data;
+    for (key in data) {
+      const value = data[key] ?? "";
       setKeyValue(key, value);
     }
     routeToNextStep(router, formProgressPosition);

--- a/src/app/form/(formSteps)/disclosures/DisclosureData.ts
+++ b/src/app/form/(formSteps)/disclosures/DisclosureData.ts
@@ -1,0 +1,9 @@
+export interface Disclosure1Data {
+  isSoleProprietorship: "true" | "false" | "";
+  hasSameBusinessAddress: "true" | "false" | "";
+  businessStreetAddress1: string | null;
+  businessStreetAddress2: string | null;
+  businessCity: string | null;
+  businessState: string | null;
+  businessZip: string | null;
+}

--- a/src/app/form/(formSteps)/download/page.tsx
+++ b/src/app/form/(formSteps)/download/page.tsx
@@ -16,8 +16,14 @@ const convertToBoolean = (value: string | null): boolean | null => {
 };
 
 const getFormData = (): FormData => {
-  const dateOfBirthString = getValue("dateOfBirth");
-  const dateOfBirth = dateOfBirthString ? new Date(dateOfBirthString) : null;
+  const dateOfBirth =
+    getValue("dateOfBirthMonth") === null ||
+    getValue("dateOfBirthDay") === null ||
+    getValue("dateOfBirthYear") === null
+      ? null
+      : new Date(
+          `${getValue("dateOfBirthMonth")}/${getValue("dateOfBirthDay")}/${getValue("dateOfBirthYear")}`,
+        );
 
   const stateString = (getValue("state") as keyof typeof AddressState) || null;
   const state = stateString ? AddressState[stateString] : null;

--- a/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
@@ -1,5 +1,9 @@
 import PersonalDetailsStep1 from "@form/(formSteps)/personal-details/1/page";
-import { RouterPathnameProvider } from "@form/_utils/testUtils";
+import {
+  fillAllInputsExcept,
+  RouterPathnameProvider,
+  type InputField,
+} from "@form/_utils/testUtils";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
@@ -8,10 +12,37 @@ const textInputFields = [
   { name: "First name *", key: "firstName", testValue: "Test first name" },
   { name: "Middle name", key: "middleName", testValue: "Test middle name" },
   { name: "Last name *", key: "lastName", testValue: "Test last name" },
-  { name: "Date of birth *", key: "dateOfBirth", testValue: "01/01/1990" },
+  { name: "Day *", key: "dateOfBirthDay", testValue: "6" },
+  { name: "Year *", key: "dateOfBirthYear", testValue: "1988" },
   { name: "Email address *", key: "email", testValue: "test@test.com" },
-  { name: "Social security number *", key: "socialSecurityNumber", testValue: "123456789" },
-  { name: "Phone number *", key: "phoneNumber", testValue: "3211234567" },
+  {
+    name: "Social security number *",
+    key: "socialSecurityNumber",
+    testValue: "123456789",
+    expectedValue: "123-45-6789",
+  },
+  {
+    name: "Phone number *",
+    key: "phoneNumber",
+    testValue: "3211234567",
+    expectedValue: "321-123-4567",
+  },
+];
+
+const allInputFields: Array<InputField> = [
+  ...textInputFields,
+  { name: "Month *", role: "combobox", testValue: "07 - July" },
+];
+
+const requiredInputs = [
+  { labelWithoutAsterisk: "First name", role: "textbox" },
+  { labelWithoutAsterisk: "Last name", role: "textbox" },
+  { labelWithoutAsterisk: "Month", role: "combobox" },
+  { labelWithoutAsterisk: "Day", role: "textbox" },
+  { labelWithoutAsterisk: "Year", role: "textbox" },
+  { labelWithoutAsterisk: "Phone number", role: "textbox" },
+  { labelWithoutAsterisk: "Email address", role: "textbox" },
+  { labelWithoutAsterisk: "Social security number", role: "textbox" },
 ];
 
 describe("<PersonalDetailsStep1 />", () => {
@@ -33,34 +64,230 @@ describe("<PersonalDetailsStep1 />", () => {
     return mockRouter;
   };
 
-  it.each(textInputFields)("updates the $name text input", async ({ name, testValue }) => {
-    const user = userEvent.setup();
-    renderWithRouter();
-    const inputField = screen.getByRole("textbox", {
-      name: name,
-    });
-    expect(inputField).toHaveValue("");
+  describe("input updates", () => {
+    it.each(textInputFields)(
+      "updates the $name text input",
+      async ({ name, testValue, expectedValue }) => {
+        const user = userEvent.setup();
+        renderWithRouter();
+        const input = screen.getByRole("textbox", {
+          name: name,
+        });
+        expect(input).toHaveValue("");
 
-    await user.type(inputField, testValue);
-    expect(inputField).toHaveValue(testValue);
+        await user.type(input, testValue);
+        expect(input).toHaveValue(expectedValue ?? testValue);
+      },
+    );
+
+    it("updates the date of birth month", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      const combobox = screen.getByRole("combobox", {
+        name: "Month *",
+      });
+      await user.selectOptions(combobox, "07 - July");
+      expect(combobox).toHaveValue("7");
+    });
+  });
+
+  describe("individual input validation and error messages", () => {
+    it.each(requiredInputs)(
+      "marks $labelWithoutAsterisk as required and displays an error message if it is not filled in",
+      async ({ labelWithoutAsterisk, role }) => {
+        const user = userEvent.setup();
+        renderWithRouter();
+
+        const name = `${labelWithoutAsterisk} *`;
+        const input = screen.getByRole(role, {
+          name: name,
+        });
+        expect(input).toBeRequired();
+        await fillAllInputsExcept(screen, user, allInputFields, new Set([name]));
+        await user.click(screen.getByRole("button", { name: "Next" }));
+
+        expect(input).toHaveAccessibleDescription(
+          expect.stringContaining(`${labelWithoutAsterisk} is required`),
+        );
+        expect(input).toHaveAttribute("aria-invalid", "true");
+        expect(input).toHaveFocus();
+      },
+    );
+
+    it("validates date of birth day", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+
+      const input = screen.getByRole("textbox", {
+        name: "Day *",
+      });
+
+      await user.type(input, "test");
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      expect(input).toHaveAccessibleDescription(expect.stringContaining("Day must be a number"));
+      expect(input).toHaveAttribute("aria-invalid", "true");
+
+      await user.clear(input);
+      await user.type(input, "0");
+      expect(input).toHaveAccessibleDescription(
+        expect.stringContaining(`Day must be between 1 and 31`),
+      );
+      expect(input).toHaveAttribute("aria-invalid", "true");
+
+      await user.clear(input);
+      await user.type(input, "50");
+      expect(input).toHaveAccessibleDescription(
+        expect.stringContaining(`Day must be between 1 and 31`),
+      );
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("validates date of birth year", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+
+      const input = screen.getByRole("textbox", {
+        name: "Year *",
+      });
+
+      await user.type(input, "test");
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      expect(input).toHaveAccessibleDescription(expect.stringContaining("Year must be a number"));
+      expect(input).toHaveAttribute("aria-invalid", "true");
+
+      await user.clear(input);
+      await user.type(input, "1");
+      expect(input).toHaveAccessibleDescription(
+        expect.stringContaining("Year must have four digits"),
+      );
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it.each([
+      {
+        name: "Social security number *",
+        lowercaseName: "social security number",
+      },
+      {
+        name: "Phone number *",
+        lowercaseName: "phone number",
+      },
+    ])("validates $lowercaseName", async ({ name, lowercaseName }) => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      const input = screen.getByRole("textbox", {
+        name: name,
+      });
+
+      await user.type(input, "aaa");
+      expect(input).toHaveValue("");
+      await user.type(input, "!!");
+      expect(input).toHaveValue("");
+
+      await user.type(input, "123");
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      expect(input).toHaveAccessibleDescription(
+        expect.stringContaining(`Entered value does not match ${lowercaseName} format`),
+      );
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it.each([["invalid-email"], ["invalid@email"], ["invalid.email"]])(
+      "displays an error message if the invalid email format %s is submitted",
+      async () => {
+        const user = userEvent.setup();
+        renderWithRouter();
+
+        const input = screen.getByRole("textbox", {
+          name: `Email address *`,
+        });
+        await user.type(input, "invalid-email");
+        await user.click(screen.getByRole("button", { name: "Next" }));
+
+        expect(input).toHaveAccessibleDescription(
+          expect.stringContaining("Entered value does not match email format"),
+        );
+        expect(input).toHaveAttribute("aria-invalid", "true");
+      },
+    );
+  });
+
+  describe("error summary", () => {
+    it("shows an error summary if there are 3 or more errors", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      const requiredInputsToLeaveEmpty = [
+        { name: "First name *", errorMessage: "First name is required" },
+        { name: "Day *", errorMessage: "Day is required" },
+        { name: "Email address *", errorMessage: "Email address is required" },
+      ];
+
+      const requiredInputsToLeaveEmptyNames = new Set(
+        requiredInputsToLeaveEmpty.map((x) => x.name),
+      );
+      await fillAllInputsExcept(screen, user, allInputFields, requiredInputsToLeaveEmptyNames);
+      await user.click(screen.getByRole("button", { name: "Next" }));
+
+      const focusedElement = document.activeElement as HTMLElement;
+      expect(
+        within(focusedElement).getByRole("heading", {
+          name: "There is a problem",
+        }),
+      ).toBeInTheDocument();
+
+      for (const field of requiredInputsToLeaveEmpty) {
+        expect(focusedElement).toHaveTextContent(field.errorMessage);
+      }
+    });
+
+    it.each(requiredInputs)(
+      "clicking on the $name error focuses on the input",
+      async ({ labelWithoutAsterisk, role }) => {
+        const user = userEvent.setup();
+        renderWithRouter();
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        await user.click(screen.getByRole("link", { name: `${labelWithoutAsterisk} is required` }));
+
+        const input = screen.getByRole(role, {
+          name: `${labelWithoutAsterisk} *`,
+        });
+        expect(input).toHaveFocus();
+      },
+    );
+
+    it("does not show an error summary if there are fewer than 3 errors", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      const requiredInputsToLeaveEmpty = [
+        { name: "First name *", errorMessage: "First name is required" },
+        { name: "Day *", errorMessage: "Day is required" },
+      ];
+
+      const requiredInputsToLeaveEmptyNames = new Set(
+        requiredInputsToLeaveEmpty.map((x) => x.name),
+      );
+      await fillAllInputsExcept(screen, user, allInputFields, requiredInputsToLeaveEmptyNames);
+      await user.click(screen.getByRole("button", { name: "Next" }));
+
+      expect(screen.queryByRole("alert", { name: "There is a problem" })).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("textbox", {
+          name: "First name *",
+        }),
+      ).toHaveFocus();
+    });
   });
 
   it("saves form data on submit", async () => {
     const user = userEvent.setup();
     const mockRouter = renderWithRouter();
-    for (const textInputField of textInputFields) {
-      const inputField = screen.getByRole("textbox", {
-        name: textInputField.name,
-      });
-      expect(window.sessionStorage.getItem(textInputField.key)).toEqual(null);
-      await user.type(inputField, textInputField.testValue);
-    }
-
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    await user.click(nextButton);
+    await fillAllInputsExcept(screen, user, allInputFields, new Set());
+    await user.click(screen.getByRole("button", { name: "Next" }));
 
     for (const textInputField of textInputFields) {
-      expect(window.sessionStorage.getItem(textInputField.key)).toEqual(textInputField.testValue);
+      expect(window.sessionStorage.getItem(textInputField.key)).toEqual(
+        textInputField.expectedValue ?? textInputField.testValue,
+      );
     }
 
     expect(mockRouter.push).toHaveBeenCalledWith("/form/personal-details/2");
@@ -71,7 +298,9 @@ describe("<PersonalDetailsStep1 />", () => {
     window.sessionStorage.setItem("firstName", "Jane");
     window.sessionStorage.setItem("middleName", "A");
     window.sessionStorage.setItem("lastName", "Doe");
-    window.sessionStorage.setItem("dateOfBirth", "01/01/1990");
+    window.sessionStorage.setItem("dateOfBirthMonth", "1");
+    window.sessionStorage.setItem("dateOfBirthDay", "8");
+    window.sessionStorage.setItem("dateOfBirthYear", "1990");
     window.sessionStorage.setItem("socialSecurityNumber", "123-45-6789");
     window.sessionStorage.setItem("email", "example@test.com");
     window.sessionStorage.setItem("phoneNumber", "123-456-7890");
@@ -80,7 +309,13 @@ describe("<PersonalDetailsStep1 />", () => {
     expect(screen.getByRole("textbox", { name: "First name *" })).toHaveValue("Jane");
     expect(screen.getByRole("textbox", { name: "Middle name" })).toHaveValue("A");
     expect(screen.getByRole("textbox", { name: "Last name *" })).toHaveValue("Doe");
-    expect(screen.getByRole("textbox", { name: "Date of birth *" })).toHaveValue("01/01/1990");
+    expect(
+      screen.getByRole("combobox", {
+        name: "Month *",
+      }),
+    ).toHaveDisplayValue("01 - January");
+    expect(screen.getByRole("textbox", { name: "Day *" })).toHaveValue("8");
+    expect(screen.getByRole("textbox", { name: "Year *" })).toHaveValue("1990");
     expect(screen.getByRole("textbox", { name: "Social security number *" })).toHaveValue(
       "123-45-6789",
     );
@@ -88,108 +323,5 @@ describe("<PersonalDetailsStep1 />", () => {
       "example@test.com",
     );
     expect(screen.getByRole("textbox", { name: "Phone number *" })).toHaveValue("123-456-7890");
-  });
-
-  it.each([
-    { labelWithoutAsterisk: "First name" },
-    { labelWithoutAsterisk: "Last name" },
-    { labelWithoutAsterisk: "Date of birth" },
-    { labelWithoutAsterisk: "Phone number" },
-    { labelWithoutAsterisk: "Email address" },
-    { labelWithoutAsterisk: "Social security number" },
-  ])(
-    "marks $labelWithoutAsterisk as required and displays an error message if it is not filled in",
-    async ({ labelWithoutAsterisk }) => {
-      const user = userEvent.setup();
-      renderWithRouter();
-
-      const input = screen.getByRole("textbox", {
-        name: `${labelWithoutAsterisk} *`,
-      });
-      expect(input).toBeRequired();
-
-      const nextButton = screen.getByRole("button", { name: "Next" });
-      await user.click(nextButton);
-
-      expect(input).toHaveAccessibleDescription(
-        expect.stringContaining(`${labelWithoutAsterisk} is required`),
-      );
-      expect(input).toHaveAttribute("aria-invalid", "true");
-    },
-  );
-
-  it.each([["invalid-email"], ["invalid@email"], ["invalid.email"]])(
-    "displays an error message if the invalid email format %s is submitted",
-    async (invalidEmail) => {
-      const user = userEvent.setup();
-      renderWithRouter();
-
-      const input = screen.getByRole("textbox", {
-        name: `Email address *`,
-      });
-      await user.type(input, invalidEmail);
-      const nextButton = screen.getByRole("button", { name: "Next" });
-      await user.click(nextButton);
-
-      expect(input).toHaveAccessibleDescription(
-        expect.stringContaining("Entered value does not match email format"),
-      );
-    },
-  );
-
-  it("shows an error summary if there are 3 or more errors", async () => {
-    const user = userEvent.setup();
-    renderWithRouter();
-    const requiredInputsToLeaveEmpty = [
-      { label: "First name *", errorMessage: "First name is required" },
-      { label: "Date of birth *", errorMessage: "Date of birth is required" },
-      { label: "Email address *", errorMessage: "Email address is required" },
-    ];
-
-    const requiredInputsToLeaveEmptyLabels = new Set(
-      requiredInputsToLeaveEmpty.map((x) => x.label),
-    );
-    for (const textInputField of textInputFields) {
-      if (!requiredInputsToLeaveEmptyLabels.has(textInputField.name)) {
-        const inputField = screen.getByRole("textbox", {
-          name: textInputField.name,
-        });
-        await user.type(inputField, textInputField.testValue);
-      }
-    }
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    await user.click(nextButton);
-
-    const focusedElement = document.activeElement as HTMLElement;
-    const errorSummary = within(focusedElement).getByRole("alert", { name: "There is a problem" });
-
-    for (const field of requiredInputsToLeaveEmpty) {
-      expect(errorSummary).toHaveTextContent(field.errorMessage);
-    }
-  });
-
-  it("does not show an error summary if there are fewer than 3 errors", async () => {
-    const user = userEvent.setup();
-    renderWithRouter();
-    const requiredInputsToLeaveEmpty = [
-      { label: "First name *", errorMessage: "First name is required" },
-      { label: "Date of birth *", errorMessage: "Date of birth is required" },
-    ];
-
-    const requiredInputsToLeaveEmptyLabels = new Set(
-      requiredInputsToLeaveEmpty.map((x) => x.label),
-    );
-    for (const textInputField of textInputFields) {
-      if (!requiredInputsToLeaveEmptyLabels.has(textInputField.name)) {
-        const inputField = screen.getByRole("textbox", {
-          name: textInputField.name,
-        });
-        await user.type(inputField, textInputField.testValue);
-      }
-    }
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    await user.click(nextButton);
-
-    expect(screen.queryByRole("alert", { name: "There is a problem" })).not.toBeInTheDocument();
   });
 });

--- a/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
@@ -1,5 +1,9 @@
 import PersonalDetailsStep2 from "@form/(formSteps)/personal-details/2/page";
-import { RouterPathnameProvider } from "@form/_utils/testUtils";
+import {
+  fillAllInputsExcept,
+  RouterPathnameProvider,
+  type InputField,
+} from "@form/_utils/testUtils";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
@@ -9,6 +13,17 @@ const textInputFields = [
   { name: "Street address line 2", key: "streetAddress2", testValue: "Test address 2" },
   { name: "City *", key: "city", testValue: "Test city" },
   { name: "ZIP code *", key: "zip", testValue: "12345" },
+];
+
+const allInputFields: Array<InputField> = [
+  ...textInputFields,
+  { name: "State *", role: "combobox", testValue: "PA" },
+];
+
+const requiredFields = [
+  { labelWithoutAsterisk: "Street address 1" },
+  { labelWithoutAsterisk: "City" },
+  { labelWithoutAsterisk: "ZIP code" },
 ];
 
 describe("<PersonalDetailsStep2 />", () => {
@@ -30,47 +45,142 @@ describe("<PersonalDetailsStep2 />", () => {
     return mockRouter;
   };
 
-  it.each(textInputFields)("updates the $name text input", async ({ name, testValue }) => {
-    const user = userEvent.setup();
-    renderWithRouter();
-    const inputField = screen.getByRole("textbox", {
-      name: name,
-    });
-    expect(inputField).toHaveValue("");
+  describe("input updates", () => {
+    it.each(textInputFields)("updates the $name text input", async ({ name, testValue }) => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      const input = screen.getByRole("textbox", {
+        name: name,
+      });
+      expect(input).toHaveValue("");
 
-    await user.type(inputField, testValue);
-    expect(inputField).toHaveValue(testValue);
+      await user.type(input, testValue);
+      expect(input).toHaveValue(testValue);
+    });
+
+    it("defaults address state to NJ and updates it", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      const combobox = screen.getByRole("combobox", {
+        name: "State *",
+      });
+      expect(combobox).toHaveValue("NJ");
+
+      await user.selectOptions(combobox, "PA");
+      expect(combobox).toHaveValue("PA");
+    });
   });
 
-  it("defaults address state to NJ and updates it", async () => {
-    const user = userEvent.setup();
-    renderWithRouter();
-    const combobox = screen.getByRole("combobox", {
-      name: "State *",
-    });
-    expect(combobox).toHaveValue("NJ");
+  describe("individual input validation and error messages", () => {
+    it.each(requiredFields)(
+      "marks $labelWithoutAsterisk as required and displays an error message if it is not filled in",
+      async ({ labelWithoutAsterisk }) => {
+        const user = userEvent.setup();
+        renderWithRouter();
 
-    await user.selectOptions(combobox, "PA");
-    expect(combobox).toHaveValue("PA");
+        const name = `${labelWithoutAsterisk} *`;
+        const input = screen.getByRole("textbox", {
+          name: name,
+        });
+        expect(input).toBeRequired();
+        await fillAllInputsExcept(screen, user, allInputFields, new Set([name]));
+        await user.click(screen.getByRole("button", { name: "Next" }));
+
+        expect(input).toHaveAccessibleDescription(
+          expect.stringContaining(`${labelWithoutAsterisk} is required`),
+        );
+        expect(input).toHaveAttribute("aria-invalid", "true");
+        expect(input).toHaveFocus();
+      },
+    );
+
+    it("validates ZIP code", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+
+      const input = screen.getByRole("textbox", {
+        name: "ZIP code *",
+      });
+
+      await user.type(input, "aaa");
+      expect(input).toHaveValue("");
+      await user.type(input, "!!");
+      expect(input).toHaveValue("");
+
+      await user.type(input, "1");
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      expect(input).toHaveAccessibleDescription(
+        expect.stringContaining("ZIP code must have five digits"),
+      );
+      expect(input).toHaveAttribute("aria-invalid", "true");
+    });
+  });
+
+  describe("error summary", () => {
+    it("shows an error summary if there are 3 or more errors", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      await user.click(screen.getByRole("button", { name: "Next" }));
+
+      const focusedElement = document.activeElement as HTMLElement;
+      expect(
+        within(focusedElement).getByRole("heading", {
+          name: "There is a problem",
+        }),
+      ).toBeInTheDocument();
+
+      const expectedErrorMessages = [
+        "Street address 1 is required",
+        "City is required",
+        "ZIP code is required",
+      ];
+      for (const errorMessage of expectedErrorMessages) {
+        expect(focusedElement).toHaveTextContent(errorMessage);
+      }
+    });
+
+    it.each(requiredFields)(
+      "clicking on the $name error focuses on the input",
+      async ({ labelWithoutAsterisk }) => {
+        const user = userEvent.setup();
+        renderWithRouter();
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        await user.click(screen.getByRole("link", { name: `${labelWithoutAsterisk} is required` }));
+
+        const input = screen.getByRole("textbox", {
+          name: `${labelWithoutAsterisk} *`,
+        });
+        expect(input).toHaveFocus();
+      },
+    );
+
+    it("does not show an error summary if there are fewer than 3 errors", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+
+      const requiredInputsToLeaveEmpty = [
+        { label: "Street address 1 *", errorMessage: "Street address is required" },
+      ];
+      const requiredInputsToLeaveEmptyNames = new Set(
+        requiredInputsToLeaveEmpty.map((x) => x.label),
+      );
+      await fillAllInputsExcept(screen, user, allInputFields, requiredInputsToLeaveEmptyNames);
+      await user.click(screen.getByRole("button", { name: "Next" }));
+
+      expect(screen.queryByRole("alert", { name: "There is a problem" })).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("textbox", {
+          name: "Street address 1 *",
+        }),
+      ).toHaveFocus();
+    });
   });
 
   it("saves form data on submit", async () => {
     const user = userEvent.setup();
     const mockRouter = renderWithRouter();
-    for (const textInputField of textInputFields) {
-      const inputField = screen.getByRole("textbox", {
-        name: textInputField.name,
-      });
-      expect(window.sessionStorage.getItem(textInputField.key)).toEqual(null);
-      await user.type(inputField, textInputField.testValue);
-    }
-    const combobox = screen.getByRole("combobox", {
-      name: "State *",
-    });
-    await user.selectOptions(combobox, "PA");
-
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    await user.click(nextButton);
+    await fillAllInputsExcept(screen, user, allInputFields, new Set());
+    await user.click(screen.getByRole("button", { name: "Next" }));
 
     for (const textInputField of textInputFields) {
       expect(window.sessionStorage.getItem(textInputField.key)).toEqual(textInputField.testValue);
@@ -94,73 +204,5 @@ describe("<PersonalDetailsStep2 />", () => {
     expect(screen.getByRole("textbox", { name: "City *" })).toHaveValue("Newark");
     expect(screen.getByRole("combobox", { name: "State *" })).toHaveValue("NJ");
     expect(screen.getByRole("textbox", { name: "ZIP code *" })).toHaveValue("12345");
-  });
-
-  it.each([
-    { labelWithoutAsterisk: "Street address 1" },
-    { labelWithoutAsterisk: "City" },
-    { labelWithoutAsterisk: "ZIP code" },
-  ])(
-    "marks $labelWithoutAsterisk as required and displays an error message if it is not filled in",
-    async ({ labelWithoutAsterisk }) => {
-      const user = userEvent.setup();
-      renderWithRouter();
-
-      const input = screen.getByRole("textbox", {
-        name: `${labelWithoutAsterisk} *`,
-      });
-      expect(input).toBeRequired();
-
-      const nextButton = screen.getByRole("button", { name: "Next" });
-      await user.click(nextButton);
-
-      expect(input).toHaveAccessibleDescription(
-        expect.stringContaining(`${labelWithoutAsterisk} is required`),
-      );
-      expect(input).toHaveAttribute("aria-invalid", "true");
-    },
-  );
-
-  it("shows an error summary if there are 3 or more errors", async () => {
-    const user = userEvent.setup();
-    renderWithRouter();
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    await user.click(nextButton);
-
-    const focusedElement = document.activeElement as HTMLElement;
-    const errorSummary = within(focusedElement).getByRole("alert", { name: "There is a problem" });
-
-    const expectedErrorMessages = [
-      "Street address 1 is required",
-      "City is required",
-      "ZIP code is required",
-    ];
-    for (const errorMessage of expectedErrorMessages) {
-      expect(errorSummary).toHaveTextContent(errorMessage);
-    }
-  });
-
-  it("does not show an error summary if there are fewer than 3 errors", async () => {
-    const user = userEvent.setup();
-    renderWithRouter();
-
-    const requiredInputsToLeaveEmpty = [
-      { label: "Street address 1 *", errorMessage: "Street address is required" },
-    ];
-    const requiredInputsToLeaveEmptyLabels = new Set(
-      requiredInputsToLeaveEmpty.map((x) => x.label),
-    );
-    for (const textInputField of textInputFields) {
-      if (!requiredInputsToLeaveEmptyLabels.has(textInputField.name)) {
-        const inputField = screen.getByRole("textbox", {
-          name: textInputField.name,
-        });
-        await user.type(inputField, textInputField.testValue);
-      }
-    }
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    await user.click(nextButton);
-
-    expect(screen.queryByRole("alert", { name: "There is a problem" })).not.toBeInTheDocument();
   });
 });

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -5,7 +5,7 @@ import { type PersonalDetails2Data } from "@form/(formSteps)/personal-details/Pe
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState } from "@form/_utils/inputFields/enums";
 import { getValue, setKeyValue } from "@form/_utils/sessionStorage";
-import { Fieldset, Form, Label, Select, TextInput } from "@trussworks/react-uswds";
+import { Fieldset, Form, Label, Select, TextInput, TextInputMask } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useForm, type SubmitErrorHandler, type SubmitHandler } from "react-hook-form";
@@ -27,6 +27,7 @@ const PersonalDetailsStep2 = () => {
     handleSubmit,
     formState: { errors },
     setFocus,
+    watch,
   } = useForm<PersonalDetails2Data>({
     defaultValues: {
       streetAddress1: getValue("streetAddress1") || "",
@@ -39,10 +40,12 @@ const PersonalDetailsStep2 = () => {
   });
   const [shouldSummarizeErrors, setShouldSummarizeErrors] = useState(false);
   const errorSummaryRef = useRef<HTMLInputElement>(null);
+  const zip = watch("zip");
 
   const onSubmit: SubmitHandler<PersonalDetails2Data> = (data) => {
-    for (const key in data) {
-      const value = data[key as keyof PersonalDetails2Data] ?? "";
+    let key: keyof PersonalDetails2Data;
+    for (key in data) {
+      const value = data[key] ?? "";
       setKeyValue(key, value);
     }
     routeToNextStep(router, formProgressPosition);
@@ -77,7 +80,6 @@ const PersonalDetailsStep2 = () => {
               {shouldSummarizeErrors && Object.keys(errors).length >= 1 && (
                 <div
                   className="usa-alert usa-alert--error margin-bottom-3 border-05 border-top-105 border-secondary-dark"
-                  role="alert"
                   aria-labelledby="error-summary-heading"
                 >
                   <div className="usa-alert__body">
@@ -86,7 +88,17 @@ const PersonalDetailsStep2 = () => {
                     </h2>
                     <ul className="usa-list usa-list--unstyled">
                       {Object.entries(errors).map(([field, error]) => (
-                        <li key={field}>{error.message}</li>
+                        <li key={field}>
+                          <a
+                            href={`#${field}`}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setFocus(field as keyof PersonalDetails2Data);
+                            }}
+                          >
+                            {error.message}
+                          </a>
+                        </li>
                       ))}
                     </ul>
                   </div>
@@ -115,11 +127,7 @@ const PersonalDetailsStep2 = () => {
                     })}
                   />
                   {errors.streetAddress1 && (
-                    <span
-                      id="streetAddress1ErrorMessage"
-                      className="usa-error-message"
-                      role="alert"
-                    >
+                    <span id="streetAddress1ErrorMessage" className="usa-error-message">
                       {errors.streetAddress1.message}
                     </span>
                   )}
@@ -148,7 +156,7 @@ const PersonalDetailsStep2 = () => {
                     })}
                   />
                   {errors.city && (
-                    <span id="cityErrorMessage" className="usa-error-message" role="alert">
+                    <span id="cityErrorMessage" className="usa-error-message">
                       {errors.city.message}
                     </span>
                   )}
@@ -171,20 +179,27 @@ const PersonalDetailsStep2 = () => {
                   <Label htmlFor="zip" requiredMarker>
                     {orderedInputNameToLabel["zip"]}
                   </Label>
-                  <TextInput
+                  <TextInputMask
                     className="usa-input--medium"
                     id="zip"
                     type="text"
+                    value={zip ?? ""}
+                    mask="#####"
+                    pattern="\d{5}"
                     required
                     validationStatus={errors.zip ? "error" : undefined}
                     aria-invalid={errors.zip ? "true" : "false"}
                     aria-describedby={errors.zip && "zipErrorMessage"}
                     {...register("zip", {
                       required: `${orderedInputNameToLabel["zip"]} is required`,
+                      minLength: {
+                        value: 5,
+                        message: `${orderedInputNameToLabel["zip"]} must have five digits`,
+                      },
                     })}
                   />
                   {errors.zip && (
-                    <span id="zipErrorMessage" className="usa-error-message" role="alert">
+                    <span id="zipErrorMessage" className="usa-error-message">
                       {errors.zip.message}
                     </span>
                   )}

--- a/src/app/form/(formSteps)/personal-details/3/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/page.tsx
@@ -32,8 +32,9 @@ const PersonalDetailsStep3 = () => {
   });
 
   const onSubmit: SubmitHandler<PersonalDetails3Data> = (data) => {
-    for (const key in data) {
-      const value = data[key as keyof PersonalDetails3Data] ?? "";
+    let key: keyof PersonalDetails3Data;
+    for (key in data) {
+      const value = data[key] ?? "";
       setKeyValue(key, value);
     }
     routeToNextStep(router, formProgressPosition);
@@ -68,7 +69,7 @@ const PersonalDetailsStep3 = () => {
               })}
             />
             {errors.npiNumber && (
-              <span id="npiNumberErrorMessage" className="usa-error-message" role="alert">
+              <span id="npiNumberErrorMessage" className="usa-error-message">
                 {errors.npiNumber.message}
               </span>
             )}

--- a/src/app/form/(formSteps)/personal-details/PersonalDetailsData.ts
+++ b/src/app/form/(formSteps)/personal-details/PersonalDetailsData.ts
@@ -2,7 +2,9 @@ export interface PersonalDetails1Data {
   firstName: string | null;
   middleName: string | null;
   lastName: string | null;
-  dateOfBirth: string | null;
+  dateOfBirthMonth: string | null;
+  dateOfBirthDay: string | null;
+  dateOfBirthYear: string | null;
   socialSecurityNumber: string | null;
   email: string | null;
   phoneNumber: string | null;
@@ -21,8 +23,3 @@ export interface PersonalDetails3Data {
   medicareProviderId: string | null;
   upinNumber: string | null;
 }
-
-export interface PersonalDetailsData
-  extends PersonalDetails1Data,
-    PersonalDetails2Data,
-    PersonalDetails3Data {}

--- a/src/app/form/_utils/inputFields/dateOfBirth.ts
+++ b/src/app/form/_utils/inputFields/dateOfBirth.ts
@@ -1,7 +1,0 @@
-export const formatDateOfBirthDefaultValue = (dateOfBirth: Date) => {
-  const year = new Intl.DateTimeFormat("en", { year: "numeric" }).format(dateOfBirth);
-  const month = new Intl.DateTimeFormat("en", { month: "2-digit" }).format(dateOfBirth);
-  const day = new Intl.DateTimeFormat("en", { day: "2-digit" }).format(dateOfBirth);
-  const format = `${year}-${month}-${day}`;
-  return format;
-};

--- a/src/app/form/_utils/sessionStorage.ts
+++ b/src/app/form/_utils/sessionStorage.ts
@@ -1,14 +1,27 @@
-export const setKeyValue = (key: string, value: string): void => {
+import type { Disclosure1Data } from "@/app/form/(formSteps)/disclosures/DisclosureData";
+import type {
+  PersonalDetails1Data,
+  PersonalDetails2Data,
+  PersonalDetails3Data,
+} from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
+
+type SessionStorageKey =
+  | keyof PersonalDetails1Data
+  | keyof PersonalDetails2Data
+  | keyof PersonalDetails3Data
+  | keyof Disclosure1Data;
+
+export const setKeyValue = (key: SessionStorageKey, value: string): void => {
   window.sessionStorage.setItem(key, value);
 };
 
-export const getValue = (key: string): string | null => {
+export const getValue = (key: SessionStorageKey): string | null => {
   if (typeof window !== "undefined") {
     return window.sessionStorage.getItem(key);
   }
   return null;
 };
 
-export const removeKey = (key: string): void => {
+export const removeKey = (key: SessionStorageKey): void => {
   window.sessionStorage.removeItem(key);
 };

--- a/src/app/form/_utils/testUtils.tsx
+++ b/src/app/form/_utils/testUtils.tsx
@@ -1,3 +1,5 @@
+import type { Screen } from "@testing-library/dom";
+import type { UserEvent } from "@testing-library/user-event";
 import {
   AppRouterContext,
   type AppRouterInstance,
@@ -14,4 +16,38 @@ export const RouterPathnameProvider = (props: {
       <PathnameContext.Provider value={props.pathname}>{props.children}</PathnameContext.Provider>
     </AppRouterContext.Provider>
   );
+};
+
+export interface InputField {
+  name: string;
+  role?: "textbox" | "combobox";
+  testValue?: string;
+}
+
+export const fillAllInputsExcept = async (
+  screen: Screen,
+  user: UserEvent,
+  allInputs: Array<InputField>,
+  namesToSkip: Set<string>,
+) => {
+  for (const input of allInputs) {
+    if (!namesToSkip.has(input.name)) {
+      const role = input.role ?? "textbox";
+      const value = input.testValue ?? "test";
+      const inputField = screen.getByRole(role, {
+        name: input.name,
+      });
+
+      switch (role) {
+        case "textbox":
+          await user.type(inputField, value);
+          break;
+        case "combobox":
+          await user.selectOptions(inputField, value);
+          break;
+        default:
+          throw new Error(`Role ${role} not implemented`);
+      }
+    }
+  }
 };


### PR DESCRIPTION
## Link to issue

This commit resolves #[30](https://github.com/newjersey/doula-pm/issues/30) and #[86](https://github.com/newjersey/doula-pm/issues/86).

## What was done?
Out of scope:
- Matching error validation styling to NJWDS https://github.com/newjersey/doula-pm/issues/155

This commit
- Updates the error summary to have links to the individual input fields
- Changes the date of birth input to the recommended format (https://github.com/newjersey/doula-pm/issues/86), because it was easier to do so than ge†ting a ref into DatePicker to focus on
- Sets focus on individual date of birth fields when it is the first with an error, or when linked to by the error summary
- Reintroduces `TextInputMask` for phone number, SSN, and ZIP code to standardize the format such that the user only inputs numbers, and the value includes dashes in the appropriate place
- Adds additional validation for the numberse in date of birth day, date of birth year, SSN, and phone number

It also
- Takes off the role="alert" on error summary, since the alert group is read by setting focus, and every change to the contents (e.g. fixing one form field) re-triggers alerting on all others. Also removes role="alert" on inline errors, per https://github.com/newjersey/doula-medicaid/pull/37#discussion_r2248621960
- Gets rid of the `PersonalDetailsData` type (all personal data across all steps), and creates a `SessionStorageKey` type
- Group tests (they are getting long), tidy the code, and add tests for individual input error focus

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the WAVE extension.

## How should a reviewer test?

- [ ] Locally, run \`npm install\` then \`npm run dev\`.
- [ ] On pages http://localhost:3000/form/personal-details/1, /2, and /3, clicking "Next" without filling the required fields. In the error summary that pops up, the individual errors should be links that set focus on the corresponding input
- [ ] Date of birth should error on submission if the month is outside 1 to 31, or if the year is fewer than 4 digits. Both should not let you type more than the corresponding number of digits.
- [ ] Phone number, SSN (in the first step), and ZIP code (second step) should only allow typing numbers, and should format with dashes. Not filling the required number of numbers should cause an error on clicking "Next". Successfully clicking "Next", and then coming back should pre-populate phone number and SSN without any visual issues.
- [ ] On a screen reader, when an error summary appears, it should not constantly read alerts as inputs are fixed and the messages in the error summary modifies.
- [ ] Clicking through to download the pdf should populate the date of birth correctly

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

<img width="1832" height="3060" alt="main d20cvhuc4595ep amplifyapp com_form_personal-details_1 (2)" src="https://github.com/user-attachments/assets/44458ab8-924b-4fb3-9732-2d42e844e411" />

<img width="1862" height="1936" alt="main d20cvhuc4595ep amplifyapp com_form_personal-details_2 (1)" src="https://github.com/user-attachments/assets/4a060676-221d-4343-a517-068791516573" />


</details>


<details>
<summary>After</summary>

<img width="1818" height="3492" alt="localhost_3000_form_personal-details_1 (4)" src="https://github.com/user-attachments/assets/1982d817-87fc-42d2-9a1c-045586b39f14" />

<img width="1818" height="2258" alt="localhost_3000_form_personal-details_2 (1)" src="https://github.com/user-attachments/assets/e1297f0f-cf99-4bcb-95b8-0173261f1ddc" />

</details>