### PR TITLE
Fix PDF invisible fields

### DIFF
--- a/src/app/form/_utils/fillPdf/form.ts
+++ b/src/app/form/_utils/fillPdf/form.ts
@@ -13,7 +13,7 @@ import {
 import { fillAetnaForm } from "@form/_utils/fillPdf/aetna";
 import { fillFfsIndividualForm } from "@form/_utils/fillPdf/ffsIndividual";
 import { fillFidelisForm } from "@form/_utils/fillPdf/fidelis";
-import { PDFCheckBox, PDFDocument, PDFTextField } from "pdf-lib";
+import { PDFBool, PDFCheckBox, PDFDocument, PDFName, PDFTextField } from "pdf-lib";
 
 export interface FormData
   extends TrainingFormData,
@@ -69,6 +69,9 @@ export const fillForm = async (
       }
     }
   });
+
+  form.acroForm.dict.set(PDFName.of("NeedAppearances"), PDFBool.True);
+  form.updateFieldAppearances();
 
   const filledPdfBytes = await pdfDoc.save();
   return { filename, bytes: filledPdfBytes };


### PR DESCRIPTION
## Link to issue
https://github.com/newjersey/doula-pm/issues/202

## What was done?
- Fixed issue where PDF fields had data, but it wasn't visible unless field was focused.
- Found this fix; https://stackoverflow.com/questions/73058238/some-pdf-textfield-content-not-visible-until-clicked
  - Checked that PDF fields were visible in the output PDF field in Acrobat and Mac Preview.
## Accessibility
N/A

## How should a reviewer test?
- Checkout branch, step through flow, verify that Training fields on Page 3 are visible in Adobe Acrobat.

- Describe the testing approach taken to verify the changes, including:

## Screenshots (for visual changes)

- Before
<img width="1784" height="1102" alt="image" src="https://github.com/user-attachments/assets/860ce247-bf1a-4424-a260-b4e42424ec73" />

- After
<img width="923" height="766" alt="image" src="https://github.com/user-attachments/assets/66c800e9-bfdf-451d-b3f1-0ff7a19bc1ba" />

