### PR TITLE
184 Finish "Training" Section

### DIFF
--- a/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
@@ -102,7 +102,7 @@ describe("<PersonalDetailsStep1 />", () => {
         renderWithRouter();
 
         const labelWithoutAsterisk = name.replace(" *", "");
-        const input = await getInputField(screen, { name, key });
+        const input = await getInputField(screen, { name });
         expect(input).toBeRequired();
         await fillAllInputsExcept(screen, user, allInputFields, new Set([key]));
         await user.click(screen.getByRole("button", { name: "Next" }));
@@ -241,14 +241,14 @@ describe("<PersonalDetailsStep1 />", () => {
 
     it.each(requiredInputs)(
       "clicking on the $name error focuses on the input",
-      async ({ name, key }) => {
+      async ({ name }) => {
         const labelWithoutAsterisk = name.replace(" *", "");
         const user = userEvent.setup();
         renderWithRouter();
         await user.click(screen.getByRole("button", { name: "Next" }));
         await user.click(screen.getByRole("link", { name: `${labelWithoutAsterisk} is required` }));
 
-        const input = await getInputField(screen, { name, key });
+        const input = await getInputField(screen, { name });
         expect(input).toHaveFocus();
       },
     );

--- a/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
@@ -159,7 +159,7 @@ describe("<PersonalDetailsStep2 />", () => {
         const user = userEvent.setup();
         renderWithRouter();
 
-        const input = await getInputField(screen, { name, key });
+        const input = await getInputField(screen, { name });
         expect(input).toBeRequired();
         await fillAllInputsExcept(screen, user, minimalSetOfInputFields, new Set([key]));
         await user.click(screen.getByRole("button", { name: "Next" }));
@@ -254,7 +254,7 @@ describe("<PersonalDetailsStep2 />", () => {
 
       it.each(requiredBillingFields)(
         "clicking on the billing $name error focuses on the input",
-        async ({ name, key, withinGroupName }) => {
+        async ({ name, withinGroupName }) => {
           const user = userEvent.setup();
           renderWithRouter();
           await fillAllInputsExcept(screen, user, minimalSetOfInputFields, new Set());
@@ -266,7 +266,7 @@ describe("<PersonalDetailsStep2 />", () => {
             }),
           );
 
-          const input = await getInputField(screen, { name, key, withinGroupName });
+          const input = await getInputField(screen, { name, withinGroupName });
           expect(input).toHaveFocus();
         },
       );

--- a/src/app/form/(formSteps)/training/1/DoulaTrainingExplainer.tsx
+++ b/src/app/form/(formSteps)/training/1/DoulaTrainingExplainer.tsx
@@ -1,0 +1,45 @@
+import { Accordion } from "@trussworks/react-uswds";
+import type { AccordionItemProps } from "node_modules/@trussworks/react-uswds/lib/components/Accordion/Accordion";
+
+const headingLevel = "h3";
+const doulaExplainerItems: AccordionItemProps[] = [
+  {
+    title: "What if my doula training isn't listed here?",
+    content: (
+      <>
+        <p>
+          You can still enter your training organization, but you might not be eligible at the time.
+        </p>
+        <p>Contact the Doula Guides to learn more: mahs.doulaguide@dhs.nj.gov</p>
+      </>
+    ),
+    expanded: false,
+    id: "whatIfMyDoulaTrainingIsNotListed",
+    headingLevel,
+  },
+  {
+    title: "What are the state-approved doula trainings?",
+    content: (
+      <p>
+        Check the updated list of{" "}
+        <a
+          href="https://www.nj.gov/humanservices/dmahs/info/NJFC_Approved_Doula_Trainings.pdf"
+          target="_blank"
+          rel="noopener"
+        >
+          NJ Family Care doula trainings
+        </a>{" "}
+        on the State of New Jersey Department of Human Services website.
+      </p>
+    ),
+    expanded: false,
+    id: "whatAreTheStateApprovedDoulaTrainings",
+    headingLevel,
+  },
+];
+
+const DoulaTrainingExplainer = () => {
+  return <Accordion bordered={true} items={doulaExplainerItems} />;
+};
+
+export default DoulaTrainingExplainer;

--- a/src/app/form/(formSteps)/training/1/TrainingStep1.test.tsx
+++ b/src/app/form/(formSteps)/training/1/TrainingStep1.test.tsx
@@ -8,6 +8,8 @@ import userEvent from "@testing-library/user-event";
 import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
 const trainingAddressGroupName = "What is the address of your training organization? *";
+const trainingInstructorGroupName =
+  "Training organization point of contact Most doulas use their program instructor's information.";
 const trainingAddressFields: InputField[] = [
   {
     name: "Street address *",
@@ -35,11 +37,72 @@ const trainingAddressFields: InputField[] = [
   },
 ];
 
-const requiredKeys = ["trainingStreetAddress1", "trainingCity", "trainingZip"];
+const trainingInstructorFields: InputField[] = [
+  {
+    name: "First name *",
+    key: "instructorFirstName",
+    testValue: "Jane",
+    withinGroupName: trainingInstructorGroupName,
+  },
+  {
+    name: "Last name *",
+    key: "instructorLastName",
+    testValue: "Doe",
+    withinGroupName: trainingInstructorGroupName,
+  },
+  {
+    name: "Email address *",
+    key: "instructorEmail",
+    testValue: "test@example.com",
+    withinGroupName: trainingInstructorGroupName,
+  },
+  {
+    name: "Phone number *",
+    key: "instructorPhoneNumber",
+    testValue: "111-111-1111",
+    withinGroupName: trainingInstructorGroupName,
+  },
+];
 
-const requiredFields: Array<InputField> = trainingAddressFields.filter((field) =>
+const requiredKeys = [
+  "trainingStreetAddress1",
+  "trainingCity",
+  "trainingZip",
+  "instructorFirstName",
+  "instructorLastName",
+  "instructorEmail",
+  "instructorPhoneNumber",
+];
+
+const requiredTrainingFields: Array<InputField> = trainingAddressFields.filter((field) =>
   requiredKeys.includes(field.key),
 );
+
+const requiredInstructorFields: Array<InputField> = trainingInstructorFields.filter((field) =>
+  requiredKeys.includes(field.key),
+);
+
+const selectTrainingOrganization = async (
+  organization: string = "Children's Home Society of NJ (Trenton)",
+) => {
+  const user = userEvent.setup();
+  const field = {
+    name: "Which state-approved training did you complete? Select one *",
+    role: "combobox" as const,
+    testValue: "Children's Home Society of NJ (Trenton)",
+    key: "stateApprovedTraining",
+  };
+  const input = await getInputField(screen, field);
+  await user.selectOptions(input, organization);
+};
+
+const fillTrainingInstructorFields = async () => {
+  const user = userEvent.setup();
+  for (const field of trainingInstructorFields) {
+    const input = await getInputField(screen, field);
+    await user.type(input, field.testValue!);
+  }
+};
 
 const renderWithRouter = () => {
   const mockPush = jest.fn();
@@ -61,11 +124,56 @@ describe("<TrainingStep1 />", () => {
     window.sessionStorage.clear();
   });
 
+  describe("doula training organization fields", () => {
+    it("conditionally asks the user for the name of their training organization", async () => {
+      const user = userEvent.setup();
+      const alertText =
+        "If your training organization isn't listed, you may not be eligible to apply right now. Contact the Doula Guides at mahs.doulaguide@dhs.nj.gov to learn more.";
+      renderWithRouter();
+      expect(
+        screen.queryByRole("textbox", {
+          name: "What is the name of your training organization? *",
+        }),
+      ).not.toBeInTheDocument();
+      await selectTrainingOrganization("None of these");
+      const input = screen.getByRole("textbox", {
+        name: "What is the name of your training organization? *",
+      });
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAccessibleDescription(alertText);
+      await user.click(screen.getByRole("radio", { name: "No, it was virtual" }));
+      await fillTrainingInstructorFields();
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      expect(input).toHaveFocus();
+      expect(input).toHaveAttribute("aria-invalid", "true");
+      expect(input).toHaveAccessibleDescription(
+        expect.stringContaining("This question is required"),
+      );
+      expect(input).toHaveAccessibleDescription(expect.stringContaining(alertText));
+    });
+
+    it("saves the selected org to sessionStorage", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      await selectTrainingOrganization("None of these");
+      const input = screen.getByRole("textbox", {
+        name: "What is the name of your training organization? *",
+      });
+      await user.type(input, "Test org name");
+      await user.click(screen.getByRole("radio", { name: "No, it was virtual" }));
+      await fillTrainingInstructorFields();
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      expect(sessionStorage.getItem("stateApprovedTraining")).toBe("None of these");
+      expect(sessionStorage.getItem("nameOfTrainingOrganization")).toBe("Test org name");
+    });
+  });
+
   describe("doula training address fields", () => {
     it("conditionally renders training address fields based on isDoulaTrainingInPerson", async () => {
       const user = userEvent.setup();
       renderWithRouter();
 
+      await selectTrainingOrganization();
       expect(
         screen.queryByRole("group", { name: trainingAddressGroupName }),
       ).not.toBeInTheDocument();
@@ -95,6 +203,8 @@ describe("<TrainingStep1 />", () => {
       const user = userEvent.setup();
       renderWithRouter();
 
+      await selectTrainingOrganization();
+      await fillTrainingInstructorFields();
       await user.click(screen.getByRole("button", { name: "Next" }));
 
       const inputYes = screen.getByRole("radio", { name: "Yes, in person or hybrid" });
@@ -110,7 +220,7 @@ describe("<TrainingStep1 />", () => {
       );
     });
 
-    it.each(requiredFields)(
+    it.each(requiredTrainingFields)(
       "clicking on the $name error focuses on the input",
       async ({ name }) => {
         const labelWithoutAsterisk = name.replace(" *", "");
@@ -131,6 +241,42 @@ describe("<TrainingStep1 />", () => {
         expect(input).toHaveFocus();
       },
     );
+  });
+
+  describe("doula training instructor fields", () => {
+    it.each(requiredInstructorFields)(
+      "clicking on the $name error focuses on the input",
+      async ({ name }) => {
+        const labelWithoutAsterisk = name.replace(" *", "");
+        const user = userEvent.setup();
+        renderWithRouter();
+
+        await user.click(screen.getByRole("radio", { name: "Yes, in person or hybrid" }));
+        await user.click(screen.getByRole("button", { name: "Next" }));
+        await user.click(
+          screen.getByRole("link", {
+            name: `${labelWithoutAsterisk} is required`,
+          }),
+        );
+
+        const input = screen.getByRole("textbox", {
+          name: `${labelWithoutAsterisk} *`,
+        });
+        expect(input).toHaveFocus();
+      },
+    );
+
+    it("saves values to session storage when user clicks Next", async () => {
+      const user = userEvent.setup();
+      renderWithRouter();
+      await selectTrainingOrganization();
+      await user.click(screen.getByRole("radio", { name: "No, it was virtual" }));
+      await fillTrainingInstructorFields();
+      await user.click(screen.getByRole("button", { name: "Next" }));
+      for (const field of trainingInstructorFields) {
+        expect(sessionStorage.getItem(field.key)).toBe(field.testValue);
+      }
+    });
   });
 
   it("displays an error summary if there are 3 or more errors", async () => {
@@ -157,19 +303,40 @@ describe("<TrainingStep1 />", () => {
   });
 
   it("fills fields from sessionStorage", async () => {
+    window.sessionStorage.setItem("stateApprovedTraining", "None of these");
+    window.sessionStorage.setItem("nameOfTrainingOrganization", "Test training org");
     window.sessionStorage.setItem("trainingStreetAddress1", "123 Main St");
     window.sessionStorage.setItem("trainingStreetAddress2", "Apt 4B");
     window.sessionStorage.setItem("trainingCity", "Newark");
     window.sessionStorage.setItem("trainingState", "NJ");
     window.sessionStorage.setItem("trainingZip", "12345");
     window.sessionStorage.setItem("isDoulaTrainingInPerson", "true");
+    window.sessionStorage.setItem("instructorFirstName", "First");
+    window.sessionStorage.setItem("instructorLastName", "Last");
+    window.sessionStorage.setItem("instructorEmail", "email@test.com");
+    window.sessionStorage.setItem("instructorPhoneNumber", "111-111-1111");
+
     renderWithRouter();
 
+    expect(
+      screen.getByRole("combobox", {
+        name: "Which state-approved training did you complete? Select one *",
+      }),
+    ).toHaveValue("None of these");
+    expect(
+      screen.getByRole("textbox", {
+        name: "What is the name of your training organization? *",
+      }),
+    ).toHaveValue("Test training org");
     expect(screen.getByRole("radio", { name: "Yes, in person or hybrid" })).toBeChecked();
     expect(screen.getByRole("textbox", { name: "Street address *" })).toHaveValue("123 Main St");
     expect(screen.getByRole("textbox", { name: "Street address line 2" })).toHaveValue("Apt 4B");
     expect(screen.getByRole("textbox", { name: "City *" })).toHaveValue("Newark");
     expect(screen.getByRole("combobox", { name: "State *" })).toHaveValue("NJ");
     expect(screen.getByRole("textbox", { name: "ZIP code *" })).toHaveValue("12345");
+    expect(screen.getByRole("textbox", { name: "First name *" })).toHaveValue("First");
+    expect(screen.getByRole("textbox", { name: "Last name *" })).toHaveValue("Last");
+    expect(screen.getByRole("textbox", { name: "Email address *" })).toHaveValue("email@test.com");
+    expect(screen.getByRole("textbox", { name: "Phone number *" })).toHaveValue("111-111-1111");
   });
 });

--- a/src/app/form/(formSteps)/training/1/TrainingStep1.test.tsx
+++ b/src/app/form/(formSteps)/training/1/TrainingStep1.test.tsx
@@ -8,8 +8,6 @@ import userEvent from "@testing-library/user-event";
 import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
 const trainingAddressGroupName = "What is the address of your training organization? *";
-const trainingInstructorGroupName =
-  "Training organization point of contact Most doulas use their program instructor's information.";
 const trainingAddressFields: InputField[] = [
   {
     name: "Street address *",
@@ -42,25 +40,21 @@ const trainingInstructorFields: InputField[] = [
     name: "First name *",
     key: "instructorFirstName",
     testValue: "Jane",
-    withinGroupName: trainingInstructorGroupName,
   },
   {
     name: "Last name *",
     key: "instructorLastName",
     testValue: "Doe",
-    withinGroupName: trainingInstructorGroupName,
   },
   {
     name: "Email address *",
     key: "instructorEmail",
     testValue: "test@example.com",
-    withinGroupName: trainingInstructorGroupName,
   },
   {
-    name: "Phone number *",
+    name: "Phone number",
     key: "instructorPhoneNumber",
     testValue: "111-111-1111",
-    withinGroupName: trainingInstructorGroupName,
   },
 ];
 
@@ -71,7 +65,6 @@ const requiredKeys = [
   "instructorFirstName",
   "instructorLastName",
   "instructorEmail",
-  "instructorPhoneNumber",
 ];
 
 const requiredTrainingFields: Array<InputField> = trainingAddressFields.filter((field) =>
@@ -89,8 +82,6 @@ const selectTrainingOrganization = async (
   const field = {
     name: "Which state-approved training did you complete? Select one *",
     role: "combobox" as const,
-    testValue: "Children's Home Society of NJ (Trenton)",
-    key: "stateApprovedTraining",
   };
   const input = await getInputField(screen, field);
   await user.selectOptions(input, organization);
@@ -125,7 +116,7 @@ describe("<TrainingStep1 />", () => {
   });
 
   describe("doula training organization fields", () => {
-    it("conditionally asks the user for the name of their training organization", async () => {
+    it("asks the user for the name of their training organization if 'None of these' is selected", async () => {
       const user = userEvent.setup();
       const alertText =
         "If your training organization isn't listed, you may not be eligible to apply right now. Contact the Doula Guides at mahs.doulaguide@dhs.nj.gov to learn more.";
@@ -337,6 +328,6 @@ describe("<TrainingStep1 />", () => {
     expect(screen.getByRole("textbox", { name: "First name *" })).toHaveValue("First");
     expect(screen.getByRole("textbox", { name: "Last name *" })).toHaveValue("Last");
     expect(screen.getByRole("textbox", { name: "Email address *" })).toHaveValue("email@test.com");
-    expect(screen.getByRole("textbox", { name: "Phone number *" })).toHaveValue("111-111-1111");
+    expect(screen.getByRole("textbox", { name: "Phone number" })).toHaveValue("111-111-1111");
   });
 });

--- a/src/app/form/(formSteps)/training/1/page.tsx
+++ b/src/app/form/(formSteps)/training/1/page.tsx
@@ -188,6 +188,7 @@ const TrainingStep1 = () => {
                   </Alert>
                 </div>
               )}
+              <hr className="margin-top-5" />
             </div>
             <div className="form-explainer">
               <DoulaTrainingExplainer />
@@ -199,7 +200,7 @@ const TrainingStep1 = () => {
                 <Fieldset
                   legend={
                     <div>
-                      <p className="font-ui-xs text-normal">
+                      <p className="font-ui-xs text-normal margin-top-4">
                         {orderedInputNameToLabel["isDoulaTrainingInPerson"]}
                       </p>
                       <p className="font-ui-xs text-normal">
@@ -372,130 +373,124 @@ const TrainingStep1 = () => {
                   </Fieldset>
                 )}
               </div>
+              <hr className="margin-top-5" />
+
               <div>
-                <Fieldset
-                  legend={
-                    <div>
-                      <h2 className="font-heading-md margin-top-5">
-                        Training organization point of contact
-                      </h2>
-                      <p className="usa-hint">
-                        Most doulas use their program instructor&apos;s information.
-                      </p>
-                    </div>
-                  }
-                >
-                  <div className="grid-row grid-gap">
-                    <div className="tablet:grid-col-6">
-                      <Label htmlFor="instructorFirstName" requiredMarker>
-                        {orderedInputNameToLabel["instructorFirstName"]}
-                      </Label>
-                      <TextInput
-                        id="instructorFirstName"
-                        type="text"
-                        required
-                        validationStatus={errors.instructorFirstName ? "error" : undefined}
-                        aria-invalid={errors.instructorFirstName ? "true" : "false"}
-                        aria-describedby={
-                          errors.instructorFirstName && "instructorFirstNameErrorMessage"
-                        }
-                        {...register("instructorFirstName", {
-                          required: `${orderedInputNameToLabel["instructorFirstName"]} is required`,
-                        })}
-                      />
-                      {errors.instructorFirstName && (
-                        <span id="instructorFirstNameErrorMessage" className="usa-error-message">
-                          {errors.instructorFirstName.message}
-                        </span>
-                      )}
-                    </div>
-                    <div className="tablet:grid-col-6">
-                      <Label htmlFor="instructorLastName" requiredMarker>
-                        {orderedInputNameToLabel["instructorLastName"]}
-                      </Label>
-                      <TextInput
-                        id="instructorLastName"
-                        type="text"
-                        required
-                        validationStatus={errors.instructorLastName ? "error" : undefined}
-                        aria-invalid={errors.instructorLastName ? "true" : "false"}
-                        aria-describedby={
-                          errors.instructorLastName && "instructorLastNameErrorMessage"
-                        }
-                        {...register("instructorLastName", {
-                          required: `${orderedInputNameToLabel["instructorLastName"]} is required`,
-                        })}
-                      />
-                      {errors.instructorLastName && (
-                        <span id="instructorLastNameErrorMessage" className="usa-error-message">
-                          {errors.instructorLastName.message}
-                        </span>
-                      )}
-                    </div>
+                <h2 className="font-heading-md margin-top-5">
+                  Training organization point of contact
+                </h2>
+                <p className="usa-hint">
+                  Most doulas use their program instructor&apos;s information.
+                </p>
+
+                <div className="grid-row grid-gap">
+                  <div className="tablet:grid-col-6">
+                    <Label htmlFor="instructorFirstName" requiredMarker>
+                      {orderedInputNameToLabel["instructorFirstName"]}
+                    </Label>
+                    <TextInput
+                      id="instructorFirstName"
+                      type="text"
+                      required
+                      validationStatus={errors.instructorFirstName ? "error" : undefined}
+                      aria-invalid={errors.instructorFirstName ? "true" : "false"}
+                      aria-describedby={
+                        errors.instructorFirstName && "instructorFirstNameErrorMessage"
+                      }
+                      {...register("instructorFirstName", {
+                        required: `${orderedInputNameToLabel["instructorFirstName"]} is required`,
+                      })}
+                    />
+                    {errors.instructorFirstName && (
+                      <span id="instructorFirstNameErrorMessage" className="usa-error-message">
+                        {errors.instructorFirstName.message}
+                      </span>
+                    )}
                   </div>
-                  <div className="grid-row grid-gap">
-                    <div className="tablet:grid-col-6">
-                      <Label htmlFor="instructorEmail" requiredMarker>
-                        {orderedInputNameToLabel["instructorEmail"]}
-                      </Label>
-                      <TextInput
-                        id="instructorEmail"
-                        autoCorrect="off"
-                        autoCapitalize="off"
-                        required
-                        validationStatus={errors.instructorEmail ? "error" : undefined}
-                        aria-invalid={errors.instructorEmail ? "true" : "false"}
-                        aria-describedby={errors.instructorEmail && "instructorEmailErrorMessage"}
-                        {...register("instructorEmail", {
-                          required: `${orderedInputNameToLabel["instructorEmail"]} is required`,
-                          pattern: {
-                            value: /\S+@\S+\.\S+/,
-                            message: "Entered value does not match email format",
-                          },
-                        })}
-                        type="email"
-                      />
-                      {errors.instructorEmail && (
-                        <span id="instructorEmailErrorMessage" className="usa-error-message">
-                          {errors.instructorEmail.message}
-                        </span>
-                      )}
-                    </div>
+                  <div className="tablet:grid-col-6">
+                    <Label htmlFor="instructorLastName" requiredMarker>
+                      {orderedInputNameToLabel["instructorLastName"]}
+                    </Label>
+                    <TextInput
+                      id="instructorLastName"
+                      type="text"
+                      required
+                      validationStatus={errors.instructorLastName ? "error" : undefined}
+                      aria-invalid={errors.instructorLastName ? "true" : "false"}
+                      aria-describedby={
+                        errors.instructorLastName && "instructorLastNameErrorMessage"
+                      }
+                      {...register("instructorLastName", {
+                        required: `${orderedInputNameToLabel["instructorLastName"]} is required`,
+                      })}
+                    />
+                    {errors.instructorLastName && (
+                      <span id="instructorLastNameErrorMessage" className="usa-error-message">
+                        {errors.instructorLastName.message}
+                      </span>
+                    )}
                   </div>
-                  <div className="grid-row grid-gap">
-                    <div className="tablet:grid-col-6">
-                      <Label htmlFor="instructorPhoneNumber" requiredMarker>
-                        {orderedInputNameToLabel["instructorPhoneNumber"]}
-                      </Label>
-                      <TextInputMask
-                        id="instructorPhoneNumber"
-                        type="tel"
-                        value={instructorPhoneNumber ?? ""}
-                        inputMode="numeric"
-                        mask="___-___-____"
-                        pattern="\d{3}-\d{3}-\d{4}"
-                        required
-                        validationStatus={errors.instructorPhoneNumber ? "error" : undefined}
-                        aria-invalid={errors.instructorPhoneNumber ? "true" : "false"}
-                        aria-describedby={
-                          errors.instructorPhoneNumber && "instructorPhoneNumberErrorMessage"
-                        }
-                        {...register("instructorPhoneNumber", {
-                          required: `${orderedInputNameToLabel["instructorPhoneNumber"]} is required`,
-                          pattern: {
-                            value: /\d{3}-\d{3}-\d{4}/,
-                            message: "Entered value does not match phone number format",
-                          },
-                        })}
-                      />
-                      {errors.instructorPhoneNumber && (
-                        <span id="instructorPhoneNumberErrorMessage" className="usa-error-message">
-                          {errors.instructorPhoneNumber.message}
-                        </span>
-                      )}
-                    </div>
+                </div>
+                <div className="grid-row grid-gap">
+                  <div className="tablet:grid-col-6">
+                    <Label htmlFor="instructorEmail" requiredMarker>
+                      {orderedInputNameToLabel["instructorEmail"]}
+                    </Label>
+                    <TextInput
+                      id="instructorEmail"
+                      autoCorrect="off"
+                      autoCapitalize="off"
+                      required
+                      validationStatus={errors.instructorEmail ? "error" : undefined}
+                      aria-invalid={errors.instructorEmail ? "true" : "false"}
+                      aria-describedby={errors.instructorEmail && "instructorEmailErrorMessage"}
+                      {...register("instructorEmail", {
+                        required: `${orderedInputNameToLabel["instructorEmail"]} is required`,
+                        pattern: {
+                          value: /\S+@\S+\.\S+/,
+                          message: "Entered value does not match email format",
+                        },
+                      })}
+                      type="email"
+                    />
+                    {errors.instructorEmail && (
+                      <span id="instructorEmailErrorMessage" className="usa-error-message">
+                        {errors.instructorEmail.message}
+                      </span>
+                    )}
                   </div>
-                </Fieldset>
+                </div>
+                <div className="grid-row grid-gap">
+                  <div className="tablet:grid-col-6">
+                    <Label htmlFor="instructorPhoneNumber">
+                      {orderedInputNameToLabel["instructorPhoneNumber"]}
+                    </Label>
+                    <TextInputMask
+                      id="instructorPhoneNumber"
+                      type="tel"
+                      value={instructorPhoneNumber ?? ""}
+                      inputMode="numeric"
+                      mask="___-___-____"
+                      pattern="\d{3}-\d{3}-\d{4}"
+                      validationStatus={errors.instructorPhoneNumber ? "error" : undefined}
+                      aria-invalid={errors.instructorPhoneNumber ? "true" : "false"}
+                      aria-describedby={
+                        errors.instructorPhoneNumber && "instructorPhoneNumberErrorMessage"
+                      }
+                      {...register("instructorPhoneNumber", {
+                        pattern: {
+                          value: /\d{3}-\d{3}-\d{4}/,
+                          message: "Entered value does not match phone number format",
+                        },
+                      })}
+                    />
+                    {errors.instructorPhoneNumber && (
+                      <span id="instructorPhoneNumberErrorMessage" className="usa-error-message">
+                        {errors.instructorPhoneNumber.message}
+                      </span>
+                    )}
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/form/(formSteps)/training/1/page.tsx
+++ b/src/app/form/(formSteps)/training/1/page.tsx
@@ -7,6 +7,7 @@ import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgr
 import { AddressState } from "@form/_utils/inputFields/enums";
 import { getDefaultValue, setKeyValue } from "@form/_utils/sessionStorage";
 import {
+  Alert,
   Fieldset,
   Form,
   Label,
@@ -19,14 +20,21 @@ import {
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { type SubmitErrorHandler, type SubmitHandler, useForm } from "react-hook-form";
+import DoulaTrainingExplainer from "./DoulaTrainingExplainer";
 
 const orderedInputNameToLabel: { [key in keyof TrainingData]: string } = {
+  stateApprovedTraining: "Which state-approved training did you complete?",
+  nameOfTrainingOrganization: "What is the name of your training organization?",
   trainingStreetAddress1: "Street address",
   trainingStreetAddress2: "Street address line 2",
   trainingCity: "City",
   trainingState: "State",
   trainingZip: "ZIP code",
   isDoulaTrainingInPerson: "Did you attend your doula training classes in person?",
+  instructorFirstName: "First name",
+  instructorLastName: "Last name",
+  instructorEmail: "Email address",
+  instructorPhoneNumber: "Phone number",
 };
 
 const TrainingStep1 = () => {
@@ -40,16 +48,24 @@ const TrainingStep1 = () => {
     watch,
   } = useForm<TrainingData>({
     defaultValues: {
+      stateApprovedTraining: getDefaultValue("stateApprovedTraining") || "",
+      nameOfTrainingOrganization: getDefaultValue("nameOfTrainingOrganization") || "",
       trainingStreetAddress1: getDefaultValue("trainingStreetAddress1") || "",
       trainingStreetAddress2: getDefaultValue("trainingStreetAddress2") || "",
       trainingCity: getDefaultValue("trainingCity") || "",
       trainingState: getDefaultValue("trainingState") || "NJ",
       trainingZip: getDefaultValue("trainingZip") || "",
       isDoulaTrainingInPerson: getDefaultValue("isDoulaTrainingInPerson") || "",
+      instructorFirstName: getDefaultValue("instructorFirstName") || "",
+      instructorLastName: getDefaultValue("instructorLastName") || "",
+      instructorEmail: getDefaultValue("instructorEmail") || "",
+      instructorPhoneNumber: getDefaultValue("instructorPhoneNumber") || "",
     },
     shouldFocusError: false,
   });
+  const stateApprovedTraining = watch("stateApprovedTraining");
   const trainingZip = watch("trainingZip");
+  const instructorPhoneNumber = watch("instructorPhoneNumber");
   const isDoulaTrainingInPerson = watch("isDoulaTrainingInPerson");
   const [shouldSummarizeErrors, setShouldSummarizeErrors] = useState(false);
   const [dataHasLoaded, setDataHasLoaded] = useState<boolean>(false);
@@ -87,186 +103,402 @@ const TrainingStep1 = () => {
     <div>
       {dataHasLoaded && (
         <Form onSubmit={handleSubmit(onSubmit, onError)} className="maxw-full" noValidate>
-          <ErrorSummary<TrainingData>
-            shouldSummarizeErrors={shouldSummarizeErrors}
-            errors={errors}
-            ref={errorSummaryRef}
-            setFocus={setFocus}
-          />
-
-          <h2 className="font-heading-md">Training organization address</h2>
-          <p className="usa-hint">This is where you completed your doula training.</p>
-          <Fieldset
-            legend={
-              <div>
+          <div className="form-grid">
+            <div>
+              <ErrorSummary<TrainingData>
+                shouldSummarizeErrors={shouldSummarizeErrors}
+                errors={errors}
+                ref={errorSummaryRef}
+                setFocus={setFocus}
+              />
+              <h2 className="font-heading-md margin-top-0">Doula training organization</h2>
+              <Label htmlFor="stateApprovedTraining">
                 <p className="font-ui-xs text-normal">
-                  {orderedInputNameToLabel["isDoulaTrainingInPerson"]}
+                  {orderedInputNameToLabel["stateApprovedTraining"]}
                 </p>
                 <p className="font-ui-xs text-normal">
                   Select one <RequiredMarker />
                 </p>
-              </div>
-            }
-          >
-            <Radio
-              id="isDoulaTrainingInPersonYes"
-              label="Yes, in person or hybrid"
-              value="true"
-              checked={isDoulaTrainingInPerson === "true"}
-              required
-              {...register("isDoulaTrainingInPerson", {
-                required: `This question is required`,
-              })}
-              aria-invalid={errors.isDoulaTrainingInPerson ? "true" : "false"}
-              aria-describedby={
-                errors.isDoulaTrainingInPerson && "isDoulaTrainingInPersonErrorMessage"
-              }
-            />
-            <Radio
-              id="isDoulaTrainingInPersonNo"
-              label="No, it was virtual"
-              value="false"
-              checked={isDoulaTrainingInPerson === "false"}
-              required
-              {...register("isDoulaTrainingInPerson", {
-                required: `This question is required`,
-              })}
-              aria-invalid={errors.isDoulaTrainingInPerson ? "true" : "false"}
-              aria-describedby={
-                errors.isDoulaTrainingInPerson && "isDoulaTrainingInPersonErrorMessage"
-              }
-            />
-            {errors.isDoulaTrainingInPerson && (
-              <span
-                id="isDoulaTrainingInPersonErrorMessage"
-                className="usa-error-message"
-                role="alert"
+              </Label>
+              <Select
+                className="tablet:grid-col-6"
+                id="stateApprovedTraining"
+                required
+                validationStatus={errors.stateApprovedTraining ? "error" : undefined}
+                aria-invalid={errors.stateApprovedTraining ? "true" : "false"}
+                aria-describedby={
+                  errors.stateApprovedTraining && "stateApprovedTrainingErrorMessage"
+                }
+                {...register("stateApprovedTraining", {
+                  required: `This question is required`,
+                })}
               >
-                {errors.isDoulaTrainingInPerson.message}
-              </span>
-            )}
-          </Fieldset>
-
-          {isDoulaTrainingInPerson === "true" && (
-            <Fieldset
-              legend={
-                <p className="font-ui-xs text-normal margin-top-5">
-                  What is the address of your training organization? <RequiredMarker />
-                </p>
-              }
-            >
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="trainingStreetAddress1" requiredMarker>
-                    {orderedInputNameToLabel["trainingStreetAddress1"]}
+                <option value="Children's Home Society of NJ (Trenton)">
+                  Children&apos;s Home Society of NJ (Trenton)
+                </option>
+                <option value="Children's Futures (Trenton)">
+                  Children&apos;s Futures (Trenton)
+                </option>
+                <option value="Sister to Sister Community Doulas of Essex County (NJDLC)">
+                  Sister to Sister Community Doulas of Essex County (Newark)
+                </option>
+                <option value="New Jersey Doula Learning Collaborative (NJDLC)">
+                  New Jersey Doula Learning Collaborative (NJDLC)
+                </option>
+                <option
+                  value="The Partnership for Maternal and Child Health of Northern New Jersey (Paterson,
+                    Newark)"
+                >
+                  The Partnership for Maternal and Child Health of Northern New Jersey (Paterson,
+                  Newark)
+                </option>
+                <option value="None of these">None of these</option>
+              </Select>
+              {stateApprovedTraining === "None of these" && (
+                <div>
+                  <Label htmlFor="nameOfTrainingOrganization" requiredMarker>
+                    {orderedInputNameToLabel["nameOfTrainingOrganization"]}
                   </Label>
                   <TextInput
-                    id="trainingStreetAddress1"
+                    className="tablet:grid-col-6"
+                    id="nameOfTrainingOrganization"
                     type="text"
                     required
-                    validationStatus={errors.trainingStreetAddress1 ? "error" : undefined}
-                    aria-invalid={errors.trainingStreetAddress1 ? "true" : "false"}
-                    aria-describedby={
-                      errors.trainingStreetAddress1 && "trainingStreetAddress1ErrorMessage"
-                    }
-                    {...register("trainingStreetAddress1", {
-                      required: `Training ${orderedInputNameToLabel["trainingStreetAddress1"].toLowerCase()} is required`,
+                    validationStatus={errors.nameOfTrainingOrganization ? "error" : undefined}
+                    aria-invalid={errors.nameOfTrainingOrganization ? "true" : "false"}
+                    aria-describedby={`${errors.nameOfTrainingOrganization ? "nameOfTrainingOrganizationErrorMessage" : ""} nameOfTrainingOrganizationAlert`}
+                    {...register("nameOfTrainingOrganization", {
+                      required: `This question is required`,
                     })}
                   />
-                  {errors.trainingStreetAddress1 && (
+                  {errors.nameOfTrainingOrganization && (
                     <span
-                      id="trainingStreetAddress1ErrorMessage"
+                      id="nameOfTrainingOrganizationErrorMessage"
                       className="usa-error-message"
                       role="alert"
                     >
-                      {errors.trainingStreetAddress1.message}
+                      {errors.nameOfTrainingOrganization.message}
                     </span>
                   )}
+
+                  <Alert id="nameOfTrainingOrganizationAlert" type="info" headingLevel="h3" noIcon>
+                    If your training organization isn&apos;t listed, you may not be eligible to
+                    apply right now. Contact the Doula Guides at mahs.doulaguide@dhs.nj.gov to learn
+                    more.
+                  </Alert>
                 </div>
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="trainingStreetAddress2">
-                    {orderedInputNameToLabel["trainingStreetAddress2"]}
-                  </Label>
-                  <TextInput
-                    id="trainingStreetAddress2"
-                    type="text"
-                    {...register("trainingStreetAddress2")}
-                  />
-                </div>
-              </div>
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="trainingCity" requiredMarker>
-                    {orderedInputNameToLabel["trainingCity"]}
-                  </Label>
-                  <TextInput
-                    id="trainingCity"
-                    type="text"
+              )}
+            </div>
+            <div className="form-explainer">
+              <DoulaTrainingExplainer />
+            </div>
+            <div>
+              <div>
+                <h2 className="font-heading-md">Training organization address</h2>
+                <p className="usa-hint">This is where you completed your doula training.</p>
+                <Fieldset
+                  legend={
+                    <div>
+                      <p className="font-ui-xs text-normal">
+                        {orderedInputNameToLabel["isDoulaTrainingInPerson"]}
+                      </p>
+                      <p className="font-ui-xs text-normal">
+                        Select one <RequiredMarker />
+                      </p>
+                    </div>
+                  }
+                >
+                  <Radio
+                    id="isDoulaTrainingInPersonYes"
+                    label="Yes, in person or hybrid"
+                    value="true"
+                    checked={isDoulaTrainingInPerson === "true"}
                     required
-                    validationStatus={errors.trainingCity ? "error" : undefined}
-                    aria-invalid={errors.trainingCity ? "true" : "false"}
-                    aria-describedby={errors.trainingCity && "trainingCityErrorMessage"}
-                    {...register("trainingCity", {
-                      required: `Training ${orderedInputNameToLabel["trainingCity"].toLowerCase()} is required`,
+                    {...register("isDoulaTrainingInPerson", {
+                      required: `This question is required`,
                     })}
+                    aria-invalid={errors.isDoulaTrainingInPerson ? "true" : "false"}
+                    aria-describedby={
+                      errors.isDoulaTrainingInPerson && "isDoulaTrainingInPersonErrorMessage"
+                    }
                   />
-                  {errors.trainingCity && (
-                    <span id="trainingCityErrorMessage" className="usa-error-message" role="alert">
-                      {errors.trainingCity.message}
+                  <Radio
+                    id="isDoulaTrainingInPersonNo"
+                    label="No, it was virtual"
+                    value="false"
+                    checked={isDoulaTrainingInPerson === "false"}
+                    required
+                    {...register("isDoulaTrainingInPerson", {
+                      required: `This question is required`,
+                    })}
+                    aria-invalid={errors.isDoulaTrainingInPerson ? "true" : "false"}
+                    aria-describedby={
+                      errors.isDoulaTrainingInPerson && "isDoulaTrainingInPersonErrorMessage"
+                    }
+                  />
+                  {errors.isDoulaTrainingInPerson && (
+                    <span
+                      id="isDoulaTrainingInPersonErrorMessage"
+                      className="usa-error-message"
+                      role="alert"
+                    >
+                      {errors.isDoulaTrainingInPerson.message}
                     </span>
                   )}
-                </div>
-              </div>
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="trainingState" requiredMarker>
-                    {orderedInputNameToLabel["trainingState"]}
-                  </Label>
-                  <Select
-                    className="usa-select"
-                    id="trainingState"
-                    required
-                    {...register("trainingState")}
+                </Fieldset>
+
+                {isDoulaTrainingInPerson === "true" && (
+                  <Fieldset
+                    legend={
+                      <p className="font-ui-xs text-normal margin-top-3">
+                        What is the address of your training organization? <RequiredMarker />
+                      </p>
+                    }
                   >
-                    {Object.keys(AddressState).map((trainingState) => (
-                      <option key={trainingState} value={trainingState}>
-                        {trainingState}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-                <div className="mobile-lg:grid-col-4">
-                  <Label htmlFor="trainingZip" requiredMarker>
-                    {orderedInputNameToLabel["trainingZip"]}
-                  </Label>
-                  <TextInputMask
-                    className="usa-input--medium"
-                    id="trainingZip"
-                    type="text"
-                    value={trainingZip ?? ""}
-                    mask="#####"
-                    pattern="\d{5}"
-                    required
-                    validationStatus={errors.trainingZip ? "error" : undefined}
-                    aria-invalid={errors.trainingZip ? "true" : "false"}
-                    aria-describedby={errors.trainingZip && "trainingZipErrorMessage"}
-                    {...register("trainingZip", {
-                      required: `Training ${orderedInputNameToLabel["trainingZip"].toLowerCase()} is required`,
-                      minLength: {
-                        value: 5,
-                        message: `Training ${orderedInputNameToLabel["trainingZip"].toLowerCase()} must have five digits`,
-                      },
-                    })}
-                  />
-                  {errors.trainingZip && (
-                    <span id="trainingZipErrorMessage" className="usa-error-message">
-                      {errors.trainingZip.message}
-                    </span>
-                  )}
-                </div>
+                    <div className="grid-row grid-gap">
+                      <div className="mobile-lg:grid-col-6">
+                        <Label htmlFor="trainingStreetAddress1" requiredMarker>
+                          {orderedInputNameToLabel["trainingStreetAddress1"]}
+                        </Label>
+                        <TextInput
+                          id="trainingStreetAddress1"
+                          type="text"
+                          required
+                          validationStatus={errors.trainingStreetAddress1 ? "error" : undefined}
+                          aria-invalid={errors.trainingStreetAddress1 ? "true" : "false"}
+                          aria-describedby={
+                            errors.trainingStreetAddress1 && "trainingStreetAddress1ErrorMessage"
+                          }
+                          {...register("trainingStreetAddress1", {
+                            required: `Training ${orderedInputNameToLabel["trainingStreetAddress1"].toLowerCase()} is required`,
+                          })}
+                        />
+                        {errors.trainingStreetAddress1 && (
+                          <span
+                            id="trainingStreetAddress1ErrorMessage"
+                            className="usa-error-message"
+                            role="alert"
+                          >
+                            {errors.trainingStreetAddress1.message}
+                          </span>
+                        )}
+                      </div>
+                      <div className="mobile-lg:grid-col-6">
+                        <Label htmlFor="trainingStreetAddress2">
+                          {orderedInputNameToLabel["trainingStreetAddress2"]}
+                        </Label>
+                        <TextInput
+                          id="trainingStreetAddress2"
+                          type="text"
+                          {...register("trainingStreetAddress2")}
+                        />
+                      </div>
+                    </div>
+                    <div className="grid-row grid-gap">
+                      <div className="mobile-lg:grid-col-6">
+                        <Label htmlFor="trainingCity" requiredMarker>
+                          {orderedInputNameToLabel["trainingCity"]}
+                        </Label>
+                        <TextInput
+                          id="trainingCity"
+                          type="text"
+                          required
+                          validationStatus={errors.trainingCity ? "error" : undefined}
+                          aria-invalid={errors.trainingCity ? "true" : "false"}
+                          aria-describedby={errors.trainingCity && "trainingCityErrorMessage"}
+                          {...register("trainingCity", {
+                            required: `Training ${orderedInputNameToLabel["trainingCity"].toLowerCase()} is required`,
+                          })}
+                        />
+                        {errors.trainingCity && (
+                          <span
+                            id="trainingCityErrorMessage"
+                            className="usa-error-message"
+                            role="alert"
+                          >
+                            {errors.trainingCity.message}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="grid-row grid-gap">
+                      <div className="mobile-lg:grid-col-6">
+                        <Label htmlFor="trainingState" requiredMarker>
+                          {orderedInputNameToLabel["trainingState"]}
+                        </Label>
+                        <Select
+                          className="usa-select"
+                          id="trainingState"
+                          required
+                          {...register("trainingState")}
+                        >
+                          {Object.keys(AddressState).map((trainingState) => (
+                            <option key={trainingState} value={trainingState}>
+                              {trainingState}
+                            </option>
+                          ))}
+                        </Select>
+                      </div>
+                      <div className="mobile-lg:grid-col-4">
+                        <Label htmlFor="trainingZip" requiredMarker>
+                          {orderedInputNameToLabel["trainingZip"]}
+                        </Label>
+                        <TextInputMask
+                          className="usa-input--medium"
+                          id="trainingZip"
+                          type="text"
+                          value={trainingZip ?? ""}
+                          mask="#####"
+                          pattern="\d{5}"
+                          required
+                          validationStatus={errors.trainingZip ? "error" : undefined}
+                          aria-invalid={errors.trainingZip ? "true" : "false"}
+                          aria-describedby={errors.trainingZip && "trainingZipErrorMessage"}
+                          {...register("trainingZip", {
+                            required: `Training ${orderedInputNameToLabel["trainingZip"].toLowerCase()} is required`,
+                            minLength: {
+                              value: 5,
+                              message: `Training ${orderedInputNameToLabel["trainingZip"].toLowerCase()} must have five digits`,
+                            },
+                          })}
+                        />
+                        {errors.trainingZip && (
+                          <span id="trainingZipErrorMessage" className="usa-error-message">
+                            {errors.trainingZip.message}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </Fieldset>
+                )}
               </div>
-            </Fieldset>
-          )}
+              <div>
+                <Fieldset
+                  legend={
+                    <div>
+                      <h2 className="font-heading-md margin-top-5">
+                        Training organization point of contact
+                      </h2>
+                      <p className="usa-hint">
+                        Most doulas use their program instructor&apos;s information.
+                      </p>
+                    </div>
+                  }
+                >
+                  <div className="grid-row grid-gap">
+                    <div className="tablet:grid-col-6">
+                      <Label htmlFor="instructorFirstName" requiredMarker>
+                        {orderedInputNameToLabel["instructorFirstName"]}
+                      </Label>
+                      <TextInput
+                        id="instructorFirstName"
+                        type="text"
+                        required
+                        validationStatus={errors.instructorFirstName ? "error" : undefined}
+                        aria-invalid={errors.instructorFirstName ? "true" : "false"}
+                        aria-describedby={
+                          errors.instructorFirstName && "instructorFirstNameErrorMessage"
+                        }
+                        {...register("instructorFirstName", {
+                          required: `${orderedInputNameToLabel["instructorFirstName"]} is required`,
+                        })}
+                      />
+                      {errors.instructorFirstName && (
+                        <span id="instructorFirstNameErrorMessage" className="usa-error-message">
+                          {errors.instructorFirstName.message}
+                        </span>
+                      )}
+                    </div>
+                    <div className="tablet:grid-col-6">
+                      <Label htmlFor="instructorLastName" requiredMarker>
+                        {orderedInputNameToLabel["instructorLastName"]}
+                      </Label>
+                      <TextInput
+                        id="instructorLastName"
+                        type="text"
+                        required
+                        validationStatus={errors.instructorLastName ? "error" : undefined}
+                        aria-invalid={errors.instructorLastName ? "true" : "false"}
+                        aria-describedby={
+                          errors.instructorLastName && "instructorLastNameErrorMessage"
+                        }
+                        {...register("instructorLastName", {
+                          required: `${orderedInputNameToLabel["instructorLastName"]} is required`,
+                        })}
+                      />
+                      {errors.instructorLastName && (
+                        <span id="instructorLastNameErrorMessage" className="usa-error-message">
+                          {errors.instructorLastName.message}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="grid-row grid-gap">
+                    <div className="tablet:grid-col-6">
+                      <Label htmlFor="instructorEmail" requiredMarker>
+                        {orderedInputNameToLabel["instructorEmail"]}
+                      </Label>
+                      <TextInput
+                        id="instructorEmail"
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        required
+                        validationStatus={errors.instructorEmail ? "error" : undefined}
+                        aria-invalid={errors.instructorEmail ? "true" : "false"}
+                        aria-describedby={errors.instructorEmail && "instructorEmailErrorMessage"}
+                        {...register("instructorEmail", {
+                          required: `${orderedInputNameToLabel["instructorEmail"]} is required`,
+                          pattern: {
+                            value: /\S+@\S+\.\S+/,
+                            message: "Entered value does not match email format",
+                          },
+                        })}
+                        type="email"
+                      />
+                      {errors.instructorEmail && (
+                        <span id="instructorEmailErrorMessage" className="usa-error-message">
+                          {errors.instructorEmail.message}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="grid-row grid-gap">
+                    <div className="tablet:grid-col-6">
+                      <Label htmlFor="instructorPhoneNumber" requiredMarker>
+                        {orderedInputNameToLabel["instructorPhoneNumber"]}
+                      </Label>
+                      <TextInputMask
+                        id="instructorPhoneNumber"
+                        type="tel"
+                        value={instructorPhoneNumber ?? ""}
+                        inputMode="numeric"
+                        mask="___-___-____"
+                        pattern="\d{3}-\d{3}-\d{4}"
+                        required
+                        validationStatus={errors.instructorPhoneNumber ? "error" : undefined}
+                        aria-invalid={errors.instructorPhoneNumber ? "true" : "false"}
+                        aria-describedby={
+                          errors.instructorPhoneNumber && "instructorPhoneNumberErrorMessage"
+                        }
+                        {...register("instructorPhoneNumber", {
+                          required: `${orderedInputNameToLabel["instructorPhoneNumber"]} is required`,
+                          pattern: {
+                            value: /\d{3}-\d{3}-\d{4}/,
+                            message: "Entered value does not match phone number format",
+                          },
+                        })}
+                      />
+                      {errors.instructorPhoneNumber && (
+                        <span id="instructorPhoneNumberErrorMessage" className="usa-error-message">
+                          {errors.instructorPhoneNumber.message}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </Fieldset>
+              </div>
+            </div>
+          </div>
           <FormProgressButtons />
         </Form>
       )}

--- a/src/app/form/(formSteps)/training/TrainingData.test.ts
+++ b/src/app/form/(formSteps)/training/TrainingData.test.ts
@@ -11,20 +11,30 @@ describe("getTrainingFormData", () => {
       it("saves all training address values", () => {
         setRequiredFieldsInSessionStorage();
         setInSessionStorage({
+          stateApprovedTraining: "Doula training org",
           isDoulaTrainingInPerson: "true",
           trainingStreetAddress1: "123 Main St",
           trainingStreetAddress2: "Apt 4B",
           trainingCity: "Trenton",
           trainingState: "NJ",
           trainingZip: "10001",
+          instructorFirstName: "John",
+          instructorLastName: "Doe",
+          instructorEmail: "john@test.com",
+          instructorPhoneNumber: "111-111-1111",
         });
         expect(getTrainingFormData()).toMatchObject({
+          stateApprovedTraining: "Doula training org",
           isDoulaTrainingInPerson: true,
           trainingStreetAddress1: "123 Main St",
           trainingStreetAddress2: "Apt 4B",
           trainingCity: "Trenton",
           trainingState: AddressState.NJ,
           trainingZip: "10001",
+          instructorFirstName: "John",
+          instructorLastName: "Doe",
+          instructorEmail: "john@test.com",
+          instructorPhoneNumber: "111-111-1111",
         });
       });
     });
@@ -32,20 +42,30 @@ describe("getTrainingFormData", () => {
       it("overwrites all training address values with empty string/null", () => {
         setRequiredFieldsInSessionStorage();
         setInSessionStorage({
+          stateApprovedTraining: "Doula training org",
           isDoulaTrainingInPerson: "false",
           trainingStreetAddress1: "123 Main St",
           trainingStreetAddress2: "Apt 4B",
           trainingCity: "Trenton",
           trainingState: "NJ",
           trainingZip: "10001",
+          instructorFirstName: "John",
+          instructorLastName: "Doe",
+          instructorEmail: "john@test.com",
+          instructorPhoneNumber: "111-111-1111",
         });
         expect(getTrainingFormData()).toMatchObject({
+          stateApprovedTraining: "Doula training org",
           isDoulaTrainingInPerson: false,
           trainingStreetAddress1: "",
           trainingStreetAddress2: "",
           trainingCity: "",
           trainingState: null,
           trainingZip: "",
+          instructorFirstName: "John",
+          instructorLastName: "Doe",
+          instructorEmail: "john@test.com",
+          instructorPhoneNumber: "111-111-1111",
         });
       });
     });

--- a/src/app/form/(formSteps)/training/TrainingData.ts
+++ b/src/app/form/(formSteps)/training/TrainingData.ts
@@ -17,17 +17,17 @@ export interface TrainingData {
 }
 
 export interface TrainingFormData {
-  stateApprovedTraining: string | null;
+  stateApprovedTraining: string;
   nameOfTrainingOrganization: string | null;
-  isDoulaTrainingInPerson: boolean | null;
+  isDoulaTrainingInPerson: boolean;
   trainingStreetAddress1: string | null;
   trainingStreetAddress2: string | null;
   trainingCity: string | null;
   trainingState: AddressState | null;
   trainingZip: string | null;
-  instructorFirstName: string | null;
-  instructorLastName: string | null;
-  instructorEmail: string | null;
+  instructorFirstName: string;
+  instructorLastName: string;
+  instructorEmail: string;
   instructorPhoneNumber: string | null;
 }
 

--- a/src/app/form/(formSteps)/training/TrainingData.ts
+++ b/src/app/form/(formSteps)/training/TrainingData.ts
@@ -2,26 +2,40 @@ import type { AddressState } from "@/app/form/_utils/inputFields/enums";
 import { getAddressState, getBoolean, getValue } from "@/app/form/_utils/sessionStorage";
 
 export interface TrainingData {
+  stateApprovedTraining: string | null;
+  nameOfTrainingOrganization: string | null;
   isDoulaTrainingInPerson: string | null;
   trainingStreetAddress1: string | null;
   trainingStreetAddress2: string | null;
   trainingCity: string | null;
   trainingState: string | null;
   trainingZip: string | null;
+  instructorFirstName: string | null;
+  instructorLastName: string | null;
+  instructorEmail: string | null;
+  instructorPhoneNumber: string | null;
 }
 
 export interface TrainingFormData {
+  stateApprovedTraining: string | null;
+  nameOfTrainingOrganization: string | null;
   isDoulaTrainingInPerson: boolean | null;
   trainingStreetAddress1: string | null;
   trainingStreetAddress2: string | null;
   trainingCity: string | null;
   trainingState: AddressState | null;
   trainingZip: string | null;
+  instructorFirstName: string | null;
+  instructorLastName: string | null;
+  instructorEmail: string | null;
+  instructorPhoneNumber: string | null;
 }
 
 export const getTrainingFormData = () => {
   const isDoulaTrainingInPerson = getBoolean("isDoulaTrainingInPerson", true);
   return {
+    stateApprovedTraining: getValue("stateApprovedTraining", true),
+    nameOfTrainingOrganization: getValue("nameOfTrainingOrganization", false),
     isDoulaTrainingInPerson: isDoulaTrainingInPerson,
     trainingStreetAddress1: isDoulaTrainingInPerson
       ? getValue("trainingStreetAddress1", false)
@@ -32,5 +46,9 @@ export const getTrainingFormData = () => {
     trainingCity: isDoulaTrainingInPerson ? getValue("trainingCity", false) : "",
     trainingState: isDoulaTrainingInPerson ? getAddressState("trainingState", false) : null,
     trainingZip: isDoulaTrainingInPerson ? getValue("trainingZip", false) : "",
+    instructorFirstName: getValue("instructorFirstName", true),
+    instructorLastName: getValue("instructorLastName", true),
+    instructorEmail: getValue("instructorEmail", true),
+    instructorPhoneNumber: getValue("instructorPhoneNumber", true),
   };
 };

--- a/src/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual.test.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual.test.ts
@@ -263,16 +263,55 @@ describe("mapFfsIndividualFields", () => {
       testSocialSecurityNumber("fd427SocialSecurityNumber");
     });
 
-    it("fills doula training address line 1", () => {
-      testTrainingStreetAddress("fd427trainingsiteStreetaddress");
-    });
+    describe("doula training fields", () => {
+      describe("when user selects a state approved training", () => {
+        it("fills the selected approved training", () => {
+          const formData: FormData = generateFormData({
+            stateApprovedTraining: "Children's Futures (Trenton)",
+            nameOfTrainingOrganization: null,
+          });
+          const fieldsToFill = mapFfsIndividualFields(formData);
+          expect(fieldsToFill["fd427TrainingProgramName"]).toEqual("Children's Futures (Trenton)");
+        });
+      });
 
-    it("fills doula training address city", () => {
-      testTrainingCityStateZip(
-        "fd427trainingsiteCity",
-        "fd427trainingsiteState",
-        "fd427trainingsiteZip",
-      );
+      describe("when user provides the name of a non-approved training", () => {
+        it("fills the provided training", () => {
+          const formData: FormData = generateFormData({
+            stateApprovedTraining: "None of these",
+            nameOfTrainingOrganization: "Name of training org",
+          });
+          const fieldsToFill = mapFfsIndividualFields(formData);
+          expect(fieldsToFill["fd427TrainingProgramName"]).toEqual("Name of training org");
+        });
+      });
+
+      it("fills in training instructor fields", () => {
+        const formData: FormData = generateFormData({
+          instructorFirstName: "First",
+          instructorLastName: "Last",
+          instructorEmail: "test@example.com",
+          instructorPhoneNumber: "111-111-1111",
+        });
+        const fieldsToFill = mapFfsIndividualFields(formData);
+        expect(fieldsToFill["fd427TrainingProgramContact"]).toEqual("First Last");
+        expect(fieldsToFill["fd427trainingprogramcontanctE-mailAddress"]).toEqual(
+          "test@example.com",
+        );
+        expect(fieldsToFill["fd427trainingprogramcontactTelephoneNo"]).toEqual("111-111-1111");
+      });
+
+      it("fills doula street address1", () => {
+        testTrainingStreetAddress("fd427trainingsiteStreetaddress");
+      });
+
+      it("fills doula training address city", () => {
+        testTrainingCityStateZip(
+          "fd427trainingsiteCity",
+          "fd427trainingsiteState",
+          "fd427trainingsiteZip",
+        );
+      });
     });
   });
 

--- a/src/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual.test.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual.test.ts
@@ -312,6 +312,15 @@ describe("mapFfsIndividualFields", () => {
           "fd427trainingsiteZip",
         );
       });
+
+      it("throws an UnexpectedFormDataError when formData contains None of these but no Training Organization", () => {
+        const formData: FormData = generateFormData({
+          stateApprovedTraining: "None of these",
+        });
+        expect(() => mapFfsIndividualFields(formData)).toThrow(
+          "stateApprovedTraining had value none of these, but no training organization was provided.",
+        );
+      });
     });
   });
 

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page3.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page3.ts
@@ -30,6 +30,13 @@ export const getPage3Fields = (formData: FormData): Partial<PdfFfsIndividualPage
     fd427dateofbirthDate1_af_date: formatDateOfBirth(formData),
     fd427LegalName: formatName(formData),
     fd427SocialSecurityNumber: formData.socialSecurityNumber || "",
+    fd427TrainingProgramName:
+      formData.stateApprovedTraining === "None of these"
+        ? formData.nameOfTrainingOrganization!
+        : formData.stateApprovedTraining!,
+    fd427TrainingProgramContact: `${formData.instructorFirstName!} ${formData.instructorLastName!}`,
+    "fd427trainingprogramcontanctE-mailAddress": formData.instructorEmail!,
+    fd427trainingprogramcontactTelephoneNo: formData.instructorPhoneNumber!,
     fd427trainingsiteStreetaddress: formData.isDoulaTrainingInPerson!
       ? `${formData.trainingStreetAddress1}${formData.trainingStreetAddress2 ? ` ${formData.trainingStreetAddress2}` : ""}`
       : "Virtual",

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page3.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page3.ts
@@ -2,6 +2,14 @@ import { formatDateOfBirth, formatName } from "@/app/form/_utils/fillPdf/formatt
 import { type FormData } from "@form/_utils/fillPdf/form";
 
 // Page 3 - doula qualifications form
+
+export class UnexpectedFormDataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnexpectedFormDataError";
+  }
+}
+
 export interface PdfFfsIndividualPage3 {
   fd427LegalName: string;
   fd427SocialSecurityNumber: string;
@@ -26,6 +34,15 @@ export interface PdfFfsIndividualPage3 {
 }
 
 export const getPage3Fields = (formData: FormData): Partial<PdfFfsIndividualPage3> => {
+  if (
+    formData.stateApprovedTraining === "None of these" &&
+    formData.nameOfTrainingOrganization === null
+  ) {
+    throw new UnexpectedFormDataError(
+      "stateApprovedTraining had value none of these, but no training organization was provided.",
+    );
+  }
+
   return {
     fd427dateofbirthDate1_af_date: formatDateOfBirth(formData),
     fd427LegalName: formatName(formData),
@@ -33,7 +50,7 @@ export const getPage3Fields = (formData: FormData): Partial<PdfFfsIndividualPage
     fd427TrainingProgramName:
       formData.stateApprovedTraining === "None of these"
         ? formData.nameOfTrainingOrganization!
-        : formData.stateApprovedTraining!,
+        : formData.stateApprovedTraining,
     fd427TrainingProgramContact: `${formData.instructorFirstName!} ${formData.instructorLastName!}`,
     "fd427trainingprogramcontanctE-mailAddress": formData.instructorEmail!,
     fd427trainingprogramcontactTelephoneNo: formData.instructorPhoneNumber!,

--- a/src/app/form/_utils/fillPdf/testUtils/formData.ts
+++ b/src/app/form/_utils/fillPdf/testUtils/formData.ts
@@ -7,6 +7,12 @@ const defaultDateOfBirthMonth = "12";
 const defaultDateOfBirthYear = "1990";
 
 const defaultFormData = {
+  stateApprovedTraining: "Children's Home Society of NJ (Trenton)",
+  nameOfTrainingOrganization: null,
+  instructorFirstName: "First",
+  instructorLastName: "Last",
+  instructorEmail: "test@example.com",
+  instructorPhoneNumber: "111-111-1111",
   isDoulaTrainingInPerson: false,
   trainingStreetAddress1: null,
   trainingStreetAddress2: null,

--- a/src/app/form/_utils/testUtils/fillInputs.ts
+++ b/src/app/form/_utils/testUtils/fillInputs.ts
@@ -2,15 +2,20 @@ import type { Screen } from "@testing-library/dom";
 import { within } from "@testing-library/react";
 import type { UserEvent } from "@testing-library/user-event";
 
+type Role = "textbox" | "combobox" | "radio";
+
 export interface InputField {
   name: string;
   key: string;
-  role?: "textbox" | "combobox" | "radio" | "select";
+  role?: Role;
   testValue?: string;
   withinGroupName?: string;
 }
 
-export const getInputField = async (screen: Screen, input: InputField): Promise<HTMLElement> => {
+export const getInputField = async (
+  screen: Screen,
+  input: { name: string; role?: Role; withinGroupName?: string },
+): Promise<HTMLElement> => {
   const role = input.role ?? "textbox";
   return input.withinGroupName
     ? within(

--- a/src/app/form/_utils/testUtils/fillInputs.ts
+++ b/src/app/form/_utils/testUtils/fillInputs.ts
@@ -5,7 +5,7 @@ import type { UserEvent } from "@testing-library/user-event";
 export interface InputField {
   name: string;
   key: string;
-  role?: "textbox" | "combobox" | "radio";
+  role?: "textbox" | "combobox" | "radio" | "select";
   testValue?: string;
   withinGroupName?: string;
 }


### PR DESCRIPTION
## Link to issue
https://github.com/newjersey/doula-pm/issues/186
https://github.com/newjersey/doula-pm/issues/188

## What was done?
- Added additional questions to Training section to make it feature complete, matching the [EPIC](https://github.com/newjersey/doula-pm/issues/172)
- Added logic to fill in PDF on Page 3 with the user's values

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/). 
  - there is an alert because we are linking out to a PDF in our second accordion, but this is part of the design

## How should a reviewer test?

- Run through flow, validate that Training Fields on page 3 of the PDF populate with the data you entered

## Screenshots (for visual changes)

- Before
<img width="1100" height="625" alt="image" src="https://github.com/user-attachments/assets/d10b69b9-1f7f-466e-99d8-df633fb271b2" />

- After
<img width="698" height="763" alt="image" src="https://github.com/user-attachments/assets/90050a59-70c1-4b48-99c0-6f6d65e3805a" />

<img width="927" height="760" alt="image" src="https://github.com/user-attachments/assets/7d1e9b9c-f9f0-41da-99d5-6f380d6df444" />

