### PR TITLE
[newjersey/doula-pm#220] Wrap radio inputs

### DIFF
--- a/src/app/_utils/stringHasWhiteSpace.ts
+++ b/src/app/_utils/stringHasWhiteSpace.ts
@@ -1,0 +1,3 @@
+export const hasWhiteSpace = (str: string) => {
+  return /\s/g.test(str);
+};

--- a/src/app/form/(formSteps)/business-details/1/page.tsx
+++ b/src/app/form/(formSteps)/business-details/1/page.tsx
@@ -1,19 +1,12 @@
 "use client";
 
 import type { BusinessDetails1Data } from "@/app/form/(formSteps)/business-details/BusinessDetailsData";
+import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { createFormSubmitHandler } from "@form/_utils/formHandlers";
 import { useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState } from "@form/_utils/inputFields/enums";
-import {
-  Fieldset,
-  Form,
-  Label,
-  Radio,
-  RequiredMarker,
-  Select,
-  TextInput,
-} from "@trussworks/react-uswds";
+import { Fieldset, Form, Label, Select, TextInput } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -22,7 +15,12 @@ const BusinessDetails1 = () => {
   const [dataHasLoaded, setDataHasLoaded] = useState<boolean>(false);
   const router = useRouter();
   const formProgressPosition = useFormProgressPosition();
-  const { register, handleSubmit, watch } = useForm<BusinessDetails1Data>({
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<BusinessDetails1Data>({
     defaultValues: {
       hasSameBusinessAddress: "",
       businessStreetAddress1: "",
@@ -44,39 +42,21 @@ const BusinessDetails1 = () => {
   return (
     <div>
       {dataHasLoaded && (
-        <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full">
+        <Form onSubmit={handleSubmit(onSubmit)} className="maxw-full" noValidate>
           <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
             <div className="desktop:grid-col-8">
               <h2 className="font-heading-md">Business address</h2>
               <p className="usa-hint">
                 This is the physical location where your business operates.
               </p>
-              <Fieldset
-                legend={
-                  <div className="usa-label">
-                    <p className="font-ui-xs text-normal">
-                      Is your business address the same as your residential and billing address?
-                    </p>
-                    <p className="font-ui-xs text-normal">
-                      Select one <RequiredMarker />
-                    </p>
-                  </div>
-                }
-                legendStyle="large"
-              >
-                <Radio
-                  id="sameBusinessAddressYes"
-                  label="Yes"
-                  value="true"
-                  {...register("hasSameBusinessAddress")}
-                />
-                <Radio
-                  id="sameBusinessAddressNo"
-                  label="No"
-                  value="false"
-                  {...register("hasSameBusinessAddress")}
-                />
-              </Fieldset>
+              <DoulaYesNoRadio
+                name="hasSameBusinessAddress"
+                value={hasSameBusinessAddress}
+                label="Is your business address the same as your residential and billing address?"
+                required
+                register={register}
+                errors={errors}
+              />
             </div>
 
             {hasSameBusinessAddress === "false" && (

--- a/src/app/form/(formSteps)/components/DoulaRadio.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaRadio.test.tsx
@@ -1,0 +1,230 @@
+import DoulaRadio from "@/app/form/(formSteps)/components/DoulaRadio";
+import { render, screen, within } from "@testing-library/react";
+
+const threeOptions = [
+  {
+    label: "Option 1",
+    value: "option1",
+  },
+  {
+    label: "Option 2",
+    value: "option2",
+  },
+  {
+    label: "Option 3",
+    value: "option3",
+  },
+];
+
+describe("DoulaRadio", () => {
+  it("renders a group with all the radio options", () => {
+    const mockRegister = jest.fn();
+    render(
+      <DoulaRadio
+        name="testRadio"
+        value=""
+        label="What option do you choose?"
+        options={threeOptions}
+        register={mockRegister}
+      />,
+    );
+    expect(mockRegister).toHaveBeenCalledTimes(threeOptions.length);
+    expect(mockRegister).toHaveBeenCalledWith("testRadio", {});
+
+    const group = screen.getByRole("group", { name: "What option do you choose? Select one" });
+    expect(group).toBeInTheDocument();
+    for (const option of threeOptions) {
+      const radio = within(group).getByRole("radio", { name: option.label });
+      expect(radio).toBeInTheDocument();
+      expect(radio).not.toBeChecked();
+      expect(radio).not.toHaveAttribute("required");
+      expect(radio).not.toHaveAttribute("aria-invalid");
+      expect(radio).not.toHaveAttribute("aria-describedby");
+    }
+  });
+
+  it("check the appropriate radio option if one is selected", () => {
+    render(
+      <DoulaRadio
+        name="testRadio"
+        value="option2"
+        label="What option do you choose?"
+        options={threeOptions}
+        register={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: "Option 2" })).toBeChecked();
+    for (const optionLabel of ["Option 1", "Option 3"]) {
+      expect(screen.getByRole("radio", { name: optionLabel })).not.toBeChecked();
+    }
+  });
+
+  it("calls registered with required and sets appropriate attributes when the input is required", () => {
+    const mockRegister = jest.fn();
+    const expectedRegisterOptions = {
+      required: "This question is required",
+    };
+    render(
+      <DoulaRadio
+        name="testRadio"
+        value=""
+        label="What option do you choose?"
+        required
+        options={threeOptions}
+        errors={{}}
+        register={mockRegister}
+      />,
+    );
+    expect(mockRegister).toHaveBeenCalledTimes(threeOptions.length);
+    expect(mockRegister).toHaveBeenCalledWith("testRadio", expectedRegisterOptions);
+
+    for (const option of threeOptions) {
+      const radio = screen.getByRole("radio", { name: option.label });
+      expect(radio).toHaveAttribute("required");
+    }
+  });
+
+  it("accepts additional register options", () => {
+    const mockRegister = jest.fn();
+    const validationFunction = (value: string) => value === "true";
+    render(
+      <DoulaRadio
+        name="testRadio"
+        value={""}
+        label="What option do you choose?"
+        required
+        options={[
+          {
+            label: "Yes",
+            value: "true",
+          },
+          {
+            label: "No",
+            value: "false",
+            additionalRegisterOptions: { validate: validationFunction },
+          },
+        ]}
+        errors={{}}
+        register={mockRegister}
+      />,
+    );
+    expect(mockRegister).toHaveBeenNthCalledWith(1, "testRadio", {
+      required: "This question is required",
+    });
+    expect(mockRegister).toHaveBeenNthCalledWith(2, "testRadio", {
+      required: "This question is required",
+      validate: validationFunction,
+    });
+  });
+
+  it("shows an error message and sets appropriate attributes when there is an error for the radio group", () => {
+    render(
+      <DoulaRadio
+        name="testRadio"
+        value={""}
+        label="What option do you choose?"
+        required
+        options={threeOptions}
+        errors={{
+          testRadio: {
+            type: "required",
+            message: "This question is required",
+          },
+        }}
+        register={jest.fn()}
+      />,
+    );
+
+    for (const option of threeOptions) {
+      const radio = screen.getByRole("radio", { name: option.label });
+      expect(radio).toHaveAccessibleDescription("This question is required");
+      expect(radio).toHaveAttribute("aria-invalid", "true");
+    }
+  });
+
+  it("shows a custom error message if provided", async () => {
+    render(
+      <DoulaRadio<{ testRadio: string; otherInput: string }>
+        name="testRadio"
+        value={""}
+        label="What option do you choose?"
+        required
+        options={threeOptions}
+        errors={{
+          testRadio: {
+            type: "required",
+          },
+        }}
+        customErrorMessages={[
+          {
+            type: "required",
+            message: (
+              <div>
+                Fancy error <span>message</span>
+              </div>
+            ),
+          },
+        ]}
+        register={jest.fn()}
+      />,
+    );
+
+    for (const option of threeOptions) {
+      const radio = screen.getByRole("radio", { name: option.label });
+      expect(radio).toHaveAccessibleDescription("Fancy error message");
+      expect(radio).toHaveAttribute("aria-invalid", "true");
+    }
+  });
+
+  it("does not show an error message if there is no error for the input", () => {
+    render(
+      <DoulaRadio<{ testRadio: string; otherInput: string }>
+        name="testRadio"
+        value={""}
+        label="What option do you choose?"
+        required
+        options={threeOptions}
+        errors={{
+          otherInput: {
+            type: "required",
+            message: "This other question is required",
+          },
+        }}
+        register={jest.fn()}
+      />,
+    );
+
+    for (const option of threeOptions) {
+      const radio = screen.getByRole("radio", { name: option.label });
+      expect(radio).not.toHaveAttribute("aria-invalid");
+      expect(radio).not.toHaveAttribute("aria-describedby");
+    }
+  });
+
+  it("throws an error if any provided option has whitespace in the value", () => {
+    expect(() =>
+      render(
+        <DoulaRadio<{ testRadio: string; otherInput: string }>
+          name="testRadio"
+          value={""}
+          label="What option do you choose?"
+          required
+          options={[
+            {
+              label: "Yes",
+              value: "true",
+            },
+            {
+              label: "No",
+              value: "test value",
+            },
+          ]}
+          register={jest.fn()}
+        />,
+      ),
+    ).toThrow(
+      "The option value is used in the HTML id, and should not have white space: test value",
+    );
+  });
+});

--- a/src/app/form/(formSteps)/components/DoulaRadio.tsx
+++ b/src/app/form/(formSteps)/components/DoulaRadio.tsx
@@ -1,0 +1,106 @@
+import { hasWhiteSpace } from "@/app/_utils/stringHasWhiteSpace";
+import {
+  ErrorMessage,
+  type CustomErrorMessage,
+} from "@/app/form/(formSteps)/components/ErrorMessage";
+import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
+import { Fieldset, Radio, RequiredMarker, type RadioProps } from "@trussworks/react-uswds";
+import type {
+  FieldErrors,
+  FieldPath,
+  FieldValues,
+  RegisterOptions,
+  UseFormRegister,
+} from "react-hook-form";
+
+export interface DoulaRadioOption<T extends FieldValues> {
+  label: string;
+  value: string;
+  additionalRegisterOptions?: RegisterOptions<T>;
+}
+
+type wrappedAttributes = "type" | "name" | "required";
+type internallySetAttributes = "id" | "aria-invalid" | "aria-describedby";
+
+export interface DoulaRadioProps<T extends FieldValues>
+  extends Omit<RadioProps, wrappedAttributes | internallySetAttributes> {
+  name: FieldPath<T>;
+  value: string;
+  label: React.ReactNode;
+  required?: boolean;
+  options: Array<DoulaRadioOption<T>>;
+  customErrorMessages?: Array<CustomErrorMessage>;
+  errors?: FieldErrors<T>;
+  register: UseFormRegister<T>;
+}
+
+const getLegend = (label: React.ReactNode, isRequired: boolean | undefined) => {
+  return typeof label === "string" ? (
+    <div className="usa-label">
+      <p>{label}</p>
+      <p>Select one {isRequired === true && <RequiredMarker />}</p>
+    </div>
+  ) : (
+    <div className="usa-label">
+      {label}
+      <p>Select one {isRequired === true && <RequiredMarker />}</p>
+    </div>
+  );
+};
+
+const DoulaRadio = <T extends FieldValues>(props: DoulaRadioProps<T>) => {
+  const {
+    name,
+    value,
+    label,
+    required,
+    options,
+    customErrorMessages,
+    errors,
+    register,
+    ...otherProps
+  } = props;
+
+  const hasError = errors !== undefined && errors[name] !== undefined;
+  const internallySetProps: Partial<RadioProps> = {};
+  const describedby = formatDescribedBy(name, errors, undefined);
+  if (describedby !== "") {
+    internallySetProps["aria-describedby"] = describedby;
+  }
+
+  if (hasError) {
+    internallySetProps["aria-invalid"] = errors[name] ? ("true" as const) : ("false" as const);
+  }
+
+  const defaultRegisterOptions = required === true ? { required: "This question is required" } : {};
+
+  return (
+    <Fieldset legend={getLegend(label, required)}>
+      {options.map((option: DoulaRadioOption<T>) => {
+        if (hasWhiteSpace(option.value)) {
+          throw new Error(
+            `The option value is used in the HTML id, and should not have white space: ${option.value}`,
+          );
+        }
+        return (
+          <Radio
+            key={option.value}
+            id={`${name}${option.value}`}
+            label={option.label}
+            value={option.value}
+            checked={value === option.value}
+            required={required}
+            {...register(name, { ...defaultRegisterOptions, ...option.additionalRegisterOptions })}
+            {...otherProps}
+            {...internallySetProps}
+          />
+        );
+      })}
+      {hasError && (
+        <ErrorMessage name={name} errors={errors} customErrorMessages={customErrorMessages} />
+      )}
+    </Fieldset>
+  );
+};
+
+export default DoulaRadio;

--- a/src/app/form/(formSteps)/components/DoulaTextInput.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.tsx
@@ -25,8 +25,8 @@ interface DoulaTextInputProps<T extends FieldValues>
   hint?: string;
   type?: TextInputProps["type"];
   required?: boolean;
-  errors?: FieldErrors<T>;
   hideErrorMessage?: boolean;
+  errors?: FieldErrors<T>;
   register: UseFormRegister<T>;
   registerOptions?: RegisterOptions<T>;
 }

--- a/src/app/form/(formSteps)/components/DoulaYesNoRadio.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaYesNoRadio.test.tsx
@@ -1,0 +1,47 @@
+import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
+import { render, screen, within } from "@testing-library/react";
+
+describe("DoulaYesNoRadio", () => {
+  it("renders a radio group with options Yes and No", () => {
+    render(<DoulaYesNoRadio name="testRadio" value="" label="Yes or no?" register={jest.fn()} />);
+    const group = screen.getByRole("group", { name: "Yes or no? Select one" });
+    for (const optionLabel of ["Yes", "No"]) {
+      expect(within(group).getByRole("radio", { name: optionLabel })).toBeInTheDocument();
+    }
+  });
+
+  it.each([
+    { invalidLabel: "Yes" as const, trueIsValid: false, falseIsValid: true },
+    { invalidLabel: "No" as const, trueIsValid: true, falseIsValid: false },
+  ])(
+    "considers $invalidLabel invalid and shows the error message if not when errorOn is set to $invalidLabel",
+    ({ invalidLabel, trueIsValid, falseIsValid }) => {
+      const mockRegister = jest.fn();
+      render(
+        <DoulaYesNoRadio
+          name="testRadio"
+          value=""
+          label="Yes or no?"
+          invalidOption={{ label: invalidLabel, message: "This option is invalid" }}
+          errors={{
+            testRadio: { type: "validate" },
+          }}
+          register={mockRegister}
+        />,
+      );
+
+      // The validate function is defined within the component and so difficult to test equality. We instead test that it does what it should.
+      for (let i = 0; i < 2; i++) {
+        const [arg1, arg2] = mockRegister.mock.calls[i];
+        expect(arg1).toEqual("testRadio");
+        expect(arg2.validate("true")).toEqual(trueIsValid);
+        expect(arg2.validate("false")).toEqual(falseIsValid);
+      }
+
+      for (const optionLabel of ["Yes", "No"]) {
+        const radio = screen.getByRole("radio", { name: optionLabel });
+        expect(radio).toHaveAccessibleDescription("This option is invalid");
+      }
+    },
+  );
+});

--- a/src/app/form/(formSteps)/components/DoulaYesNoRadio.tsx
+++ b/src/app/form/(formSteps)/components/DoulaYesNoRadio.tsx
@@ -1,0 +1,46 @@
+import type {
+  DoulaRadioOption,
+  DoulaRadioProps,
+} from "@/app/form/(formSteps)/components/DoulaRadio";
+import DoulaRadio from "@/app/form/(formSteps)/components/DoulaRadio";
+import type { FieldValues } from "react-hook-form";
+
+interface DoulaYesNoRadioProps<T extends FieldValues> extends Omit<DoulaRadioProps<T>, "options"> {
+  invalidOption?: { label: "Yes" | "No"; message: React.ReactNode };
+}
+
+const DoulaYesNoRadio = <T extends FieldValues>(props: DoulaYesNoRadioProps<T>) => {
+  const { invalidOption, ...otherProps } = props;
+  const optionYes: DoulaRadioOption<T> = {
+    label: "Yes",
+    value: "true",
+  };
+  const optionNo: DoulaRadioOption<T> = {
+    label: "No",
+    value: "false",
+  };
+
+  let customErrorMessages;
+  let options = [optionYes, optionNo];
+  if (invalidOption !== undefined) {
+    const validValue = invalidOption.label === "Yes" ? "false" : "true";
+    options = options.map((option) => {
+      return {
+        ...option,
+        additionalRegisterOptions: {
+          validate: (value: string) => value === validValue,
+        },
+      };
+    });
+    customErrorMessages = [
+      {
+        type: "validate",
+        message: invalidOption.message,
+      },
+    ];
+  }
+
+  return <DoulaRadio options={options} customErrorMessages={customErrorMessages} {...otherProps} />;
+};
+
+export default DoulaYesNoRadio;

--- a/src/app/form/(formSteps)/components/ErrorMessage.tsx
+++ b/src/app/form/(formSteps)/components/ErrorMessage.tsx
@@ -7,7 +7,7 @@ import type {
   RegisterOptions,
 } from "react-hook-form";
 
-type CustomErrorMessage = {
+export type CustomErrorMessage = {
   type: LiteralUnion<keyof RegisterOptions, string>;
   message: React.ReactNode;
 };

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
 import ErrorSummary from "@/app/form/(formSteps)/components/ErrorSummary";
 import PublicInformationExplainer from "@/app/form/(formSteps)/personal-details/2/PublicInformationExplainer";
 import { typecheckAutocomplete } from "@/app/form/_utils/types/autocomplete";
@@ -9,16 +10,7 @@ import { createFormErrorHandler, createFormSubmitHandler } from "@form/_utils/fo
 import { useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { AddressState } from "@form/_utils/inputFields/enums";
 import { getDefaultValue } from "@form/_utils/sessionStorage";
-import {
-  Fieldset,
-  Form,
-  Label,
-  Radio,
-  RequiredMarker,
-  Select,
-  TextInput,
-  TextInputMask,
-} from "@trussworks/react-uswds";
+import { Fieldset, Form, Label, Select, TextInput, TextInputMask } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -215,66 +207,18 @@ const PersonalDetailsStep2 = () => {
                 <p className="usa-hint">
                   This is the location where you want to receive your payments.
                 </p>
-                <Fieldset
-                  legend={
-                    <div className="usa-label">
-                      <p className="font-ui-xs text-normal">
-                        {orderedInputNameToLabel["hasSameBillingMailingAddress"]}
-                      </p>
-                      <p className="font-ui-xs text-normal">
-                        Select one <RequiredMarker />
-                      </p>
-                    </div>
-                  }
-                >
-                  <Radio
-                    id="sameBillingMailingAddressYes"
-                    label="Yes"
-                    value="true"
-                    checked={hasSameBillingMailingAddress === "true"}
-                    required
-                    {...register("hasSameBillingMailingAddress", {
-                      required: `This question is required`,
-                    })}
-                    aria-invalid={errors.hasSameBillingMailingAddress ? "true" : "false"}
-                    aria-describedby={
-                      errors.hasSameBillingMailingAddress &&
-                      "hasSameBillingMailingAddressErrorMessage"
-                    }
-                  />
-                  <Radio
-                    id="sameBillingMailingAddressNo"
-                    label="No"
-                    value="false"
-                    checked={hasSameBillingMailingAddress === "false"}
-                    required
-                    {...register("hasSameBillingMailingAddress", {
-                      required: `This question is required`,
-                    })}
-                    aria-invalid={errors.hasSameBillingMailingAddress ? "true" : "false"}
-                    aria-describedby={
-                      errors.hasSameBillingMailingAddress &&
-                      "hasSameBillingMailingAddressErrorMessage"
-                    }
-                  />
-                  {errors.hasSameBillingMailingAddress && (
-                    <span
-                      id="hasSameBillingMailingAddressErrorMessage"
-                      className="usa-error-message"
-                      role="alert"
-                    >
-                      {errors.hasSameBillingMailingAddress.message}
-                    </span>
-                  )}
-                </Fieldset>
+                <DoulaYesNoRadio
+                  name="hasSameBillingMailingAddress"
+                  value={hasSameBillingMailingAddress}
+                  label={orderedInputNameToLabel["hasSameBillingMailingAddress"]}
+                  required
+                  register={register}
+                  errors={errors}
+                />
 
                 {hasSameBillingMailingAddress === "false" && (
                   <Fieldset
-                    legend={
-                      <p className="font-ui-xs text-normal margin-top-5">
-                        What&apos;s your billing address?
-                      </p>
-                    }
+                    legend={<p className="margin-top-5">What&apos;s your billing address?</p>}
                   >
                     <div className="grid-row grid-gap">
                       <div className="mobile-lg:grid-col-6">

--- a/src/app/form/(formSteps)/screening/1/page.tsx
+++ b/src/app/form/(formSteps)/screening/1/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
 import SoleProprietorExplainer from "@/app/form/(formSteps)/screening/1/SoleProprietorExplainer";
 import type { Screening1Data } from "@/app/form/(formSteps)/screening/ScreeningData";
 import { createFormSubmitHandler } from "@/app/form/_utils/formHandlers";
 import { getDefaultBoolean } from "@/app/form/_utils/sessionStorage";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { useFormProgressPosition } from "@form/_utils/formProgressRouting";
-import { Fieldset, Form, Radio, RequiredMarker } from "@trussworks/react-uswds";
+import { Form } from "@trussworks/react-uswds";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -42,66 +43,40 @@ const ScreeningStep1 = () => {
                 If you have an LLC or another business type, use the standard Medicaid
                 Fee-for-Service application.
               </p>
-              <Fieldset
-                legend={
-                  <div className="usa-label">
-                    <p className="font-ui-xs text-normal">
+              <DoulaYesNoRadio
+                name="isSoleProprietor"
+                value={isSoleProprietor}
+                label={
+                  <div>
+                    <p>
                       Do you manage your business as an individual doula operating as a Sole
                       Proprietor?
                     </p>
                     <p className="usa-hint">
                       Most NJ FamilyCare doulas operate as Sole Proprietor.
                     </p>
-                    <p className="font-ui-xs text-normal">
-                      Select one <RequiredMarker />
-                    </p>
                   </div>
                 }
-                legendStyle="large"
-              >
-                <Radio
-                  id="soleProprietorYes"
-                  label="Yes"
-                  value="true"
-                  checked={isSoleProprietor === "true"}
-                  required
-                  {...register("isSoleProprietor", { required: "This question is required." })}
-                  aria-invalid={errors.isSoleProprietor ? "true" : "false"}
-                  aria-describedby={errors.isSoleProprietor && "isSoleProprietorErrorMessage"}
-                />
-                <Radio
-                  id="soleProprietorNo"
-                  label="No"
-                  value="false"
-                  checked={isSoleProprietor === "false"}
-                  required
-                  {...register("isSoleProprietor", {
-                    required: "This question is required.",
-                    validate: (value) => value === "true",
-                  })}
-                  aria-invalid={errors.isSoleProprietor ? "true" : "false"}
-                  aria-describedby={errors.isSoleProprietor && "isSoleProprietorErrorMessage"}
-                />
-                {errors.isSoleProprietor && (
-                  <span id="isSoleProprietorErrorMessage" className="usa-error-message">
-                    {errors.isSoleProprietor?.type === "validate" ? (
-                      <span>
-                        Currently this site is only for Sole Proprietors. Please use the{" "}
-                        <a
-                          href="https://www.njmmis.com/providerEnrollment.aspx "
-                          target="_blank"
-                          rel="noopener"
-                        >
-                          standard FFS application
-                        </a>
-                        .
-                      </span>
-                    ) : (
-                      errors.isSoleProprietor.message
-                    )}
-                  </span>
-                )}
-              </Fieldset>
+                required
+                invalidOption={{
+                  label: "No",
+                  message: (
+                    <span>
+                      Currently this site is only for Sole Proprietors. Please use the{" "}
+                      <a
+                        href="https://www.njmmis.com/providerEnrollment.aspx "
+                        target="_blank"
+                        rel="noopener"
+                      >
+                        standard FFS application
+                      </a>
+                      .
+                    </span>
+                  ),
+                }}
+                register={register}
+                errors={errors}
+              />
             </div>
             <div className="form-explainer desktop:grid-col-4">
               <SoleProprietorExplainer />

--- a/src/app/form/(formSteps)/training/1/page.tsx
+++ b/src/app/form/(formSteps)/training/1/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
+import DoulaRadio from "@/app/form/(formSteps)/components/DoulaRadio";
 import ErrorSummary from "@form/(formSteps)/components/ErrorSummary";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import type { TrainingData } from "@form/(formSteps)/training/TrainingData";
@@ -13,7 +14,6 @@ import {
   Fieldset,
   Form,
   Label,
-  Radio,
   RequiredMarker,
   Select,
   TextInput,
@@ -99,10 +99,8 @@ const TrainingStep1 = () => {
               />
               <h2 className="font-heading-md">Doula training organization</h2>
               <Label htmlFor="stateApprovedTraining">
-                <p className="font-ui-xs text-normal">
-                  {orderedInputNameToLabel["stateApprovedTraining"]}
-                </p>
-                <p className="font-ui-xs text-normal">
+                <p>{orderedInputNameToLabel["stateApprovedTraining"]}</p>
+                <p>
                   Select one <RequiredMarker />
                 </p>
               </Label>
@@ -169,61 +167,29 @@ const TrainingStep1 = () => {
             <div className="desktop:grid-col-8">
               <h2 className="font-heading-md">Training organization address</h2>
               <p className="usa-hint">This is where you completed your doula training.</p>
-              <Fieldset
-                legend={
-                  <div className="usa-label">
-                    <p className="font-ui-xs text-normal">
-                      {orderedInputNameToLabel["isDoulaTrainingInPerson"]}
-                    </p>
-                    <p className="font-ui-xs text-normal">
-                      Select one <RequiredMarker />
-                    </p>
-                  </div>
-                }
-              >
-                <Radio
-                  id="isDoulaTrainingInPersonYes"
-                  label="Yes, in person or hybrid"
-                  value="true"
-                  checked={isDoulaTrainingInPerson === "true"}
-                  required
-                  {...register("isDoulaTrainingInPerson", {
-                    required: `This question is required`,
-                  })}
-                  aria-invalid={errors.isDoulaTrainingInPerson ? "true" : "false"}
-                  aria-describedby={
-                    errors.isDoulaTrainingInPerson && "isDoulaTrainingInPersonErrorMessage"
-                  }
-                />
-                <Radio
-                  id="isDoulaTrainingInPersonNo"
-                  label="No, it was virtual"
-                  value="false"
-                  checked={isDoulaTrainingInPerson === "false"}
-                  required
-                  {...register("isDoulaTrainingInPerson", {
-                    required: `This question is required`,
-                  })}
-                  aria-invalid={errors.isDoulaTrainingInPerson ? "true" : "false"}
-                  aria-describedby={
-                    errors.isDoulaTrainingInPerson && "isDoulaTrainingInPersonErrorMessage"
-                  }
-                />
-                {errors.isDoulaTrainingInPerson && (
-                  <span
-                    id="isDoulaTrainingInPersonErrorMessage"
-                    className="usa-error-message"
-                    role="alert"
-                  >
-                    {errors.isDoulaTrainingInPerson.message}
-                  </span>
-                )}
-              </Fieldset>
+              <DoulaRadio
+                name="isDoulaTrainingInPerson"
+                value={isDoulaTrainingInPerson}
+                label={orderedInputNameToLabel["isDoulaTrainingInPerson"]}
+                required
+                options={[
+                  {
+                    label: "Yes, in person or hybrid",
+                    value: "true",
+                  },
+                  {
+                    label: "No, it was virtual",
+                    value: "false",
+                  },
+                ]}
+                register={register}
+                errors={errors}
+              />
 
               {isDoulaTrainingInPerson === "true" && (
                 <Fieldset
                   legend={
-                    <p className="font-ui-xs text-normal margin-top-3">
+                    <p className="margin-top-3">
                       What is the address of your training organization? <RequiredMarker />
                     </p>
                   }


### PR DESCRIPTION
## Link to issue

This commit contributes to #[220](https://github.com/newjersey/doula-pm/issues/220).

## What was done?
**While https://github.com/newjersey/doula-medicaid/pull/107 is still in review and not yet merged, please only review the second radio inputs commit:**
<img width="1430" height="822" alt="image" src="https://github.com/user-attachments/assets/267602bc-8795-4de6-896f-09f8037ccb45" />


This commit:
- Pulls out a common `DoulaRadio` component, and convenience `DoulaYesNoRadio` component for reuse. They wrap the fieldset, legend, and error message
    - These integrate with validation and `errors` provided by react-hook-form
- Updates all radio components to use these new components

This commit also
- Removes all usages of `font-ui-xs` and `text-normal`. `font-ui-xs` was unnecessarily changing the text size (the [figma](https://www.figma.com/design/2R3VxYvZQYsaIxBcWoA1kL/Doula-Prototypes?node-id=3328-24801&p=f&t=AF3bQPJIKt0YR012-0) doesn't show size changes), and `text-normal` is not needed

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- There is no functional change. Step through the form and test the radio buttons. Test the validation, with/without a screenreader, and try to break it.
- Slight visual changes in making text size consistent, will flag for design review