### PR TITLE
[newjersey/doula-pm#104] Add skip navigation link

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   testEnvironment: "jsdom",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   moduleNameMapper: {
+    "^.+\\.(sass|css|png)$": "<rootDir>/src/app/__mocks__/moduleMock.ts",
     "^@/(.*)$": "<rootDir>/src/$1",
     "^@form/(.*)$": "<rootDir>/src/app/form/$1",
   },

--- a/src/app/__mocks__/moduleMock.ts
+++ b/src/app/__mocks__/moduleMock.ts
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -305,7 +305,7 @@ const PersonalDetailsStep1 = () => {
           <hr className="margin-top-5 margin-bottom-5" />
           <div className="maxw-tablet">
             <h2 className="font-heading-md">Contact information</h2>
-            <p>This is where we&lsquo;ll send official updates and communications.</p>
+            <p>We&apos;ll send official updates here.</p>
             <Label htmlFor="email" requiredMarker>
               {orderedInputNameToLabel["email"]}
             </Label>

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -1,0 +1,21 @@
+import RootLayout from "@/app/layout";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("<RootLayout />", () => {
+  it("it has a skip nav that is the first item in the body and skips to main content when clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <RootLayout>
+        <div>Test child</div>
+      </RootLayout>,
+    );
+    await user.tab();
+    const skipNavigationButton = screen.getByRole("link", { name: "Skip to main content" });
+    expect(skipNavigationButton).toHaveFocus();
+
+    const skipNavigationHref = skipNavigationButton.getAttribute("href") as string;
+    expect(skipNavigationHref.substring(0, 1)).toEqual("#");
+    expect(document.getElementById(skipNavigationHref.substring(1))?.tagName).toEqual("MAIN");
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,6 +23,9 @@ export default function RootLayout({
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
       </Head>
       <body>
+        <a className="usa-skipnav" href="#main-content">
+          Skip to main content
+        </a>
         <header className="nj-banner" aria-label="Official government website">
           <div className="nj-banner__header">
             <div className="grid-container">
@@ -57,9 +60,11 @@ export default function RootLayout({
             </div>
           </div>
         </header>
-        <div className="usa-section">
-          <div className="grid-container">{children}</div>
-        </div>
+        <main id="main-content">
+          <div className="usa-section">
+            <div className="grid-container">{children}</div>
+          </div>
+        </main>
       </body>
     </html>
   );


### PR DESCRIPTION
## Link to issue

This commit resolves #[104](https://github.com/newjersey/doula-pm/issues/104).

## What was done?
This commit adds a skipnav link.
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#skip_links

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to any page, and press tab. The skip nav link should appear (and disappear if you tab away)
- Pressing enter should jump to main

## Screenshots (for visual changes)


<details>
<summary>After</summary>

<img width="697" height="333" alt="image" src="https://github.com/user-attachments/assets/c680183f-c509-4a16-a0e0-3759474799b7" />


</details>