### PR TITLE
[newjersey/doula-pm#216] Fix stale progress bar

### DIFF
--- a/src/app/form/(formSteps)/FormLayout.test.tsx
+++ b/src/app/form/(formSteps)/FormLayout.test.tsx
@@ -1,3 +1,4 @@
+import { RouterPathnameProvider } from "@/app/form/_utils/testUtils/RouterPathnameProvider";
 import { FormLayout } from "@form/(formSteps)/FormLayout";
 import { within } from "@testing-library/dom";
 import { render, screen } from "@testing-library/react";
@@ -5,9 +6,11 @@ import { render, screen } from "@testing-library/react";
 describe("<FormLayout />", () => {
   it("shows the section progress bar", () => {
     render(
-      <FormLayout pathname="/form/business-details/1">
-        <div>Test content</div>
-      </FormLayout>,
+      <RouterPathnameProvider pathname="/form/business-details/1">
+        <FormLayout>
+          <div>Test content</div>
+        </FormLayout>
+      </RouterPathnameProvider>,
     );
     const progressSection = screen.getByRole("generic", { name: /progress/i });
     const sections = within(progressSection).getAllByRole("listitem");
@@ -28,9 +31,12 @@ describe("<FormLayout />", () => {
 
   it("shows heading 1 with the step indicator and section title when the title is different from the section name", () => {
     render(
-      <FormLayout pathname="/form/finish">
-        <div>Test content</div>
-      </FormLayout>,
+      <RouterPathnameProvider pathname="/form/finish">
+        <FormLayout>
+          <div>Test content</div>
+        </FormLayout>
+        ,
+      </RouterPathnameProvider>,
     );
     const progressBarTitle = "Finish";
     const sectionTitle = "Download forms";
@@ -47,9 +53,12 @@ describe("<FormLayout />", () => {
 
   it("shows heading 1 with only section title when the section has multiple steps", () => {
     render(
-      <FormLayout pathname="/form/personal-details/2">
-        <div>Test content</div>
-      </FormLayout>,
+      <RouterPathnameProvider pathname="/form/personal-details/2">
+        <FormLayout>
+          <div>Test content</div>
+        </FormLayout>
+        ,
+      </RouterPathnameProvider>,
     );
     const heading1 = screen.getByRole("heading", { level: 1 });
     expect(heading1).toHaveTextContent("2 of 3 Personal details");
@@ -57,9 +66,12 @@ describe("<FormLayout />", () => {
 
   it("shows heading 1 with the step indicator and section title when the section does not have steps", () => {
     render(
-      <FormLayout pathname="/form/finish">
-        <div>Test content</div>
-      </FormLayout>,
+      <RouterPathnameProvider pathname="/form/finish">
+        <FormLayout>
+          <div>Test content</div>
+        </FormLayout>
+        ,
+      </RouterPathnameProvider>,
     );
     const heading1 = screen.getByRole("heading", { level: 1 });
     expect(heading1).toHaveTextContent("Download forms");
@@ -67,9 +79,12 @@ describe("<FormLayout />", () => {
 
   it("shows required field indicator text with an asterisk", () => {
     render(
-      <FormLayout pathname="/form/business-details/1">
-        <div>Test content</div>
-      </FormLayout>,
+      <RouterPathnameProvider pathname="/form/business-details/1">
+        <FormLayout>
+          <div>Test content</div>
+        </FormLayout>
+        ,
+      </RouterPathnameProvider>,
     );
 
     expect(screen.getByText(/A red asterisk.*indicates a required field/)).toBeInTheDocument();

--- a/src/app/form/(formSteps)/FormLayout.tsx
+++ b/src/app/form/(formSteps)/FormLayout.tsx
@@ -1,12 +1,17 @@
+"use client";
+
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import { allSections, getCurrentFormProgress } from "@form/_utils/formProgress";
 import { RequiredMarker } from "@trussworks/react-uswds";
+import { usePathname } from "next/navigation";
 
 type CompletionState = "complete" | "current" | "incomplete";
 
-// Separated this into a separate testable component because as of writing, Jest does not support testing NextJs asynchronous server components (https://nextjs.org/docs/app/guides/testing/jest)
-export const FormLayout = (props: { children?: React.ReactNode; pathname: string }) => {
-  const { section: currentSection, step: currentStep } = getCurrentFormProgress(props.pathname);
+// This is a client component because Next seems to not re-render server side components on browser back button https://github.com/newjersey/doula-pm/issues/216
+// Even if that issue was solved, the separate component enables us to test this, because as of writing, Jest does not support testing NextJs asynchronous server components (https://nextjs.org/docs/app/guides/testing/jest)
+export const FormLayout = (props: { children?: React.ReactNode }) => {
+  const pathname = usePathname();
+  const { section: currentSection, step: currentStep } = getCurrentFormProgress(pathname);
   const currentSectionIndex = allSections.findIndex(
     (sections) => sections.id === currentSection.id,
   );

--- a/src/app/form/(formSteps)/layout.tsx
+++ b/src/app/form/(formSteps)/layout.tsx
@@ -18,10 +18,7 @@ export const generateMetadata = async (): Promise<Metadata> => {
 };
 
 const FormLayoutWithRequestContext = async ({ children }: { children?: React.ReactNode }) => {
-  const headersList = await headers();
-  const pathname = headersList.get("x-pathname") as string;
-
-  return <FormLayout pathname={pathname}>{children}</FormLayout>;
+  return <FormLayout>{children}</FormLayout>;
 };
 
 export default FormLayoutWithRequestContext;


### PR DESCRIPTION
## Link to issue

This commit resolves #[216](https://github.com/newjersey/doula-pm/issues/216).

## What was done?
Previously, if one clicked the "Next" button on forms, then clicked their browser's back button, the page title and form inputs would update, but the progress bar would not.

This was happening because in `src/app/form/(formSteps)/layout.tsx`, the server-side `FormLayoutWithRequestContext` and its server-side child `FormLayout` were not being re-rendered on browser back button. `generateMetadata` in the same file it was still correctly being called on browser back button render, which was correctly updating the page title.

This commit fixes this bug by making the `FormLayout` component (which renders the progress bar) a client-side component, forcing its re-render.

This feels contrary to the spirit of NextJS, in that we now no longer have anything rendered server-side beyond the NJ banner. [Asked if anyone wants to chat about this](https://njcio.slack.com/archives/C0590CD1EE8/p1756826738276859) for better ideas, but merging this for now. One limitation for us might have to do with the "dynamic" part of our layout coming from statically defined routes, instead of "truly dynamic" `[slug]`s.

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/form/screening/1. Click Yes, then Next. Using your browser (like clicking the browser back button), go back to the previous page. The progress bay should correctly update to "1 of 3 Screening", and not "2 of 3".

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

Technically on the training URL, but still has the progress bar from personal details:
<img width="2558" height="1212" alt="image" src="https://github.com/user-attachments/assets/751a4c60-09db-4af5-9003-01a8b280575c" />

</details>


<details>

After, this should no longer happen