### PR TITLE
[newjersey/doula-pm#220] Wrap input label, hint, and error message for personal details step 1

### DIFF
--- a/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
@@ -1,0 +1,110 @@
+import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
+import { render, screen } from "@testing-library/react";
+
+describe("DoulaTextInput", () => {
+  it("renders the input with a label", () => {
+    const mockRegister = jest.fn();
+    render(<DoulaTextInput name="testInput" label="Test label" register={mockRegister} />);
+
+    expect(mockRegister).toHaveBeenCalledWith("testInput", undefined);
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toBeInTheDocument();
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("sets appropriate attributes when the input is required", () => {
+    const mockRegister = jest.fn();
+    const registerOptions = {
+      required: "This field is required",
+    };
+    render(
+      <DoulaTextInput
+        name="testInput"
+        label="Test label"
+        required
+        register={mockRegister}
+        registerOptions={registerOptions}
+      />,
+    );
+
+    expect(mockRegister).toHaveBeenCalledWith("testInput", registerOptions);
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAttribute("required");
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("describes the input with a string hint", () => {
+    render(
+      <DoulaTextInput name="testInput" label="Test label" hint="Test hint" register={jest.fn()} />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toHaveAccessibleDescription("Test hint");
+  });
+
+  it("shows an error message and sets appropriate attributes when there is an error for the input", () => {
+    render(
+      <DoulaTextInput
+        name="testInput"
+        label="Test label"
+        required
+        errors={{
+          testInput: {
+            type: "required",
+            message: "This field is required",
+          },
+        }}
+        register={jest.fn()}
+        registerOptions={{
+          required: "This field is required",
+        }}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAccessibleDescription("This field is required");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("does not show an error message if there is no error for the input", () => {
+    render(
+      <DoulaTextInput<{ testInput: string; otherInput: string }>
+        name="testInput"
+        label="Test label"
+        errors={{
+          otherInput: {
+            type: "required",
+            message: "This other field is required",
+          },
+        }}
+        register={jest.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("describes the input with both the hint and the error message when both are present", () => {
+    render(
+      <DoulaTextInput
+        name="testInput"
+        label="Test label"
+        hint="Test hint"
+        required
+        errors={{
+          testInput: {
+            type: "required",
+            message: "This field is required",
+          },
+        }}
+        register={jest.fn()}
+        registerOptions={{
+          required: "This field is required",
+        }}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAccessibleDescription("This field is required Test hint");
+  });
+});

--- a/src/app/form/(formSteps)/components/DoulaTextInput.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.tsx
@@ -1,0 +1,81 @@
+import { ErrorMessage } from "@/app/form/(formSteps)/components/ErrorMessage";
+import { Hint } from "@/app/form/(formSteps)/components/Hint";
+import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
+import {
+  Label,
+  TextInput,
+  type TextInputProps,
+  type ValidationStatus,
+} from "@trussworks/react-uswds";
+import type {
+  FieldErrors,
+  FieldPath,
+  FieldValues,
+  RegisterOptions,
+  UseFormRegister,
+} from "react-hook-form";
+
+type wrappedAttributes = "type" | "name" | "required";
+type internallySetAttributes = "id" | "validationStatus" | "aria-invalid" | "aria-describedby";
+
+interface DoulaTextInputProps<T extends FieldValues>
+  extends Omit<TextInputProps, wrappedAttributes | internallySetAttributes> {
+  name: FieldPath<T>;
+  label: React.ReactNode;
+  hint?: string;
+  type?: TextInputProps["type"];
+  required?: boolean;
+  errors?: FieldErrors<T>;
+  hideErrorMessage?: boolean;
+  register: UseFormRegister<T>;
+  registerOptions?: RegisterOptions<T>;
+}
+
+const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) => {
+  const {
+    name,
+    label,
+    hint,
+    type,
+    required,
+    errors,
+    hideErrorMessage,
+    register,
+    registerOptions,
+    ...otherProps
+  } = props;
+
+  const hasError = errors !== undefined && errors[name] !== undefined;
+  const internallySetProps: Partial<TextInputProps> = {};
+
+  const describedby = formatDescribedBy(name, errors, hint);
+  if (describedby !== "") {
+    internallySetProps["aria-describedby"] = describedby;
+  }
+
+  if (hasError) {
+    const validationStatusError: ValidationStatus = "error";
+    internallySetProps.validationStatus = errors[name] ? validationStatusError : undefined;
+    internallySetProps["aria-invalid"] = errors[name] ? ("true" as const) : ("false" as const);
+  }
+
+  return (
+    <>
+      <Label htmlFor={name} requiredMarker={required}>
+        {label}
+      </Label>
+      {hint !== undefined && <Hint name={name} hint={hint} />}
+      <TextInput
+        id={name}
+        type={type ?? "text"}
+        required={required}
+        {...internallySetProps}
+        {...otherProps}
+        {...register(name, registerOptions)}
+      />
+      {hasError && hideErrorMessage !== true && <ErrorMessage name={name} errors={errors} />}
+    </>
+  );
+};
+
+export default DoulaTextInput;

--- a/src/app/form/(formSteps)/components/DoulaTextInputMask.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInputMask.test.tsx
@@ -1,0 +1,138 @@
+import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
+import { render, screen } from "@testing-library/react";
+
+describe("DoulaTextInputMask", () => {
+  it("renders the input with a label", () => {
+    const mockRegister = jest.fn();
+    render(
+      <DoulaTextInputMask
+        name="testInput"
+        label="Test label"
+        inputMode="numeric"
+        mask="___-___-____"
+        pattern="\d{3}-\d{3}-\d{4}"
+        register={mockRegister}
+      />,
+    );
+
+    expect(mockRegister).toHaveBeenCalledWith("testInput", undefined);
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toBeInTheDocument();
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("sets appropriate attributes when the input is required", () => {
+    const mockRegister = jest.fn();
+    const registerOptions = {
+      required: "This field is required",
+    };
+    render(
+      <DoulaTextInputMask
+        name="testInput"
+        label="Test label"
+        inputMode="numeric"
+        mask="___-___-____"
+        pattern="\d{3}-\d{3}-\d{4}"
+        required
+        register={mockRegister}
+        registerOptions={registerOptions}
+      />,
+    );
+    expect(mockRegister).toHaveBeenCalledWith("testInput", registerOptions);
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAttribute("required");
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("describes the input with a string hint", () => {
+    render(
+      <DoulaTextInputMask
+        name="testInput"
+        label="Test label"
+        hint="Test hint"
+        inputMode="numeric"
+        mask="___-___-____"
+        pattern="\d{3}-\d{3}-\d{4}"
+        register={jest.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toHaveAccessibleDescription("Test hint");
+  });
+
+  it("shows an error message and sets appropriate attributes when there is an error for the input", () => {
+    render(
+      <DoulaTextInputMask
+        name="testInput"
+        label="Test label"
+        inputMode="numeric"
+        mask="___-___-____"
+        pattern="\d{3}-\d{3}-\d{4}"
+        required
+        errors={{
+          testInput: {
+            type: "required",
+            message: "This field is required",
+          },
+        }}
+        register={jest.fn()}
+        registerOptions={{
+          required: "This field is required",
+        }}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAccessibleDescription("This field is required");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("it does not show an error message if there is no error for the input", () => {
+    render(
+      <DoulaTextInputMask<{ testInput: string; otherInput: string }>
+        name="testInput"
+        label="Test label"
+        inputMode="numeric"
+        mask="___-___-____"
+        pattern="\d{3}-\d{3}-\d{4}"
+        errors={{
+          otherInput: {
+            type: "required",
+            message: "This other field is required",
+          },
+        }}
+        register={jest.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("describes the input with both the hint and the error message when both are present", () => {
+    render(
+      <DoulaTextInputMask
+        name="testInput"
+        label="Test label"
+        hint="Test hint"
+        inputMode="numeric"
+        mask="___-___-____"
+        pattern="\d{3}-\d{3}-\d{4}"
+        required
+        errors={{
+          testInput: {
+            type: "required",
+            message: "This field is required",
+          },
+        }}
+        register={jest.fn()}
+        registerOptions={{
+          required: "This field is required",
+        }}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAccessibleDescription("This field is required Test hint");
+  });
+});

--- a/src/app/form/(formSteps)/components/DoulaTextInputMask.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInputMask.tsx
@@ -1,0 +1,69 @@
+import { ErrorMessage } from "@/app/form/(formSteps)/components/ErrorMessage";
+import { Hint } from "@/app/form/(formSteps)/components/Hint";
+import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
+import {
+  Label,
+  TextInputMask,
+  type TextInputMaskProps,
+  type ValidationStatus,
+} from "@trussworks/react-uswds";
+import type {
+  FieldErrors,
+  FieldPath,
+  FieldValues,
+  RegisterOptions,
+  UseFormRegister,
+} from "react-hook-form";
+
+type wrappedAttributes = "type" | "name" | "required";
+type internallySetAttributes = "id" | "validationStatus" | "aria-invalid" | "aria-describedby";
+
+interface DoulaTextInputMaskProps<T extends FieldValues>
+  extends Omit<TextInputMaskProps, wrappedAttributes | internallySetAttributes> {
+  name: FieldPath<T>;
+  label: React.ReactNode;
+  hint?: string;
+  type?: TextInputMaskProps["type"];
+  required?: boolean;
+  errors?: FieldErrors<T>;
+  register: UseFormRegister<T>;
+  registerOptions?: RegisterOptions<T>;
+}
+
+const DoulaTextInputMask = <T extends FieldValues>(props: DoulaTextInputMaskProps<T>) => {
+  const { name, label, hint, type, required, errors, register, registerOptions, ...otherProps } =
+    props;
+  const hasError = errors !== undefined && errors[name] !== undefined;
+  const internallySetProps: Partial<TextInputMaskProps> = {};
+
+  const describedby = formatDescribedBy(name, errors, hint);
+  if (describedby !== "") {
+    internallySetProps["aria-describedby"] = describedby;
+  }
+
+  if (hasError) {
+    const validationStatusError: ValidationStatus = "error";
+    internallySetProps.validationStatus = errors[name] ? validationStatusError : undefined;
+    internallySetProps["aria-invalid"] = errors[name] ? ("true" as const) : ("false" as const);
+  }
+
+  return (
+    <>
+      <Label htmlFor={name} requiredMarker={required}>
+        {label}
+      </Label>
+      {hint !== undefined && <Hint name={name} hint={hint} />}
+      <TextInputMask
+        id={name}
+        type={type ?? "text"}
+        required={required}
+        {...internallySetProps}
+        {...otherProps}
+        {...register(name, registerOptions)}
+      />
+      {hasError && <ErrorMessage name={name} errors={errors} />}
+    </>
+  );
+};
+
+export default DoulaTextInputMask;

--- a/src/app/form/(formSteps)/components/ErrorMessage.test.tsx
+++ b/src/app/form/(formSteps)/components/ErrorMessage.test.tsx
@@ -1,0 +1,120 @@
+import { ErrorMessage } from "@/app/form/(formSteps)/components/ErrorMessage";
+import { render, screen } from "@testing-library/react";
+import { type FieldErrors } from "react-hook-form";
+
+describe("ErrorMessage", () => {
+  it("does not render an error message if there is no error", () => {
+    const element = render(<ErrorMessage name="testErrorMessage" errors={{}} />);
+    expect(element.container.textContent).toEqual("");
+  });
+
+  it("renders a string error message", () => {
+    const errors: FieldErrors<{ testErrorMessage: string }> = {
+      testErrorMessage: {
+        type: "required",
+        message: "This field is required",
+      },
+    };
+    render(<ErrorMessage name="testErrorMessage" errors={errors} />);
+    expect(screen.getByText("This field is required")).toBeInTheDocument();
+  });
+
+  it("renders a custom error message if the type matches", () => {
+    const errors: FieldErrors<{ testErrorMessage: string }> = {
+      testErrorMessage: {
+        type: "required",
+      },
+    };
+    const customErrorMessages = [
+      {
+        type: "required",
+        message: (
+          <p>
+            Fancy error <span>message</span>
+          </p>
+        ),
+      },
+    ];
+    const element = render(
+      <ErrorMessage
+        name="testErrorMessage"
+        errors={errors}
+        customErrorMessages={customErrorMessages}
+      />,
+    );
+    expect(element.container.textContent).toEqual("Fancy error message");
+  });
+
+  it("renders a custom error message if the type matches and a string error message is also provided", () => {
+    const errors: FieldErrors<{ testErrorMessage: string }> = {
+      testErrorMessage: {
+        type: "required",
+        message: "This will get overwritten",
+      },
+    };
+    const customErrorMessages = [
+      {
+        type: "required",
+        message: (
+          <p>
+            Fancy error <span>message</span>
+          </p>
+        ),
+      },
+    ];
+    const element = render(
+      <ErrorMessage
+        name="testErrorMessage"
+        errors={errors}
+        customErrorMessages={customErrorMessages}
+      />,
+    );
+    expect(element.container.textContent).toEqual("Fancy error message");
+  });
+
+  it("renders the regular string error message if custom errors are provided but the type does not match", () => {
+    const errors: FieldErrors<{ testErrorMessage: string }> = {
+      testErrorMessage: {
+        type: "minLength",
+        message: "Must have 10 digits",
+      },
+    };
+    const customErrorMessages = [
+      {
+        type: "required",
+        message: <p>This is required</p>,
+      },
+    ];
+    render(
+      <ErrorMessage
+        name="testErrorMessage"
+        errors={errors}
+        customErrorMessages={customErrorMessages}
+      />,
+    );
+    expect(screen.getByText("Must have 10 digits")).toBeInTheDocument();
+  });
+
+  it("throws in error if the error has no message", () => {
+    const errors: FieldErrors<{ testErrorMessage: string }> = {
+      testErrorMessage: {
+        type: "minLength",
+      },
+    };
+    const customErrorMessages = [
+      {
+        type: "required",
+        message: <p>This is required</p>,
+      },
+    ];
+    expect(() =>
+      render(
+        <ErrorMessage
+          name="testErrorMessage"
+          errors={errors}
+          customErrorMessages={customErrorMessages}
+        />,
+      ),
+    ).toThrow("Unexpected error with no message");
+  });
+});

--- a/src/app/form/(formSteps)/components/ErrorMessage.tsx
+++ b/src/app/form/(formSteps)/components/ErrorMessage.tsx
@@ -1,0 +1,53 @@
+import { formatErrorMessageId } from "@/app/form/(formSteps)/components/utils/doulaInput";
+import type {
+  FieldErrors,
+  FieldPath,
+  FieldValues,
+  LiteralUnion,
+  RegisterOptions,
+} from "react-hook-form";
+
+type CustomErrorMessage = {
+  type: LiteralUnion<keyof RegisterOptions, string>;
+  message: React.ReactNode;
+};
+
+export interface ErrorMessageProps<T extends FieldValues> {
+  name: FieldPath<T>;
+  errors: FieldErrors<T>;
+  customErrorMessages?: Array<CustomErrorMessage>;
+}
+
+const getMessage = <T extends FieldValues>(
+  error: NonNullable<FieldErrors<T>[FieldPath<T>]>,
+  customErrorMessages: Array<CustomErrorMessage> | undefined,
+) => {
+  if (customErrorMessages) {
+    for (const customErrorMessage of customErrorMessages) {
+      if (error.type === customErrorMessage.type) {
+        return customErrorMessage.message;
+      }
+    }
+  }
+  if (error.message !== undefined && error.message !== "") {
+    if (typeof error.message === "string") {
+      return error.message;
+    } else {
+      throw new Error(`Unexpected error message type ${error?.message}`);
+    }
+  }
+  throw new Error("Unexpected error with no message");
+};
+
+export const ErrorMessage = <T extends FieldValues>(props: ErrorMessageProps<T>) => {
+  const error = props.errors[props.name];
+  return (
+    <>
+      {error && (
+        <span id={formatErrorMessageId(props.name)} className="usa-error-message">
+          {getMessage(error, props.customErrorMessages)}
+        </span>
+      )}
+    </>
+  );
+};

--- a/src/app/form/(formSteps)/components/Hint.test.tsx
+++ b/src/app/form/(formSteps)/components/Hint.test.tsx
@@ -1,0 +1,9 @@
+import { Hint } from "@/app/form/(formSteps)/components/Hint";
+import { render, screen } from "@testing-library/react";
+
+describe("Hint", () => {
+  it("renders the provided string hint", () => {
+    render(<Hint name="testId" hint="Test hint" />);
+    expect(screen.getByText("Test hint")).toHaveAttribute("id", "testIdHint");
+  });
+});

--- a/src/app/form/(formSteps)/components/Hint.tsx
+++ b/src/app/form/(formSteps)/components/Hint.tsx
@@ -1,0 +1,9 @@
+import { formatHintId } from "@/app/form/(formSteps)/components/utils/doulaInput";
+
+export const Hint = (props: { name: string; hint: string }) => {
+  return (
+    <p id={formatHintId(props.name)} className="usa-hint">
+      {props.hint}
+    </p>
+  );
+};

--- a/src/app/form/(formSteps)/components/utils/doulaInput.ts
+++ b/src/app/form/(formSteps)/components/utils/doulaInput.ts
@@ -1,0 +1,24 @@
+import type { FieldErrors, FieldPath, FieldValues } from "react-hook-form";
+
+export const formatErrorMessageId = (name: string) => {
+  return `${name}ErrorMessage`;
+};
+
+export const formatHintId = (name: string) => {
+  return `${name}Hint`;
+};
+
+export const formatDescribedBy = <T extends FieldValues>(
+  name: FieldPath<T>,
+  errors: FieldErrors<T> | undefined,
+  hint: React.ReactNode | undefined,
+) => {
+  const describedbys = [];
+  if (errors !== undefined && errors[name]) {
+    describedbys.push(formatErrorMessageId(name));
+  }
+  if (hint !== undefined) {
+    describedbys.push(formatHintId(name));
+  }
+  return describedbys.join(" ");
+};

--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -1,22 +1,16 @@
 "use client";
 
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
+import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
+import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
+import { ErrorMessage } from "@/app/form/(formSteps)/components/ErrorMessage";
 import ErrorSummary from "@/app/form/(formSteps)/components/ErrorSummary";
 import { type PersonalDetails1Data } from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { createFormErrorHandler, createFormSubmitHandler } from "@form/_utils/formHandlers";
 import { useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { getDefaultValue } from "@form/_utils/sessionStorage";
-import {
-  DateInputGroup,
-  Fieldset,
-  Form,
-  FormGroup,
-  Label,
-  Select,
-  TextInput,
-  TextInputMask,
-} from "@trussworks/react-uswds";
+import { DateInputGroup, Fieldset, Form, FormGroup, Label, Select } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -89,50 +83,35 @@ const PersonalDetailsStep1 = () => {
               <h2 className="font-heading-md">Personal identification</h2>
               <Fieldset legend="Name" legendStyle="srOnly" className="grid-row grid-gap">
                 <div className="tablet:grid-col-4">
-                  <Label htmlFor="firstName" requiredMarker>
-                    {orderedInputNameToLabel["firstName"]}
-                  </Label>
-                  <TextInput
-                    id="firstName"
-                    type="text"
+                  <DoulaTextInput
+                    name="firstName"
+                    label={orderedInputNameToLabel["firstName"]}
                     required
-                    validationStatus={errors.firstName ? "error" : undefined}
-                    aria-invalid={errors.firstName ? "true" : "false"}
-                    aria-describedby={errors.firstName && "firstNameErrorMessage"}
-                    {...register("firstName", {
+                    errors={errors}
+                    register={register}
+                    registerOptions={{
                       required: `${orderedInputNameToLabel["firstName"]} is required`,
-                    })}
+                    }}
                   />
-                  {errors.firstName && (
-                    <span id="firstNameErrorMessage" className="usa-error-message">
-                      {errors.firstName.message}
-                    </span>
-                  )}
                 </div>
                 <div className="tablet:grid-col-4">
-                  <Label htmlFor="middleName">{orderedInputNameToLabel["middleName"]}</Label>
-                  <TextInput id="middleName" type="text" {...register("middleName")} />
+                  <DoulaTextInput
+                    name="middleName"
+                    label={orderedInputNameToLabel["middleName"]}
+                    register={register}
+                  />
                 </div>
                 <div className="tablet:grid-col-4">
-                  <Label htmlFor="lastName" requiredMarker>
-                    {orderedInputNameToLabel["lastName"]}
-                  </Label>
-                  <TextInput
-                    id="lastName"
-                    type="text"
+                  <DoulaTextInput
+                    name="lastName"
+                    label={orderedInputNameToLabel["lastName"]}
                     required
-                    validationStatus={errors.lastName ? "error" : undefined}
-                    aria-invalid={errors.lastName ? "true" : "false"}
-                    aria-describedby={errors.lastName && "lastNameErrorMessage"}
-                    {...register("lastName", {
+                    errors={errors}
+                    register={register}
+                    registerOptions={{
                       required: `${orderedInputNameToLabel["lastName"]} is required`,
-                    })}
+                    }}
                   />
-                  {errors.lastName && (
-                    <span id="lastNameErrorMessage" className="usa-error-message">
-                      {errors.lastName.message}
-                    </span>
-                  )}
                 </div>
               </Fieldset>
 
@@ -170,21 +149,18 @@ const PersonalDetailsStep1 = () => {
                     </Select>
                   </FormGroup>
                   <FormGroup className="usa-form-group--day">
-                    <Label htmlFor={"dateOfBirthDay"} requiredMarker>
-                      {orderedInputNameToLabel["dateOfBirthDay"]}
-                    </Label>
-                    <TextInput
-                      id={"dateOfBirthDay"}
-                      type="text"
+                    <DoulaTextInput
+                      name="dateOfBirthDay"
+                      label={orderedInputNameToLabel["dateOfBirthDay"]}
                       pattern="[0-9]*"
                       inputMode="numeric"
                       maxLength={2}
                       minLength={2}
                       required
-                      validationStatus={errors.dateOfBirthDay ? "error" : undefined}
-                      aria-invalid={errors.dateOfBirthDay ? "true" : "false"}
-                      aria-describedby="dateOfBirthDayErrorMessage"
-                      {...register("dateOfBirthDay", {
+                      hideErrorMessage
+                      errors={errors}
+                      register={register}
+                      registerOptions={{
                         required: `${orderedInputNameToLabel["dateOfBirthDay"]} is required`,
                         valueAsNumber: true,
                         min: {
@@ -204,25 +180,22 @@ const PersonalDetailsStep1 = () => {
                           }
                           return true;
                         },
-                      })}
+                      }}
                     />
                   </FormGroup>
                   <FormGroup className="usa-form-group--year">
-                    <Label htmlFor="dateOfBirthYear" requiredMarker>
-                      {orderedInputNameToLabel["dateOfBirthYear"]}
-                    </Label>
-                    <TextInput
-                      id="dateOfBirthYear"
-                      type="text"
+                    <DoulaTextInput
+                      name="dateOfBirthYear"
+                      label={orderedInputNameToLabel["dateOfBirthYear"]}
                       maxLength={4}
                       minLength={4}
                       pattern="[0-9]*"
                       inputMode="numeric"
                       required
-                      validationStatus={errors.dateOfBirthYear ? "error" : undefined}
-                      aria-invalid={errors.dateOfBirthYear ? "true" : "false"}
-                      aria-describedby="dateOfBirthYearErrorMessage"
-                      {...register("dateOfBirthYear", {
+                      hideErrorMessage
+                      errors={errors}
+                      register={register}
+                      registerOptions={{
                         required: `${orderedInputNameToLabel["dateOfBirthYear"]} is required`,
                         valueAsNumber: true,
                         validate: (value) => {
@@ -237,56 +210,33 @@ const PersonalDetailsStep1 = () => {
                           }
                           return true;
                         },
-                      })}
+                      }}
                     />
                   </FormGroup>
                 </DateInputGroup>
-                {errors.dateOfBirthMonth && (
-                  <div id="dateOfBirthMonthErrorMessage" className="usa-error-message">
-                    {errors.dateOfBirthMonth.message}
-                  </div>
-                )}
-                {errors.dateOfBirthDay && (
-                  <div id="dateOfBirthDayErrorMessage" className="usa-error-message">
-                    {errors.dateOfBirthDay.message}
-                  </div>
-                )}
-                {errors.dateOfBirthYear && (
-                  <div id="dateOfBirthYearErrorMessage" className="usa-error-message">
-                    {errors.dateOfBirthYear.message}
-                  </div>
-                )}
+                <ErrorMessage name="dateOfBirthMonth" errors={errors} />
+                <ErrorMessage name="dateOfBirthDay" errors={errors} />
+                <ErrorMessage name="dateOfBirthYear" errors={errors} />
               </Fieldset>
-              <Label htmlFor="socialSecurityNumber" requiredMarker>
-                {orderedInputNameToLabel["socialSecurityNumber"]}
-              </Label>
-              <p id="socialSecurityNumberHint" className="usa-hint">
-                Format XXX-XX-XXXX
-              </p>
-              <TextInputMask
-                id="socialSecurityNumber"
-                type="text"
+              <DoulaTextInputMask
+                name="socialSecurityNumber"
+                label={orderedInputNameToLabel["socialSecurityNumber"]}
+                hint="Format XXX-XX-XXXX"
                 inputMode="numeric"
                 value={socialSecurityNumber ?? ""}
                 mask="___-__-____"
                 pattern="\d{3}-\d{2}-\d{4}"
                 required
-                validationStatus={errors.socialSecurityNumber ? "error" : undefined}
-                aria-invalid={errors.socialSecurityNumber ? "true" : "false"}
-                aria-describedby={`${errors.socialSecurityNumber ? "socialSecurityNumberErrorMessage" : ""} socialSecurityNumberHint`}
-                {...register("socialSecurityNumber", {
+                errors={errors}
+                register={register}
+                registerOptions={{
                   required: `${orderedInputNameToLabel["socialSecurityNumber"]} is required`,
                   pattern: {
                     value: /\d{3}-\d{2}-\d{4}/,
                     message: "Entered value does not match social security number format",
                   },
-                })}
+                }}
               />
-              {errors.socialSecurityNumber && (
-                <span id="socialSecurityNumberErrorMessage" className="usa-error-message">
-                  {errors.socialSecurityNumber.message}
-                </span>
-              )}
             </div>
           </div>
           <HorizontalDivider />
@@ -294,59 +244,42 @@ const PersonalDetailsStep1 = () => {
             <div className="desktop:grid-col-8">
               <h2 className="font-heading-md">Contact information</h2>
               <p>We&apos;ll send official updates here.</p>
-              <Label htmlFor="email" requiredMarker>
-                {orderedInputNameToLabel["email"]}
-              </Label>
-              <TextInput
-                id="email"
+              <DoulaTextInput
+                name="email"
+                label={orderedInputNameToLabel["email"]}
+                type="email"
                 autoCorrect="off"
                 autoCapitalize="off"
                 required
-                validationStatus={errors.email ? "error" : undefined}
-                aria-invalid={errors.email ? "true" : "false"}
-                aria-describedby={errors.email && "emailErrorMessage"}
-                {...register("email", {
+                errors={errors}
+                register={register}
+                registerOptions={{
                   required: `${orderedInputNameToLabel["email"]} is required`,
                   pattern: {
                     value: /\S+@\S+\.\S+/,
                     message: "Entered value does not match email format",
                   },
-                })}
-                type="email"
+                }}
               />
-              {errors.email && (
-                <span id="emailErrorMessage" className="usa-error-message">
-                  {errors.email.message}
-                </span>
-              )}
-
-              <Label htmlFor="phoneNumber" requiredMarker>
-                {orderedInputNameToLabel["phoneNumber"]}
-              </Label>
-              <TextInputMask
-                id="phoneNumber"
+              <DoulaTextInputMask
+                name="phoneNumber"
+                label={orderedInputNameToLabel["phoneNumber"]}
                 type="tel"
                 value={phoneNumber ?? ""}
                 inputMode="numeric"
                 mask="___-___-____"
                 pattern="\d{3}-\d{3}-\d{4}"
                 required
-                validationStatus={errors.phoneNumber ? "error" : undefined}
-                aria-invalid={errors.phoneNumber ? "true" : "false"}
-                aria-describedby={errors.phoneNumber && "phoneNumberErrorMessage"}
-                {...register("phoneNumber", {
+                errors={errors}
+                register={register}
+                registerOptions={{
                   required: `${orderedInputNameToLabel["phoneNumber"]} is required`,
                   pattern: {
                     value: /\d{3}-\d{3}-\d{4}/,
                     message: "Entered value does not match phone number format",
                   },
-                })}
+                }}
               />
-              {errors.phoneNumber && (
-                <span id="phoneNumberErrorMessage" className="usa-error-message">
-                  {errors.phoneNumber.message}
-                </span>
-              )}
             </div>
           </div>
           <FormProgressButtons />


### PR DESCRIPTION
## Link to issue

This commit contributes to #[220](https://github.com/newjersey/doula-pm/issues/220).

## What was done?
This commit:
- Pulls out `DoulaTextInput` and `DoulaTextInputMask` components that wrap handling for a label, hint, and error message
    - These integrate with validation and `errors` provided by react-hook-form
    - Labels, hints, and error messages
- As part of doing so, also pulls out reusable `Hint` and `ErrorMessage` components
- Updates personal details step 1 to use these new components

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/form/personal-details/1. There is no functional change. Test the validation, with/without a screenreader, and try to break it.
