### PR TITLE
Rename to section for components that don't have steps

### DIFF
--- a/src/app/form/(formSteps)/finish/page.tsx
+++ b/src/app/form/(formSteps)/finish/page.tsx
@@ -56,7 +56,7 @@ const getFormData = (): FormData => {
   };
 };
 
-const DownloadStep = () => {
+const FinishSection = () => {
   const [zipDownloadUrl, setZipDownloadUrl] = useState<string | null>(null);
   useEffect(() => {
     (async () => {
@@ -78,4 +78,4 @@ const DownloadStep = () => {
   );
 };
 
-export default DownloadStep;
+export default FinishSection;

--- a/src/app/form/(formSteps)/insurance/page.tsx
+++ b/src/app/form/(formSteps)/insurance/page.tsx
@@ -6,7 +6,7 @@ import { Form } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 
-const FormStep = () => {
+const FormSection = () => {
   const router = useRouter();
   const formProgressPosition = useFormProgressPosition();
   const { handleSubmit } = useForm<object>({
@@ -26,4 +26,4 @@ const FormStep = () => {
   );
 };
 
-export default FormStep;
+export default FormSection;

--- a/src/app/form/(formSteps)/screening/page.tsx
+++ b/src/app/form/(formSteps)/screening/page.tsx
@@ -6,7 +6,7 @@ import { Form } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 
-const FormStep = () => {
+const FormSection = () => {
   const router = useRouter();
   const formProgressPosition = useFormProgressPosition();
   const { handleSubmit } = useForm<object>({
@@ -26,4 +26,4 @@ const FormStep = () => {
   );
 };
 
-export default FormStep;
+export default FormSection;

--- a/src/app/form/(formSteps)/training/page.tsx
+++ b/src/app/form/(formSteps)/training/page.tsx
@@ -6,7 +6,7 @@ import { Form } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 
-const FormStep = () => {
+const FormSection = () => {
   const router = useRouter();
   const formProgressPosition = useFormProgressPosition();
   const { handleSubmit } = useForm<object>({
@@ -26,4 +26,4 @@ const FormStep = () => {
   );
 };
 
-export default FormStep;
+export default FormSection;


### PR DESCRIPTION
## Link to issue

https://github.com/newjersey/doula-medicaid/pull/61/files#r2267876028

## What was done?

Renamed to be more consistent with the current way we're using these terms

## Accessibility

- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- All the code should work the same

## Screenshots (for visual changes)

- Before
- After
