### PR TITLE
[#152] Refactor error summary into its own component

### DIFF
--- a/src/app/form/(formSteps)/components/ErrorSummary.tsx
+++ b/src/app/form/(formSteps)/components/ErrorSummary.tsx
@@ -1,0 +1,48 @@
+import type { FieldErrors, FieldValues, Path, UseFormSetFocus } from "react-hook-form";
+
+interface ErrorSummaryProps<T extends FieldValues> {
+  shouldSummarizeErrors: boolean;
+  errors: FieldErrors<T>;
+  ref: React.RefObject<HTMLDivElement | null>;
+  setFocus: UseFormSetFocus<T>;
+}
+
+const ErrorSummary = <T extends FieldValues>(props: ErrorSummaryProps<T>) => {
+  return (
+    <div tabIndex={-1} ref={props.ref}>
+      {props.shouldSummarizeErrors && Object.keys(props.errors).length >= 1 && (
+        <div
+          className="usa-alert usa-alert--error margin-bottom-3 border-05 border-top-105 border-secondary-dark"
+          aria-labelledby="error-summary-heading"
+        >
+          <div className="usa-alert__body">
+            <h2 className="usa-alert__heading" id="error-summary-heading">
+              There is a problem
+            </h2>
+            <ul className="usa-list usa-list--unstyled">
+              {Object.entries(props.errors).map(([field, error]) => {
+                if (typeof error?.message === "string") {
+                  return (
+                    <li key={field}>
+                      <a
+                        href={`#${field}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          props.setFocus(field as Path<T>);
+                        }}
+                      >
+                        {error.message}
+                      </a>
+                    </li>
+                  );
+                }
+              })}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ErrorSummary;

--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ErrorSummary from "@/app/form/(formSteps)/components/ErrorSummary";
 import { type PersonalDetails1Data } from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
@@ -55,7 +56,7 @@ const PersonalDetailsStep1 = () => {
     },
     shouldFocusError: false,
   });
-  const errorSummaryRef = useRef<HTMLInputElement>(null);
+  const errorSummaryRef = useRef<HTMLDivElement>(null);
   const phoneNumber = watch("phoneNumber");
   const socialSecurityNumber = watch("socialSecurityNumber");
 
@@ -93,38 +94,12 @@ const PersonalDetailsStep1 = () => {
       {dataHasLoaded && (
         <Form onSubmit={handleSubmit(onSubmit, onError)} className="maxw-full" noValidate>
           <div className="maxw-tablet">
-            <div tabIndex={-1} ref={errorSummaryRef}>
-              {shouldSummarizeErrors && Object.keys(errors).length >= 1 && (
-                <div
-                  className="usa-alert usa-alert--error margin-bottom-3 border-05 border-top-105 border-secondary-dark"
-                  aria-labelledby="error-summary-heading"
-                >
-                  <div className="usa-alert__body">
-                    <h2 className="usa-alert__heading" id="error-summary-heading">
-                      There is a problem
-                    </h2>
-
-                    <ul className="usa-list usa-list--unstyled">
-                      {Object.entries(errors).map(([field, error]) => {
-                        return (
-                          <li key={field}>
-                            <a
-                              href={`#${field}`}
-                              onClick={(e) => {
-                                e.preventDefault();
-                                setFocus(field as keyof PersonalDetails1Data);
-                              }}
-                            >
-                              {error.message}
-                            </a>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </div>
-                </div>
-              )}
-            </div>
+            <ErrorSummary<PersonalDetails1Data>
+              shouldSummarizeErrors={shouldSummarizeErrors}
+              errors={errors}
+              ref={errorSummaryRef}
+              setFocus={setFocus}
+            />
             <h2 className="font-heading-md">Personal identification</h2>
             <Fieldset legend="Name" legendStyle="srOnly" className="grid-row grid-gap">
               <div className="tablet:grid-col-4">

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ErrorSummary from "@/app/form/(formSteps)/components/ErrorSummary";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { type PersonalDetails2Data } from "@form/(formSteps)/personal-details/PersonalDetailsData";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
@@ -39,7 +40,7 @@ const PersonalDetailsStep2 = () => {
     shouldFocusError: false,
   });
   const [shouldSummarizeErrors, setShouldSummarizeErrors] = useState(false);
-  const errorSummaryRef = useRef<HTMLInputElement>(null);
+  const errorSummaryRef = useRef<HTMLDivElement>(null);
   const zip = watch("zip");
 
   const onSubmit: SubmitHandler<PersonalDetails2Data> = (data) => {
@@ -76,35 +77,12 @@ const PersonalDetailsStep2 = () => {
       {dataHasLoaded && (
         <Form onSubmit={handleSubmit(onSubmit, onError)} className="maxw-full" noValidate>
           <div className="maxw-tablet">
-            <div tabIndex={-1} ref={errorSummaryRef}>
-              {shouldSummarizeErrors && Object.keys(errors).length >= 1 && (
-                <div
-                  className="usa-alert usa-alert--error margin-bottom-3 border-05 border-top-105 border-secondary-dark"
-                  aria-labelledby="error-summary-heading"
-                >
-                  <div className="usa-alert__body">
-                    <h2 className="usa-alert__heading" id="error-summary-heading">
-                      There is a problem
-                    </h2>
-                    <ul className="usa-list usa-list--unstyled">
-                      {Object.entries(errors).map(([field, error]) => (
-                        <li key={field}>
-                          <a
-                            href={`#${field}`}
-                            onClick={(e) => {
-                              e.preventDefault();
-                              setFocus(field as keyof PersonalDetails2Data);
-                            }}
-                          >
-                            {error.message}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </div>
-              )}
-            </div>
+            <ErrorSummary<PersonalDetails2Data>
+              shouldSummarizeErrors={shouldSummarizeErrors}
+              errors={errors}
+              ref={errorSummaryRef}
+              setFocus={setFocus}
+            />
             <h2 className="font-heading-md">Mailing address</h2>
             <p className="usa-hint">
               This is the location where you want to receive official mail.


### PR DESCRIPTION
## Link to issue

This commit resolves #[152](https://github.com/newjersey/doula-pm/issues/152).

## What was done?
Refactor the error summary into its own component for reusability

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the WAVE extension.

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- In both http://localhost:3000/form/personal-details/1 and http://localhost:3000/form/personal-details/2, the pages should work as previously

## Screenshots (for visual changes)

<details>
<summary>No visual changes, this is what it should look like</summary>

<img width="1912" height="3252" alt="localhost_3000_form_personal-details_1 (5)" src="https://github.com/user-attachments/assets/b3f58fc0-18ec-427f-870e-a035f1a79dc7" />


<img width="1912" height="2214" alt="localhost_3000_form_personal-details_2 (2)" src="https://github.com/user-attachments/assets/a39dfed2-e923-476e-a051-83516b9348fc" />

</details>

