### PR TITLE
[SHOW] Abstract out onError and onSubmit logic into generic functions [PART 1/3]

### DIFF
--- a/src/app/form/(formSteps)/business-details/1/page.tsx
+++ b/src/app/form/(formSteps)/business-details/1/page.tsx
@@ -2,9 +2,9 @@
 
 import type { BusinessDetails1Data } from "@/app/form/(formSteps)/business-details/BusinessDetailsData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
-import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
+import { createFormSubmitHandler } from "@form/_utils/formHandlers";
+import { useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState } from "@form/_utils/inputFields/enums";
-import { setKeyValue } from "@form/_utils/sessionStorage";
 import {
   Fieldset,
   Form,
@@ -16,7 +16,7 @@ import {
 } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { type SubmitHandler, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 
 const BusinessDetails1 = () => {
   const [dataHasLoaded, setDataHasLoaded] = useState<boolean>(false);
@@ -36,14 +36,7 @@ const BusinessDetails1 = () => {
 
   const hasSameBusinessAddress = watch("hasSameBusinessAddress");
 
-  const onSubmit: SubmitHandler<BusinessDetails1Data> = (data) => {
-    let key: keyof BusinessDetails1Data;
-    for (key in data) {
-      const value = data[key] ?? "";
-      setKeyValue(key, value);
-    }
-    routeToNextStep(router, formProgressPosition);
-  };
+  const onSubmit = createFormSubmitHandler<BusinessDetails1Data>(router, formProgressPosition);
 
   useEffect(() => {
     setDataHasLoaded(true);

--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -3,8 +3,9 @@
 import ErrorSummary from "@/app/form/(formSteps)/components/ErrorSummary";
 import { type PersonalDetails1Data } from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
-import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
-import { getDefaultValue, setKeyValue } from "@form/_utils/sessionStorage";
+import { createFormErrorHandler, createFormSubmitHandler } from "@form/_utils/formHandlers";
+import { useFormProgressPosition } from "@form/_utils/formProgressRouting";
+import { getDefaultValue } from "@form/_utils/sessionStorage";
 import {
   DateInputGroup,
   Fieldset,
@@ -17,7 +18,7 @@ import {
 } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { type SubmitErrorHandler, type SubmitHandler, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 
 const orderedInputNameToLabel: { [key in keyof PersonalDetails1Data]: string } = {
   firstName: "First name",
@@ -60,30 +61,13 @@ const PersonalDetailsStep1 = () => {
   const phoneNumber = watch("phoneNumber");
   const socialSecurityNumber = watch("socialSecurityNumber");
 
-  const onSubmit: SubmitHandler<PersonalDetails1Data> = (data) => {
-    let key: keyof PersonalDetails1Data;
-    for (key in data) {
-      const value = data[key] ?? "";
-      setKeyValue(key, value);
-    }
-    routeToNextStep(router, formProgressPosition);
-  };
-  const onError: SubmitErrorHandler<PersonalDetails1Data> = (errors) => {
-    if (Object.keys(errors).length >= 3) {
-      setShouldSummarizeErrors(true);
-      errorSummaryRef.current?.focus();
-    } else {
-      setShouldSummarizeErrors(false);
-      for (const inputName of Object.keys(orderedInputNameToLabel) as Array<
-        keyof PersonalDetails1Data
-      >) {
-        if (errors[inputName] !== undefined) {
-          setFocus(inputName);
-          break;
-        }
-      }
-    }
-  };
+  const onSubmit = createFormSubmitHandler<PersonalDetails1Data>(router, formProgressPosition);
+  const onError = createFormErrorHandler<PersonalDetails1Data>(
+    orderedInputNameToLabel,
+    setShouldSummarizeErrors,
+    errorSummaryRef,
+    setFocus,
+  );
 
   useEffect(() => {
     setDataHasLoaded(true);

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -5,9 +5,10 @@ import PublicInformationExplainer from "@/app/form/(formSteps)/personal-details/
 import { typecheckAutocomplete } from "@/app/form/_utils/types/autocomplete";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { type PersonalDetails2Data } from "@form/(formSteps)/personal-details/PersonalDetailsData";
-import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
+import { createFormErrorHandler, createFormSubmitHandler } from "@form/_utils/formHandlers";
+import { useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState } from "@form/_utils/inputFields/enums";
-import { getDefaultValue, setKeyValue } from "@form/_utils/sessionStorage";
+import { getDefaultValue } from "@form/_utils/sessionStorage";
 import {
   Fieldset,
   Form,
@@ -20,7 +21,7 @@ import {
 } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useForm, type SubmitErrorHandler, type SubmitHandler } from "react-hook-form";
+import { useForm } from "react-hook-form";
 
 const orderedInputNameToLabel: { [key in keyof PersonalDetails2Data]: string } = {
   streetAddress1: "Street address",
@@ -68,30 +69,13 @@ const PersonalDetailsStep2 = () => {
   const billingZip = watch("billingZip");
   const hasSameBillingMailingAddress = watch("hasSameBillingMailingAddress");
 
-  const onSubmit: SubmitHandler<PersonalDetails2Data> = (data) => {
-    let key: keyof PersonalDetails2Data;
-    for (key in data) {
-      const value = data[key] ?? "";
-      setKeyValue(key, value);
-    }
-    routeToNextStep(router, formProgressPosition);
-  };
-  const onError: SubmitErrorHandler<PersonalDetails2Data> = (errors) => {
-    if (Object.keys(errors).length >= 3) {
-      setShouldSummarizeErrors(true);
-      errorSummaryRef.current?.focus();
-    } else {
-      setShouldSummarizeErrors(false);
-      for (const inputName of Object.keys(orderedInputNameToLabel) as Array<
-        keyof PersonalDetails2Data
-      >) {
-        if (errors[inputName] !== undefined) {
-          setFocus(inputName);
-          break;
-        }
-      }
-    }
-  };
+  const onSubmit = createFormSubmitHandler<PersonalDetails2Data>(router, formProgressPosition);
+  const onError = createFormErrorHandler<PersonalDetails2Data>(
+    orderedInputNameToLabel,
+    setShouldSummarizeErrors,
+    errorSummaryRef,
+    setFocus,
+  );
 
   useEffect(() => {
     setDataHasLoaded(true);

--- a/src/app/form/(formSteps)/personal-details/3/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/page.tsx
@@ -3,12 +3,13 @@
 import NpiExplainer from "@/app/form/(formSteps)/personal-details/3/NpiExplainer";
 import type { PersonalDetails3Data } from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
-import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
-import { getDefaultValue, setKeyValue } from "@form/_utils/sessionStorage";
+import { createFormSubmitHandler } from "@form/_utils/formHandlers";
+import { useFormProgressPosition } from "@form/_utils/formProgressRouting";
+import { getDefaultValue } from "@form/_utils/sessionStorage";
 import { Form, Label, TextInput, TextInputMask } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { useForm, type SubmitHandler } from "react-hook-form";
+import { useForm } from "react-hook-form";
 
 const inputNameToLabel: { [key in keyof PersonalDetails3Data]: string } = {
   npiNumber: "National Provider Identifier (NPI)",
@@ -34,14 +35,7 @@ const PersonalDetailsStep3 = () => {
   });
   const npiNumber = watch("npiNumber");
 
-  const onSubmit: SubmitHandler<PersonalDetails3Data> = (data) => {
-    let key: keyof PersonalDetails3Data;
-    for (key in data) {
-      const value = data[key] ?? "";
-      setKeyValue(key, value);
-    }
-    routeToNextStep(router, formProgressPosition);
-  };
+  const onSubmit = createFormSubmitHandler<PersonalDetails3Data>(router, formProgressPosition);
 
   useEffect(() => {
     setDataHasLoaded(true);

--- a/src/app/form/(formSteps)/training/1/page.tsx
+++ b/src/app/form/(formSteps)/training/1/page.tsx
@@ -3,9 +3,10 @@
 import ErrorSummary from "@form/(formSteps)/components/ErrorSummary";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import type { TrainingData } from "@form/(formSteps)/training/TrainingData";
-import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
+import { createFormErrorHandler, createFormSubmitHandler } from "@form/_utils/formHandlers";
+import { useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState, StateApprovedTraining } from "@form/_utils/inputFields/enums";
-import { getDefaultValue, setKeyValue } from "@form/_utils/sessionStorage";
+import { getDefaultValue } from "@form/_utils/sessionStorage";
 import {
   Alert,
   Fieldset,
@@ -19,7 +20,7 @@ import {
 } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { type SubmitErrorHandler, type SubmitHandler, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import DoulaTrainingExplainer from "./DoulaTrainingExplainer";
 
 const orderedInputNameToLabel: { [key in keyof TrainingData]: string } = {
@@ -71,29 +72,13 @@ const TrainingStep1 = () => {
   const [dataHasLoaded, setDataHasLoaded] = useState<boolean>(false);
   const errorSummaryRef = useRef<HTMLDivElement>(null);
 
-  const onSubmit: SubmitHandler<TrainingData> = (data) => {
-    let key: keyof TrainingData;
-    for (key in data) {
-      const value = data[key] ?? "";
-      setKeyValue(key, value);
-    }
-    routeToNextStep(router, formProgressPosition);
-  };
-
-  const onError: SubmitErrorHandler<TrainingData> = (errors) => {
-    if (Object.keys(errors).length >= 3) {
-      setShouldSummarizeErrors(true);
-      errorSummaryRef.current?.focus();
-    } else {
-      setShouldSummarizeErrors(false);
-      for (const inputName of Object.keys(orderedInputNameToLabel) as Array<keyof TrainingData>) {
-        if (errors[inputName] !== undefined) {
-          setFocus(inputName);
-          break;
-        }
-      }
-    }
-  };
+  const onSubmit = createFormSubmitHandler<TrainingData>(router, formProgressPosition);
+  const onError = createFormErrorHandler<TrainingData>(
+    orderedInputNameToLabel,
+    setShouldSummarizeErrors,
+    errorSummaryRef,
+    setFocus,
+  );
 
   useEffect(() => {
     setDataHasLoaded(true);

--- a/src/app/form/_utils/formHandlers.ts
+++ b/src/app/form/_utils/formHandlers.ts
@@ -1,0 +1,48 @@
+import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import { type RefObject } from "react";
+import type {
+  FieldPath,
+  FieldValues,
+  SubmitErrorHandler,
+  SubmitHandler,
+  UseFormSetFocus,
+} from "react-hook-form";
+import { type FormProgressPosition, routeToNextStep } from "./formProgressRouting";
+import { type SessionStorageKey, setKeyValue } from "./sessionStorage";
+
+export const createFormSubmitHandler = <T extends FieldValues>(
+  router: AppRouterInstance,
+  formProgressPosition: FormProgressPosition,
+): SubmitHandler<T> => {
+  return (data: T) => {
+    let key: keyof T;
+    for (key in data) {
+      const value = data[key] ?? "";
+      setKeyValue(key as SessionStorageKey, value);
+    }
+    routeToNextStep(router, formProgressPosition);
+  };
+};
+
+export const createFormErrorHandler = <T extends FieldValues>(
+  orderedInputNameToLabel: { [key in keyof T]: string },
+  setShouldSummarizeErrors: (value: boolean) => void,
+  errorSummaryRef: RefObject<HTMLDivElement | null>,
+  setFocus: UseFormSetFocus<T>,
+): SubmitErrorHandler<T> => {
+  return (errors) => {
+    if (Object.keys(errors).length >= 3) {
+      setShouldSummarizeErrors(true);
+      errorSummaryRef.current?.focus();
+    } else {
+      setShouldSummarizeErrors(false);
+      for (const inputName of Object.keys(orderedInputNameToLabel) as Array<keyof T>) {
+        const fieldPath = inputName as FieldPath<T>;
+        if (errors[fieldPath] !== undefined) {
+          setFocus(fieldPath);
+          break;
+        }
+      }
+    }
+  };
+};

--- a/src/app/form/_utils/formProgressRouting.ts
+++ b/src/app/form/_utils/formProgressRouting.ts
@@ -10,7 +10,7 @@ import {
 import { type AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { usePathname } from "next/navigation";
 
-interface FormProgressPosition {
+export interface FormProgressPosition {
   previous: FormProgress | null;
   current: FormProgress;
   next: FormProgress | null;


### PR DESCRIPTION
## Link to issue
https://github.com/newjersey/doula-pm/issues/204

## What was done?
- Refactor onError and onSubmit into generic functions per page.
   
## Accessibility

- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

## Screenshots (for visual changes)
N/A
