### PR TITLE
[newjersey/doula-pm#188] Don't require instructor training phone number

### DIFF
--- a/src/app/form/(formSteps)/training/TrainingData.ts
+++ b/src/app/form/(formSteps)/training/TrainingData.ts
@@ -49,6 +49,6 @@ export const getTrainingFormData = (): TrainingFormData => {
     instructorFirstName: getValue("instructorFirstName", true),
     instructorLastName: getValue("instructorLastName", true),
     instructorEmail: getValue("instructorEmail", true),
-    instructorPhoneNumber: getValue("instructorPhoneNumber", true),
+    instructorPhoneNumber: getValue("instructorPhoneNumber", false),
   };
 };

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page3.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page3.ts
@@ -34,27 +34,27 @@ export interface PdfFfsIndividualPage3 {
 }
 
 export const getPage3Fields = (formData: FormData): Partial<PdfFfsIndividualPage3> => {
-  if (
-    formData.stateApprovedTraining === "None of these" &&
-    formData.nameOfTrainingOrganization === null
-  ) {
-    throw new UnexpectedFormDataError(
-      "stateApprovedTraining had value none of these, but no training organization was provided.",
-    );
+  let trainingProgramName: string;
+  if (formData.stateApprovedTraining === "None of these") {
+    if (formData.nameOfTrainingOrganization === null) {
+      throw new UnexpectedFormDataError(
+        "stateApprovedTraining had value none of these, but no training organization was provided.",
+      );
+    }
+    trainingProgramName = formData.nameOfTrainingOrganization;
+  } else {
+    trainingProgramName = formData.stateApprovedTraining;
   }
 
   return {
     fd427dateofbirthDate1_af_date: formatDateOfBirth(formData),
     fd427LegalName: formatName(formData),
     fd427SocialSecurityNumber: formData.socialSecurityNumber || "",
-    fd427TrainingProgramName:
-      formData.stateApprovedTraining === "None of these"
-        ? formData.nameOfTrainingOrganization!
-        : formData.stateApprovedTraining,
-    fd427TrainingProgramContact: `${formData.instructorFirstName!} ${formData.instructorLastName!}`,
-    "fd427trainingprogramcontanctE-mailAddress": formData.instructorEmail!,
-    fd427trainingprogramcontactTelephoneNo: formData.instructorPhoneNumber!,
-    fd427trainingsiteStreetaddress: formData.isDoulaTrainingInPerson!
+    fd427TrainingProgramName: trainingProgramName,
+    fd427TrainingProgramContact: `${formData.instructorFirstName} ${formData.instructorLastName}`,
+    "fd427trainingprogramcontanctE-mailAddress": formData.instructorEmail,
+    fd427trainingprogramcontactTelephoneNo: formData.instructorPhoneNumber || "",
+    fd427trainingsiteStreetaddress: formData.isDoulaTrainingInPerson
       ? `${formData.trainingStreetAddress1}${formData.trainingStreetAddress2 ? ` ${formData.trainingStreetAddress2}` : ""}`
       : "Virtual",
     fd427trainingsiteCity: formData.trainingCity ?? "",

--- a/src/app/form/_utils/fillPdf/testUtils/formData.ts
+++ b/src/app/form/_utils/fillPdf/testUtils/formData.ts
@@ -12,7 +12,7 @@ const defaultFormData = {
   instructorFirstName: "First",
   instructorLastName: "Last",
   instructorEmail: "test@example.com",
-  instructorPhoneNumber: "111-111-1111",
+  instructorPhoneNumber: null,
   isDoulaTrainingInPerson: false,
   trainingStreetAddress1: null,
   trainingStreetAddress2: null,


### PR DESCRIPTION
## Link to issue

This commit resolves #[188](https://github.com/newjersey/doula-pm/issues/188).

## What was done?
Instructor training phone number should not be required. However, previously an error message it would be displayed to the user if instructor training phone number was not in session storage.

This commit makes it okay for instructor training phone number to be null, and removes unnecessary type casts.

Specifically, two things were going on here
1. `getValue("instructorPhoneNumber", true)` while sessionStorage was null lead to a user-facing error that the field is required, even though it is not
    - https://github.com/newjersey/doula-medicaid/pull/80#discussion_r2291227023 happened mentions what causes this, which is that "We do not have type safety to catch the inverse mistake, where required is set to true when it should be false.". I still don't really have ideas how to make sure it doesn't happen in the future, but I've created https://github.com/newjersey/doula-pm/issues/222 for us to prioritize in the future
2. Even if above line had been set to false, the use of typescript non-null type casts (`!`) hid the fact that the null case was not handled. Without the handling, a hard error occurs in `fillForm` because null is an unexpected type to be filling the pdf with. `fillForm` has no test coverage for because we haven't figured out mocking the `const unfilledPdfFile = await fetch(pdfPath);`.
    - The red squiggly typescript line is telling us that there's a case we're not handling, and `!` is kind of equivalent to doing `@ts-ignore`. If we've actually handled it, in the vast majority of cases we should be able to explain to typescript that we have indeed handled it (e.g., see the rewrite for `trainingProgramName`).

<img width="1728" height="858" alt="749173 throws an error when attempting to fill the form" src="https://github.com/user-attachments/assets/8b566469-47c8-4990-868e-27e544997552" />


On the bright side, we now know that if we try to pass a null into `fillForm`, it will error! (which I think is good!)


## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Fill in all required fields
- Go to devtools -> application -> session storage, and delete `instructorPhoneNumber`
- The finish page should still let you download a pdf

## Screenshots (for visual changes)

<details>
<summary>Before</summary>



</details>


<details>
<summary>After</summary>



</details>