### PR TITLE
[newjersey/doula-pm#94] Personal Step 2 Explainers

### DIFF
--- a/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
@@ -205,4 +205,38 @@ describe("<PersonalDetailsStep2 />", () => {
     expect(screen.getByRole("combobox", { name: "State *" })).toHaveValue("NJ");
     expect(screen.getByRole("textbox", { name: "ZIP code *" })).toHaveValue("12345");
   });
+
+  describe("Public information explainer", () => {
+    it("orders the public information explainer immediately after the address input", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+
+      const zipCodeInput = screen.getByRole("textbox", {
+        name: "ZIP code *",
+      });
+      const publicInformationExplainer = screen.getByRole("button", {
+        name: "Will my information be public?",
+      });
+      await user.type(zipCodeInput, "1");
+      expect(zipCodeInput).toHaveFocus();
+
+      await user.tab();
+      expect(publicInformationExplainer).toHaveFocus();
+    });
+
+    it("has a heading level one greater than the section heading level", () => {
+      renderWithRouter();
+      const sectionHeadingLevel = 2;
+      const addressSectionHeading = screen.getByRole("heading", {
+        name: "Mailing address",
+        level: sectionHeadingLevel,
+      });
+      expect(addressSectionHeading).toBeInTheDocument();
+      const publicInformationExplainer = screen.getByRole("heading", {
+        name: "Will my information be public?",
+        level: sectionHeadingLevel + 1,
+      });
+      expect(publicInformationExplainer).toBeInTheDocument();
+    });
+  });
 });

--- a/src/app/form/(formSteps)/personal-details/2/PublicInformationExplainer.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/PublicInformationExplainer.tsx
@@ -1,0 +1,41 @@
+import { Accordion } from "@trussworks/react-uswds";
+import type { AccordionItemProps } from "node_modules/@trussworks/react-uswds/lib/components/Accordion/Accordion";
+
+const headingLevel = "h3";
+const publicInformationExplainerItems: AccordionItemProps[] = [
+  {
+    title: "Will my information be public?",
+    content: (
+      <>
+        <p>
+          Partially, yes. The information that you share in this website is encrypted, it stays
+          private. But some information will be public because when you receive an NPI (National
+          Provider Identifier), your contact and NPI details will be listed on the national National
+          Plan and Provider Enumeration System (NPPES) NPI Registry. If you use your home address as
+          your mailing and/or business address, it will be public.
+        </p>
+        <p>
+          NJ FamilyCare doesn&apos;t control NPPES listings. Once enrolled, you&apos;ll also appear
+          on the NJ FamilyCare FFS Provider Directory (
+          <a href="https://www.njmmis.com/" target="_blank" rel="noopener">
+            www.njmmis.com
+          </a>
+          ), where street addresses are removed, but city, state, and zip remain. MCOs also list
+          doulas in their directories, removing street addresses.
+        </p>
+        <p>To keep your addresses private consider using a P.O. box.</p>
+      </>
+    ),
+    expanded: false,
+    id: "willMyInformationBePublic",
+    headingLevel,
+  },
+];
+
+const PublicInformationExplainer = () => {
+  return (
+    <Accordion bordered={true} items={publicInformationExplainerItems} multiselectable={true} />
+  );
+};
+
+export default PublicInformationExplainer;

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ErrorSummary from "@/app/form/(formSteps)/components/ErrorSummary";
+import PublicInformationExplainer from "@/app/form/(formSteps)/personal-details/2/PublicInformationExplainer";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { type PersonalDetails2Data } from "@form/(formSteps)/personal-details/PersonalDetailsData";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
@@ -76,114 +77,119 @@ const PersonalDetailsStep2 = () => {
     <div>
       {dataHasLoaded && (
         <Form onSubmit={handleSubmit(onSubmit, onError)} className="maxw-full" noValidate>
-          <div className="maxw-tablet">
-            <ErrorSummary<PersonalDetails2Data>
-              shouldSummarizeErrors={shouldSummarizeErrors}
-              errors={errors}
-              ref={errorSummaryRef}
-              setFocus={setFocus}
-            />
-            <h2 className="font-heading-md">Mailing address</h2>
-            <p className="usa-hint">
-              This is the location where you want to receive official mail.
-            </p>
-            <Fieldset legend="Mailing address" legendStyle="srOnly">
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="streetAddress1" requiredMarker>
-                    {orderedInputNameToLabel["streetAddress1"]}
-                  </Label>
-                  <TextInput
-                    id="streetAddress1"
-                    type="text"
-                    required
-                    validationStatus={errors.streetAddress1 ? "error" : undefined}
-                    aria-invalid={errors.streetAddress1 ? "true" : "false"}
-                    aria-describedby={errors.streetAddress1 && "streetAddress1ErrorMessage"}
-                    {...register("streetAddress1", {
-                      required: `${orderedInputNameToLabel["streetAddress1"]} is required`,
-                    })}
-                  />
-                  {errors.streetAddress1 && (
-                    <span id="streetAddress1ErrorMessage" className="usa-error-message">
-                      {errors.streetAddress1.message}
-                    </span>
-                  )}
+          <div className="form-grid">
+            <div>
+              <ErrorSummary<PersonalDetails2Data>
+                shouldSummarizeErrors={shouldSummarizeErrors}
+                errors={errors}
+                ref={errorSummaryRef}
+                setFocus={setFocus}
+              />
+              <h2 className="font-heading-md">Mailing address</h2>
+              <p className="usa-hint">
+                We will send official mail here. It can be your home address.
+              </p>
+              <Fieldset legend="Mailing address" legendStyle="srOnly">
+                <div className="grid-row grid-gap">
+                  <div className="mobile-lg:grid-col-6">
+                    <Label htmlFor="streetAddress1" requiredMarker>
+                      {orderedInputNameToLabel["streetAddress1"]}
+                    </Label>
+                    <TextInput
+                      id="streetAddress1"
+                      type="text"
+                      required
+                      validationStatus={errors.streetAddress1 ? "error" : undefined}
+                      aria-invalid={errors.streetAddress1 ? "true" : "false"}
+                      aria-describedby={errors.streetAddress1 && "streetAddress1ErrorMessage"}
+                      {...register("streetAddress1", {
+                        required: `${orderedInputNameToLabel["streetAddress1"]} is required`,
+                      })}
+                    />
+                    {errors.streetAddress1 && (
+                      <span id="streetAddress1ErrorMessage" className="usa-error-message">
+                        {errors.streetAddress1.message}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mobile-lg:grid-col-6">
+                    <Label htmlFor="streetAddress2">
+                      {orderedInputNameToLabel["streetAddress2"]}
+                    </Label>
+                    <TextInput id="streetAddress2" type="text" {...register("streetAddress2")} />
+                  </div>
                 </div>
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="streetAddress2">
-                    {orderedInputNameToLabel["streetAddress2"]}
-                  </Label>
-                  <TextInput id="streetAddress2" type="text" {...register("streetAddress2")} />
+                <div className="grid-row grid-gap">
+                  <div className="mobile-lg:grid-col-6">
+                    <Label htmlFor="city" requiredMarker>
+                      {orderedInputNameToLabel["city"]}
+                    </Label>
+                    <TextInput
+                      id="city"
+                      type="text"
+                      required
+                      validationStatus={errors.city ? "error" : undefined}
+                      aria-invalid={errors.city ? "true" : "false"}
+                      aria-describedby={errors.city && "cityErrorMessage"}
+                      {...register("city", {
+                        required: `${orderedInputNameToLabel["city"]} is required`,
+                      })}
+                    />
+                    {errors.city && (
+                      <span id="cityErrorMessage" className="usa-error-message">
+                        {errors.city.message}
+                      </span>
+                    )}
+                  </div>
                 </div>
-              </div>
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="city" requiredMarker>
-                    {orderedInputNameToLabel["city"]}
-                  </Label>
-                  <TextInput
-                    id="city"
-                    type="text"
-                    required
-                    validationStatus={errors.city ? "error" : undefined}
-                    aria-invalid={errors.city ? "true" : "false"}
-                    aria-describedby={errors.city && "cityErrorMessage"}
-                    {...register("city", {
-                      required: `${orderedInputNameToLabel["city"]} is required`,
-                    })}
-                  />
-                  {errors.city && (
-                    <span id="cityErrorMessage" className="usa-error-message">
-                      {errors.city.message}
-                    </span>
-                  )}
+                <div className="grid-row grid-gap">
+                  <div className="mobile-lg:grid-col-6">
+                    <Label htmlFor="state" requiredMarker>
+                      {orderedInputNameToLabel["state"]}
+                    </Label>
+                    <Select className="usa-select" id="state" required {...register("state")}>
+                      {Object.keys(AddressState).map((state) => (
+                        <option key={state} value={state}>
+                          {state}
+                        </option>
+                      ))}
+                    </Select>
+                  </div>
+                  <div className="mobile-lg:grid-col-4">
+                    <Label htmlFor="zip" requiredMarker>
+                      {orderedInputNameToLabel["zip"]}
+                    </Label>
+                    <TextInputMask
+                      className="usa-input--medium"
+                      id="zip"
+                      type="text"
+                      value={zip ?? ""}
+                      mask="#####"
+                      pattern="\d{5}"
+                      required
+                      validationStatus={errors.zip ? "error" : undefined}
+                      aria-invalid={errors.zip ? "true" : "false"}
+                      aria-describedby={errors.zip && "zipErrorMessage"}
+                      {...register("zip", {
+                        required: `${orderedInputNameToLabel["zip"]} is required`,
+                        minLength: {
+                          value: 5,
+                          message: `${orderedInputNameToLabel["zip"]} must have five digits`,
+                        },
+                      })}
+                    />
+                    {errors.zip && (
+                      <span id="zipErrorMessage" className="usa-error-message">
+                        {errors.zip.message}
+                      </span>
+                    )}
+                  </div>
                 </div>
-              </div>
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="state" requiredMarker>
-                    {orderedInputNameToLabel["state"]}
-                  </Label>
-                  <Select className="usa-select" id="state" required {...register("state")}>
-                    {Object.keys(AddressState).map((state) => (
-                      <option key={state} value={state}>
-                        {state}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-                <div className="mobile-lg:grid-col-4">
-                  <Label htmlFor="zip" requiredMarker>
-                    {orderedInputNameToLabel["zip"]}
-                  </Label>
-                  <TextInputMask
-                    className="usa-input--medium"
-                    id="zip"
-                    type="text"
-                    value={zip ?? ""}
-                    mask="#####"
-                    pattern="\d{5}"
-                    required
-                    validationStatus={errors.zip ? "error" : undefined}
-                    aria-invalid={errors.zip ? "true" : "false"}
-                    aria-describedby={errors.zip && "zipErrorMessage"}
-                    {...register("zip", {
-                      required: `${orderedInputNameToLabel["zip"]} is required`,
-                      minLength: {
-                        value: 5,
-                        message: `${orderedInputNameToLabel["zip"]} must have five digits`,
-                      },
-                    })}
-                  />
-                  {errors.zip && (
-                    <span id="zipErrorMessage" className="usa-error-message">
-                      {errors.zip.message}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </Fieldset>
+              </Fieldset>
+            </div>
+            <div className="form-explainer">
+              <PublicInformationExplainer />
+            </div>
           </div>
           <FormProgressButtons />
         </Form>

--- a/src/app/form/(formSteps)/personal-details/3/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/page.tsx
@@ -95,7 +95,7 @@ const PersonalDetailsStep3 = () => {
                 </span>
               )}
             </div>
-            <div className="form-first-question-explainer">
+            <div className="form-explainer form-first-question-explainer">
               <NpiExplainer />
             </div>
             <div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,7 +37,7 @@ abbr[title] {
   }
 }
 @media (max-width: 1023px) {
-  .form-first-question-explainer {
+  .form-explainer {
     margin-top: 20px;
   }
 }


### PR DESCRIPTION
## Link to issue

This commit resolves #[94](https://github.com/newjersey/doula-pm/issues/94).

## What was done?
Add explainer for address information being public.

Figma: https://www.figma.com/design/2R3VxYvZQYsaIxBcWoA1kL/Doula-Prototypes?node-id=2829-15201&t=Lel5hmyAVcKEwqtR-0

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/form/personal-details/2
- The accordion should exist, be expandable, and be in tab order after the form inputs before the buttons for next/previous.

## Screenshots (for visual changes)

<details>
<summary>Before</summary>


<img width="2264" height="1798" alt="main d20cvhuc4595ep amplifyapp com_form_personal-details_2" src="https://github.com/user-attachments/assets/9121f66c-6aa3-4ca8-ad1e-1fef9a91a404" />

</details>


<details>
<summary>After</summary>

<img width="2234" height="2454" alt="localhost_3000_form_personal-details_2" src="https://github.com/user-attachments/assets/c803e5eb-cf0f-4079-abca-d31c5bc2d07a" />

<img width="375" height="3494" alt="localhost_3000_form_personal-details_2(iPhone SE)" src="https://github.com/user-attachments/assets/739cd61b-79e7-4533-b07b-dff378e8c8c7" />


</details>