### PR TITLE
[newjersey/doula-pm#196] Add horizontal line between form inputs and previous and next buttons

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/form/(formSteps)/business-details/1/page.tsx
+++ b/src/app/form/(formSteps)/business-details/1/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import type { BusinessDetails1Data } from "@/app/form/(formSteps)/business-details/BusinessDetailsData";
 import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
 import { DoulaForm } from "@/app/form/components/DoulaForm";
@@ -121,6 +122,7 @@ const BusinessDetails1 = () => {
           </Fieldset>
         )}
       </div>
+      <HorizontalDivider />
       <FormProgressButtons />
     </DoulaForm>
   );

--- a/src/app/form/(formSteps)/insurance/page.tsx
+++ b/src/app/form/(formSteps)/insurance/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { Form } from "@trussworks/react-uswds";
@@ -20,6 +21,7 @@ const FormSection = () => {
         })}
         className="maxw-full"
       >
+        <HorizontalDivider />
         <FormProgressButtons />
       </Form>
     </div>

--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -261,6 +261,7 @@ const PersonalDetailsStep1 = () => {
           />
         </div>
       </div>
+      <HorizontalDivider />
       <FormProgressButtons />
     </DoulaForm>
   );

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
 import FormProgressButtons from "@/app/form/(formSteps)/components/FormProgressButtons";
 import PublicInformationExplainer from "@/app/form/(formSteps)/personal-details/2/PublicInformationExplainer";
@@ -316,6 +317,7 @@ const PersonalDetailsStep2 = () => {
           <PublicInformationExplainer />
         </div>
       </div>
+      <HorizontalDivider />
       <FormProgressButtons />
     </DoulaForm>
   );

--- a/src/app/form/(formSteps)/personal-details/3/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/page.tsx
@@ -120,6 +120,7 @@ const PersonalDetailsStep3 = () => {
           />
         </div>
       </div>
+      <HorizontalDivider />
       <FormProgressButtons />
     </DoulaForm>
   );

--- a/src/app/form/(formSteps)/screening/1/page.tsx
+++ b/src/app/form/(formSteps)/screening/1/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
 import SoleProprietorExplainer from "@/app/form/(formSteps)/screening/1/SoleProprietorExplainer";
 import type { Screening1Data } from "@/app/form/(formSteps)/screening/ScreeningData";
@@ -71,6 +72,7 @@ const ScreeningStep1 = () => {
           <SoleProprietorExplainer />
         </div>
       </div>
+      <HorizontalDivider />
       <FormProgressButtons />
     </DoulaForm>
   );

--- a/src/app/form/(formSteps)/screening/2/page.tsx
+++ b/src/app/form/(formSteps)/screening/2/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { Form } from "@trussworks/react-uswds";
@@ -20,6 +21,7 @@ const FormSection = () => {
         })}
         className="maxw-full"
       >
+        <HorizontalDivider />
         <FormProgressButtons />
       </Form>
     </div>

--- a/src/app/form/(formSteps)/screening/3/page.tsx
+++ b/src/app/form/(formSteps)/screening/3/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { Form } from "@trussworks/react-uswds";
@@ -20,6 +21,7 @@ const FormSection = () => {
         })}
         className="maxw-full"
       >
+        <HorizontalDivider />
         <FormProgressButtons />
       </Form>
     </div>

--- a/src/app/form/(formSteps)/training/1/page.tsx
+++ b/src/app/form/(formSteps)/training/1/page.tsx
@@ -394,6 +394,7 @@ const TrainingStep1 = () => {
           </div>
         </div>
       </div>
+      <HorizontalDivider />
       <FormProgressButtons />
     </DoulaForm>
   );


### PR DESCRIPTION
## Link to issue

This commit resolves #[196](https://github.com/newjersey/doula-pm/issues/196).

## What was done?

Added a horizontal line above the progress buttons on all pages except the finish page.

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Click through the form, see the horizontal line between the form inputs and the progress button

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

Page with form fields (not screen shotting every single one):
<img width="2646" height="2224" alt="main d20cvhuc4595ep amplifyapp com_form_personal-details_2 (2)" src="https://github.com/user-attachments/assets/cc70b321-0f6d-41be-bf3a-b82b527ff1e4" />

Pages without fields yet:
<img width="1110" height="428" alt="image" src="https://github.com/user-attachments/assets/d58203da-8b85-4723-bd68-8a7d357a00ff" />


</details>


<details>
<summary>After</summary>

Page with form fields (not screen shotting every single one):
<img width="2646" height="2292" alt="localhost_3000_form_personal-details_2 (3)" src="https://github.com/user-attachments/assets/d9ac1151-6f40-490a-b817-0fdffefa3aa2" />

Pages without fields yet. Looks a little weird, but I figure that's fine, it'll look better when we build it, and this will help us remember to have it:
<img width="1098" height="397" alt="image" src="https://github.com/user-attachments/assets/2b944823-a58d-4144-93c6-2128c6938530" />

</details>