### PR TITLE
Improve types

### DIFF
--- a/src/app/form/(formSteps)/business-details/BusinessDetailsData.ts
+++ b/src/app/form/(formSteps)/business-details/BusinessDetailsData.ts
@@ -3,11 +3,11 @@ import { getAddressState, getBoolean, getValue } from "@/app/form/_utils/session
 
 export interface BusinessDetails1Data {
   hasSameBusinessAddress: "true" | "false" | "";
-  businessStreetAddress1: string | null;
-  businessStreetAddress2: string | null;
-  businessCity: string | null;
-  businessState: string | null;
-  businessZip: string | null;
+  businessStreetAddress1: string;
+  businessStreetAddress2: string;
+  businessCity: string;
+  businessState: string;
+  businessZip: string;
 }
 
 export interface BusinessDetailsFormData {

--- a/src/app/form/(formSteps)/personal-details/PersonalDetailsData.ts
+++ b/src/app/form/(formSteps)/personal-details/PersonalDetailsData.ts
@@ -2,35 +2,35 @@ import type { AddressState } from "@/app/form/_utils/inputFields/enums";
 import { getAddressState, getBoolean, getValue } from "@/app/form/_utils/sessionStorage";
 
 export interface PersonalDetails1Data {
-  firstName: string | null;
-  middleName: string | null;
-  lastName: string | null;
-  dateOfBirthMonth: string | null;
-  dateOfBirthDay: string | null;
-  dateOfBirthYear: string | null;
-  socialSecurityNumber: string | null;
-  email: string | null;
-  phoneNumber: string | null;
+  firstName: string;
+  middleName: string;
+  lastName: string;
+  dateOfBirthMonth: string;
+  dateOfBirthDay: string;
+  dateOfBirthYear: string;
+  socialSecurityNumber: string;
+  email: string;
+  phoneNumber: string;
 }
 
 export interface PersonalDetails2Data {
-  streetAddress1: string | null;
-  streetAddress2: string | null;
-  city: string | null;
-  state: string | null;
-  zip: string | null;
-  hasSameBillingMailingAddress: string | null;
-  billingStreetAddress1: string | null;
-  billingStreetAddress2: string | null;
-  billingCity: string | null;
-  billingState: string | null;
-  billingZip: string | null;
+  streetAddress1: string;
+  streetAddress2: string;
+  city: string;
+  state: string;
+  zip: string;
+  hasSameBillingMailingAddress: string;
+  billingStreetAddress1: string;
+  billingStreetAddress2: string;
+  billingCity: string;
+  billingState: string;
+  billingZip: string;
 }
 
 export interface PersonalDetails3Data {
-  npiNumber: string | null;
-  medicareProviderId: string | null;
-  upinNumber: string | null;
+  npiNumber: string;
+  medicareProviderId: string;
+  upinNumber: string;
 }
 
 export interface PersonalDetailsFormData {

--- a/src/app/form/(formSteps)/training/1/page.tsx
+++ b/src/app/form/(formSteps)/training/1/page.tsx
@@ -21,10 +21,10 @@ import {
 } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, type FieldPath } from "react-hook-form";
 import DoulaTrainingExplainer from "./DoulaTrainingExplainer";
 
-const orderedInputNameToLabel: { [key in keyof TrainingData]: string } = {
+const orderedInputNameToLabel: { [key in FieldPath<TrainingData>]: string } = {
   stateApprovedTraining: "Which state-approved training did you complete?",
   nameOfTrainingOrganization: "What is the name of your training organization?",
   trainingStreetAddress1: "Street address",

--- a/src/app/form/(formSteps)/training/TrainingData.ts
+++ b/src/app/form/(formSteps)/training/TrainingData.ts
@@ -2,18 +2,18 @@ import type { AddressState } from "@/app/form/_utils/inputFields/enums";
 import { getAddressState, getBoolean, getValue } from "@/app/form/_utils/sessionStorage";
 
 export interface TrainingData {
-  stateApprovedTraining: string | null;
-  nameOfTrainingOrganization: string | null;
-  isDoulaTrainingInPerson: string | null;
-  trainingStreetAddress1: string | null;
-  trainingStreetAddress2: string | null;
-  trainingCity: string | null;
-  trainingState: string | null;
-  trainingZip: string | null;
-  instructorFirstName: string | null;
-  instructorLastName: string | null;
-  instructorEmail: string | null;
-  instructorPhoneNumber: string | null;
+  stateApprovedTraining: string;
+  nameOfTrainingOrganization: string;
+  isDoulaTrainingInPerson: string;
+  trainingStreetAddress1: string;
+  trainingStreetAddress2: string;
+  trainingCity: string;
+  trainingState: string;
+  trainingZip: string;
+  instructorFirstName: string;
+  instructorLastName: string;
+  instructorEmail: string;
+  instructorPhoneNumber: string;
 }
 
 export interface TrainingFormData {

--- a/src/app/form/_utils/formHandlers.ts
+++ b/src/app/form/_utils/formHandlers.ts
@@ -25,7 +25,7 @@ export const createFormSubmitHandler = <T extends FieldValues>(
 };
 
 export const createFormErrorHandler = <T extends FieldValues>(
-  orderedInputNameToLabel: { [key in keyof T]: string },
+  orderedInputNameToLabel: { [key in FieldPath<T>]: string },
   setShouldSummarizeErrors: (value: boolean) => void,
   errorSummaryRef: RefObject<HTMLDivElement | null>,
   setFocus: UseFormSetFocus<T>,
@@ -36,7 +36,7 @@ export const createFormErrorHandler = <T extends FieldValues>(
       errorSummaryRef.current?.focus();
     } else {
       setShouldSummarizeErrors(false);
-      for (const inputName of Object.keys(orderedInputNameToLabel) as Array<keyof T>) {
+      for (const inputName of Object.keys(orderedInputNameToLabel) as Array<FieldPath<T>>) {
         const fieldPath = inputName as FieldPath<T>;
         if (errors[fieldPath] !== undefined) {
           setFocus(fieldPath);


### PR DESCRIPTION

## What was done?
This commit
- Removes `| null` types on the react-hook-form state types, as we initialize everything to empty string if not present
- More accurately types various keys of the react-hook-form state types as `FieldPath<T>`, instead of keyof T (which might be a number, or string, or something else)

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- The application should work as usual, and there should be no errors when running `npm run typecheck`
