### PR TITLE
Enforce prettier in CI

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,21 @@
+name: Prettier
+
+on:
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run prettier
+        run: npm run prettier:check

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"]
 }


### PR DESCRIPTION
## Link to issue

https://github.com/newjersey/doula-pm/issues/120

## What was done?

Enforce prettier on the CI. Verified that errors will fail it.

<img width="1942" height="932" alt="image" src="https://github.com/user-attachments/assets/315feaa1-e18c-4dd6-a4c5-b4edcf1b1990" />

Separately, the pre-commit hook already enforces prettier [via lint-staged](https://prettier.io/docs/precommit). Verified that formatting errors will fail the pre-commit.


## Accessibility

- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the WAVE extension.

## How should a reviewer test?

- Describe the testing approach taken to verify the changes, including:
  - Unit/integration/manual tests
  - Test data used

## Screenshots (for visual changes)

- Before
- After
