### PR TITLE
[newjersey/doula-pm#192] Require form data fields part 2

### DIFF
--- a/src/app/form/_utils/sessionStorage.ts
+++ b/src/app/form/_utils/sessionStorage.ts
@@ -14,6 +14,13 @@ export type SessionStorageKey =
   | keyof PersonalDetails3Data
   | keyof BusinessDetails1Data;
 
+export class ValueNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValueNotFoundError";
+  }
+}
+
 export const setKeyValue = (key: SessionStorageKey, value: string): void => {
   window.sessionStorage.setItem(key, value);
 };
@@ -25,7 +32,7 @@ export function getValue(key: SessionStorageKey, required: boolean): string | nu
   if (required) {
     const value = window.sessionStorage.getItem(key);
     if (value === null) {
-      throw new Error(`${key} is unexpectedly null`);
+      throw new ValueNotFoundError(`${key} is unexpectedly null`);
     }
     return value;
   } else if (typeof window !== "undefined") {


### PR DESCRIPTION
## Link to issue

This commit resolves #[192](https://github.com/newjersey/doula-pm/issues/192).

## What was done?
This commit implements an error message if a user arrives at `http://localhost:3000/form/finish` without having filled all required fields.

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go directly to http://localhost:3000/form/finish. Or, fill in all required fields except one. You should see the error message below

## Screenshots (for visual changes)

<img width="1083" height="438" alt="image" src="https://github.com/user-attachments/assets/381f1cb6-2d83-45a8-88b8-a54c56b30621" />
