### PR TITLE
[newjersey/doula-pm#192] Wrap getValue with getDefaultValue

### DIFF
--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -4,7 +4,7 @@ import ErrorSummary from "@/app/form/(formSteps)/components/ErrorSummary";
 import { type PersonalDetails1Data } from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
-import { getValue, setKeyValue } from "@form/_utils/sessionStorage";
+import { getDefaultValue, setKeyValue } from "@form/_utils/sessionStorage";
 import {
   DateInputGroup,
   Fieldset,
@@ -44,15 +44,15 @@ const PersonalDetailsStep1 = () => {
     watch,
   } = useForm<PersonalDetails1Data>({
     defaultValues: {
-      firstName: getValue("firstName", false) || "",
-      middleName: getValue("middleName", false) || "",
-      lastName: getValue("lastName", false) || "",
-      dateOfBirthMonth: getValue("dateOfBirthMonth", false) || "",
-      dateOfBirthDay: getValue("dateOfBirthDay", false) || "",
-      dateOfBirthYear: getValue("dateOfBirthYear", false) || "",
-      socialSecurityNumber: getValue("socialSecurityNumber", false) || "",
-      email: getValue("email", false) || "",
-      phoneNumber: getValue("phoneNumber", false) || "",
+      firstName: getDefaultValue("firstName") || "",
+      middleName: getDefaultValue("middleName") || "",
+      lastName: getDefaultValue("lastName") || "",
+      dateOfBirthMonth: getDefaultValue("dateOfBirthMonth") || "",
+      dateOfBirthDay: getDefaultValue("dateOfBirthDay") || "",
+      dateOfBirthYear: getDefaultValue("dateOfBirthYear") || "",
+      socialSecurityNumber: getDefaultValue("socialSecurityNumber") || "",
+      email: getDefaultValue("email") || "",
+      phoneNumber: getDefaultValue("phoneNumber") || "",
     },
     shouldFocusError: false,
   });

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -7,7 +7,7 @@ import FormProgressButtons from "@form/(formSteps)/components/FormProgressButton
 import { type PersonalDetails2Data } from "@form/(formSteps)/personal-details/PersonalDetailsData";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState } from "@form/_utils/inputFields/enums";
-import { getValue, setKeyValue } from "@form/_utils/sessionStorage";
+import { getDefaultValue, setKeyValue } from "@form/_utils/sessionStorage";
 import {
   Fieldset,
   Form,
@@ -48,17 +48,17 @@ const PersonalDetailsStep2 = () => {
     watch,
   } = useForm<PersonalDetails2Data>({
     defaultValues: {
-      streetAddress1: getValue("streetAddress1", false) || "",
-      streetAddress2: getValue("streetAddress2", false) || "",
-      city: getValue("city", false) || "",
-      state: getValue("state", false) || "NJ",
-      zip: getValue("zip", false) || "",
-      hasSameBillingMailingAddress: getValue("hasSameBillingMailingAddress", false) || "",
-      billingStreetAddress1: getValue("billingStreetAddress1", false) || "",
-      billingStreetAddress2: getValue("billingStreetAddress2", false) || "",
-      billingCity: getValue("billingCity", false) || "",
-      billingState: getValue("billingState", false) || "NJ",
-      billingZip: getValue("billingZip", false) || "",
+      streetAddress1: getDefaultValue("streetAddress1") || "",
+      streetAddress2: getDefaultValue("streetAddress2") || "",
+      city: getDefaultValue("city") || "",
+      state: getDefaultValue("state") || "NJ",
+      zip: getDefaultValue("zip") || "",
+      hasSameBillingMailingAddress: getDefaultValue("hasSameBillingMailingAddress") || "",
+      billingStreetAddress1: getDefaultValue("billingStreetAddress1") || "",
+      billingStreetAddress2: getDefaultValue("billingStreetAddress2") || "",
+      billingCity: getDefaultValue("billingCity") || "",
+      billingState: getDefaultValue("billingState") || "NJ",
+      billingZip: getDefaultValue("billingZip") || "",
     },
     shouldFocusError: false,
   });

--- a/src/app/form/(formSteps)/personal-details/3/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/page.tsx
@@ -4,7 +4,7 @@ import NpiExplainer from "@/app/form/(formSteps)/personal-details/3/NpiExplainer
 import type { PersonalDetails3Data } from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
-import { getValue, setKeyValue } from "@form/_utils/sessionStorage";
+import { getDefaultValue, setKeyValue } from "@form/_utils/sessionStorage";
 import { Form, Label, TextInput, TextInputMask } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -27,9 +27,9 @@ const PersonalDetailsStep3 = () => {
     watch,
   } = useForm<PersonalDetails3Data>({
     defaultValues: {
-      npiNumber: getValue("npiNumber", false) || "",
-      upinNumber: getValue("upinNumber", false) || "",
-      medicareProviderId: getValue("medicareProviderId", false) || "",
+      npiNumber: getDefaultValue("npiNumber") || "",
+      upinNumber: getDefaultValue("upinNumber") || "",
+      medicareProviderId: getDefaultValue("medicareProviderId") || "",
     },
   });
   const npiNumber = watch("npiNumber");

--- a/src/app/form/(formSteps)/training/1/page.tsx
+++ b/src/app/form/(formSteps)/training/1/page.tsx
@@ -5,7 +5,7 @@ import FormProgressButtons from "@form/(formSteps)/components/FormProgressButton
 import type { TrainingData } from "@form/(formSteps)/training/TrainingData";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState } from "@form/_utils/inputFields/enums";
-import { getValue, setKeyValue } from "@form/_utils/sessionStorage";
+import { getDefaultValue, setKeyValue } from "@form/_utils/sessionStorage";
 import {
   Fieldset,
   Form,
@@ -40,12 +40,12 @@ const TrainingStep1 = () => {
     watch,
   } = useForm<TrainingData>({
     defaultValues: {
-      trainingStreetAddress1: getValue("trainingStreetAddress1", false) || "",
-      trainingStreetAddress2: getValue("trainingStreetAddress2", false) || "",
-      trainingCity: getValue("trainingCity", false) || "",
-      trainingState: getValue("trainingState", false) || "NJ",
-      trainingZip: getValue("trainingZip", false) || "",
-      isDoulaTrainingInPerson: getValue("isDoulaTrainingInPerson", false) || "",
+      trainingStreetAddress1: getDefaultValue("trainingStreetAddress1") || "",
+      trainingStreetAddress2: getDefaultValue("trainingStreetAddress2") || "",
+      trainingCity: getDefaultValue("trainingCity") || "",
+      trainingState: getDefaultValue("trainingState") || "NJ",
+      trainingZip: getDefaultValue("trainingZip") || "",
+      isDoulaTrainingInPerson: getDefaultValue("isDoulaTrainingInPerson") || "",
     },
     shouldFocusError: false,
   });

--- a/src/app/form/_utils/sessionStorage.ts
+++ b/src/app/form/_utils/sessionStorage.ts
@@ -18,6 +18,8 @@ export const setKeyValue = (key: SessionStorageKey, value: string): void => {
   window.sessionStorage.setItem(key, value);
 };
 
+export const getDefaultValue = (key: SessionStorageKey) => getValue(key, false);
+
 export function getValue(key: SessionStorageKey, required: true): string;
 export function getValue(key: SessionStorageKey, required: false): string | null;
 export function getValue(key: SessionStorageKey, required: boolean): string | null;


### PR DESCRIPTION
## Link to issue

This commit resolves #[192](https://github.com/newjersey/doula-pm/issues/192).

## What was done?
This was done to reduce the mental load of calling getValue in deciding whether the second parameter should be true or false. When populating defaultValue for react-hook-form, the second parameter should always be false.

Per suggestion from https://github.com/newjersey/doula-medicaid/pull/80#discussion_r2288787387

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- There should be no feature changes, the application should work
