### PR TITLE
fix matchUpdateTypes selector by placing it in packageRules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
   "extends": ["config:recommended"],
   "automergeSchedule": ["* * * * 0,6", "* 0-6 * * 1"],
   "ignorePaths": ["**/scripts/**"],
-  "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-  "automerge": true
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Link to issue

## What was done?

-  follow up to https://github.com/newjersey/doula-medicaid/pull/62
- Docs at https://docs.renovatebot.com/configuration-options/#automerge

## Accessibility
N/A

## How should a reviewer test?

## Screenshots (for visual changes)

