### PR TITLE
[newjersey/doula-pm#220] Use `DoulaTextInput` and `DoulaTextInputMask` throughout

### DIFF
--- a/src/app/form/(formSteps)/business-details/1/page.tsx
+++ b/src/app/form/(formSteps)/business-details/1/page.tsx
@@ -2,11 +2,12 @@
 
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import type { BusinessDetails1Data } from "@/app/form/(formSteps)/business-details/BusinessDetailsData";
+import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
 import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
 import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { AddressState } from "@form/_utils/inputFields/enums";
-import { Fieldset, Label, Select, TextInput } from "@trussworks/react-uswds";
+import { Fieldset, Label, Select } from "@trussworks/react-uswds";
 import { useForm } from "react-hook-form";
 
 const mayHaveThreeOrMoreErrors = false;
@@ -53,37 +54,24 @@ const BusinessDetails1 = () => {
           <Fieldset legend="Business address" legendStyle="srOnly">
             <div className="grid-row grid-gap">
               <div className="mobile-lg:grid-col-6">
-                <Label requiredMarker htmlFor="businessStreetAddress1">
-                  Street address
-                </Label>
-                <TextInput
-                  id="businessStreetAddress1"
-                  type="text"
+                <DoulaTextInput
+                  name="businessStreetAddress1"
+                  label="Street address"
                   required
-                  {...register("businessStreetAddress1")}
+                  register={register}
                 />
               </div>
               <div className="mobile-lg:grid-col-6">
-                <Label htmlFor="businessStreetAddress2">Street address line 2</Label>
-                <TextInput
-                  id="businessStreetAddress2"
-                  type="text"
-                  {...register("businessStreetAddress2")}
+                <DoulaTextInput
+                  name="businessStreetAddress2"
+                  label="Street address line 2"
+                  register={register}
                 />
               </div>
             </div>
             <div className="grid-row grid-gap">
               <div className="mobile-lg:grid-col-6">
-                <Label requiredMarker htmlFor="businessCity">
-                  City
-                </Label>
-                <TextInput
-                  className="usa-input"
-                  id="businessCity"
-                  type="text"
-                  required
-                  {...register("businessCity")}
-                />
+                <DoulaTextInput name="businessCity" label="City" required register={register} />
               </div>
             </div>
             <div className="grid-row grid-gap">
@@ -106,16 +94,12 @@ const BusinessDetails1 = () => {
               </div>
 
               <div className="mobile-lg:grid-col-4">
-                <Label requiredMarker htmlFor="businessZip">
-                  ZIP code
-                </Label>
-                <TextInput
-                  className="usa-input usa-input--medium"
-                  id="businessZip"
-                  type="text"
+                <DoulaTextInput
+                  name="businessZip"
+                  label="ZIP code"
                   pattern="[\d]{5}(-[\d]{4})?"
                   required
-                  {...register("businessZip")}
+                  register={register}
                 />
               </div>
             </div>

--- a/src/app/form/(formSteps)/components/DoulaRadio.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaRadio.test.tsx
@@ -85,6 +85,28 @@ describe("DoulaRadio", () => {
     }
   });
 
+  it("it describes the input with the provided describedby", () => {
+    render(
+      <>
+        <DoulaRadio
+          name="testRadio"
+          value=""
+          label="What option do you choose?"
+          aria-describedby="anotherDescriptonID"
+          required
+          options={threeOptions}
+          errors={{}}
+          register={jest.fn()}
+        />
+        <span id="anotherDescriptonID">Additional description</span>
+      </>,
+    );
+    for (const option of threeOptions) {
+      const radio = screen.getByRole("radio", { name: option.label });
+      expect(radio).toHaveAccessibleDescription("Additional description");
+    }
+  });
+
   it("accepts additional register options", () => {
     const mockRegister = jest.fn();
     const validationFunction = (value: string) => value === "true";
@@ -156,6 +178,7 @@ describe("DoulaRadio", () => {
             type: "required",
           },
         }}
+        register={jest.fn()}
         customErrorMessages={[
           {
             type: "required",
@@ -166,7 +189,6 @@ describe("DoulaRadio", () => {
             ),
           },
         ]}
-        register={jest.fn()}
       />,
     );
 
@@ -226,5 +248,33 @@ describe("DoulaRadio", () => {
     ).toThrow(
       "The option value is used in the HTML id, and should not have white space: test value",
     );
+  });
+
+  it("describes the radio with both the error message and the aria-describedby when both are present", () => {
+    render(
+      <>
+        <DoulaRadio
+          name="testRadio"
+          value=""
+          label="What option do you choose?"
+          aria-describedby="anotherDescriptonID"
+          required
+          options={threeOptions}
+          errors={{
+            testRadio: {
+              type: "required",
+              message: "This question is required",
+            },
+          }}
+          register={jest.fn()}
+        />
+        <span id="anotherDescriptonID">Additional description</span>
+      </>,
+    );
+
+    for (const option of threeOptions) {
+      const radio = screen.getByRole("radio", { name: option.label });
+      expect(radio).toHaveAccessibleDescription("This question is required Additional description");
+    }
   });
 });

--- a/src/app/form/(formSteps)/components/DoulaRadio.tsx
+++ b/src/app/form/(formSteps)/components/DoulaRadio.tsx
@@ -20,7 +20,7 @@ export interface DoulaRadioOption<T extends FieldValues> {
 }
 
 type wrappedAttributes = "type" | "name" | "required";
-type internallySetAttributes = "id" | "aria-invalid" | "aria-describedby";
+type internallySetAttributes = "id" | "aria-invalid";
 
 export interface DoulaRadioProps<T extends FieldValues>
   extends Omit<RadioProps, wrappedAttributes | internallySetAttributes> {
@@ -29,9 +29,9 @@ export interface DoulaRadioProps<T extends FieldValues>
   label: React.ReactNode;
   required?: boolean;
   options: Array<DoulaRadioOption<T>>;
-  customErrorMessages?: Array<CustomErrorMessage>;
   errors?: FieldErrors<T>;
   register: UseFormRegister<T>;
+  customErrorMessages?: Array<CustomErrorMessage>;
 }
 
 const getLegend = (label: React.ReactNode, isRequired: boolean | undefined) => {
@@ -53,17 +53,18 @@ const DoulaRadio = <T extends FieldValues>(props: DoulaRadioProps<T>) => {
     name,
     value,
     label,
+    "aria-describedby": ariaDescribedby,
     required,
     options,
-    customErrorMessages,
     errors,
     register,
+    customErrorMessages,
     ...otherProps
   } = props;
 
   const hasError = errors !== undefined && errors[name] !== undefined;
   const internallySetProps: Partial<RadioProps> = {};
-  const describedby = formatDescribedBy(name, errors, undefined);
+  const describedby = formatDescribedBy(name, errors, undefined, ariaDescribedby);
   if (describedby !== "") {
     internallySetProps["aria-describedby"] = describedby;
   }

--- a/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
@@ -43,6 +43,22 @@ describe("DoulaTextInput", () => {
     expect(input).toHaveAccessibleDescription("Test hint");
   });
 
+  it("it describes the input with the provided describedby", () => {
+    render(
+      <>
+        <DoulaTextInput
+          name="testInput"
+          label="Test label"
+          aria-describedby="anotherDescriptonID"
+          register={jest.fn()}
+        />
+        <span id="anotherDescriptonID">Additional description</span>
+      </>,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toHaveAccessibleDescription("Additional description");
+  });
+
   it("shows an error message and sets appropriate attributes when there is an error for the input", () => {
     render(
       <DoulaTextInput
@@ -66,6 +82,40 @@ describe("DoulaTextInput", () => {
     expect(input).toHaveAttribute("aria-invalid", "true");
   });
 
+  it("shows a custom error message if provided", async () => {
+    render(
+      <DoulaTextInput
+        name="testInput"
+        label="Test label"
+        required
+        errors={{
+          testInput: {
+            type: "required",
+            message: "This field is required",
+          },
+        }}
+        register={jest.fn()}
+        registerOptions={{
+          required: "This field is required",
+        }}
+        customErrorMessages={[
+          {
+            type: "required",
+            message: (
+              <div>
+                Fancy error <span>message</span>
+              </div>
+            ),
+          },
+        ]}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAccessibleDescription("Fancy error message");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
   it("does not show an error message if there is no error for the input", () => {
     render(
       <DoulaTextInput<{ testInput: string; otherInput: string }>
@@ -85,26 +135,33 @@ describe("DoulaTextInput", () => {
     expect(input).not.toHaveAttribute("aria-describedby");
   });
 
-  it("describes the input with both the hint and the error message when both are present", () => {
+  it("describes the input with the hint, the error message, and the aria-describedby when all are present", () => {
     render(
-      <DoulaTextInput
-        name="testInput"
-        label="Test label"
-        hint="Test hint"
-        required
-        errors={{
-          testInput: {
-            type: "required",
-            message: "This field is required",
-          },
-        }}
-        register={jest.fn()}
-        registerOptions={{
-          required: "This field is required",
-        }}
-      />,
+      <>
+        <DoulaTextInput
+          name="testInput"
+          label="Test label"
+          hint="Test hint"
+          aria-describedby="anotherDescriptonID"
+          required
+          errors={{
+            testInput: {
+              type: "required",
+              message: "This field is required",
+            },
+          }}
+          register={jest.fn()}
+          registerOptions={{
+            required: "This field is required",
+          }}
+        />
+        <span id="anotherDescriptonID">Additional description</span>
+      </>,
     );
     const input = screen.getByRole("textbox", { name: "Test label *" });
-    expect(input).toHaveAccessibleDescription("This field is required Test hint");
+    expect(input).toHaveAccessibleDescription(
+      "This field is required Test hint Additional description",
+    );
+    expect(input).toHaveAttribute("aria-invalid", "true");
   });
 });

--- a/src/app/form/(formSteps)/components/DoulaTextInput.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.tsx
@@ -1,4 +1,7 @@
-import { ErrorMessage } from "@/app/form/(formSteps)/components/ErrorMessage";
+import {
+  ErrorMessage,
+  type CustomErrorMessage,
+} from "@/app/form/(formSteps)/components/ErrorMessage";
 import { Hint } from "@/app/form/(formSteps)/components/Hint";
 import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
 import {
@@ -16,7 +19,7 @@ import type {
 } from "react-hook-form";
 
 type wrappedAttributes = "type" | "name" | "required";
-type internallySetAttributes = "id" | "validationStatus" | "aria-invalid" | "aria-describedby";
+type internallySetAttributes = "id" | "validationStatus" | "aria-invalid";
 
 interface DoulaTextInputProps<T extends FieldValues>
   extends Omit<TextInputProps, wrappedAttributes | internallySetAttributes> {
@@ -29,6 +32,7 @@ interface DoulaTextInputProps<T extends FieldValues>
   errors?: FieldErrors<T>;
   register: UseFormRegister<T>;
   registerOptions?: RegisterOptions<T>;
+  customErrorMessages?: Array<CustomErrorMessage>;
 }
 
 const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) => {
@@ -37,18 +41,20 @@ const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) =>
     label,
     hint,
     type,
+    "aria-describedby": ariaDescribedby,
     required,
     errors,
     hideErrorMessage,
     register,
     registerOptions,
+    customErrorMessages,
     ...otherProps
   } = props;
 
   const hasError = errors !== undefined && errors[name] !== undefined;
   const internallySetProps: Partial<TextInputProps> = {};
 
-  const describedby = formatDescribedBy(name, errors, hint);
+  const describedby = formatDescribedBy(name, errors, hint, ariaDescribedby);
   if (describedby !== "") {
     internallySetProps["aria-describedby"] = describedby;
   }
@@ -73,7 +79,9 @@ const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) =>
         {...otherProps}
         {...register(name, registerOptions)}
       />
-      {hasError && hideErrorMessage !== true && <ErrorMessage name={name} errors={errors} />}
+      {hasError && hideErrorMessage !== true && (
+        <ErrorMessage name={name} errors={errors} customErrorMessages={customErrorMessages} />
+      )}
     </>
   );
 };

--- a/src/app/form/(formSteps)/components/DoulaTextInputMask.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInputMask.test.tsx
@@ -62,6 +62,25 @@ describe("DoulaTextInputMask", () => {
     expect(input).toHaveAccessibleDescription("Test hint");
   });
 
+  it("it describes the input with the provided describedby", () => {
+    render(
+      <>
+        <DoulaTextInputMask
+          name="testInput"
+          label="Test label"
+          aria-describedby="anotherDescriptonID"
+          inputMode="numeric"
+          mask="___-___-____"
+          pattern="\d{3}-\d{3}-\d{4}"
+          register={jest.fn()}
+        />
+        <span id="anotherDescriptonID">Additional description</span>
+      </>,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toHaveAccessibleDescription("Additional description");
+  });
+
   it("shows an error message and sets appropriate attributes when there is an error for the input", () => {
     render(
       <DoulaTextInputMask
@@ -88,6 +107,43 @@ describe("DoulaTextInputMask", () => {
     expect(input).toHaveAttribute("aria-invalid", "true");
   });
 
+  it("shows a custom error message if provided", async () => {
+    render(
+      <DoulaTextInputMask
+        name="testInput"
+        label="Test label"
+        inputMode="numeric"
+        mask="___-___-____"
+        pattern="\d{3}-\d{3}-\d{4}"
+        required
+        errors={{
+          testInput: {
+            type: "required",
+            message: "This field is required",
+          },
+        }}
+        register={jest.fn()}
+        registerOptions={{
+          required: "This field is required",
+        }}
+        customErrorMessages={[
+          {
+            type: "required",
+            message: (
+              <div>
+                Fancy error <span>message</span>
+              </div>
+            ),
+          },
+        ]}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAccessibleDescription("Fancy error message");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
   it("it does not show an error message if there is no error for the input", () => {
     render(
       <DoulaTextInputMask<{ testInput: string; otherInput: string }>
@@ -110,29 +166,63 @@ describe("DoulaTextInputMask", () => {
     expect(input).not.toHaveAttribute("aria-describedby");
   });
 
-  it("describes the input with both the hint and the error message when both are present", () => {
+  it("describes the input with the hint, the error message, and the aria-describedby when all are present", () => {
     render(
-      <DoulaTextInputMask
-        name="testInput"
-        label="Test label"
-        hint="Test hint"
-        inputMode="numeric"
-        mask="___-___-____"
-        pattern="\d{3}-\d{3}-\d{4}"
-        required
-        errors={{
-          testInput: {
-            type: "required",
-            message: "This field is required",
-          },
-        }}
-        register={jest.fn()}
-        registerOptions={{
-          required: "This field is required",
-        }}
-      />,
+      <>
+        <DoulaTextInputMask
+          name="testInput"
+          label="Test label"
+          inputMode="numeric"
+          mask="___-___-____"
+          pattern="\d{3}-\d{3}-\d{4}"
+          required
+          errors={{
+            testInput: {
+              type: "required",
+              message: "This field is required",
+            },
+          }}
+          register={jest.fn()}
+          registerOptions={{
+            required: "This field is required",
+          }}
+        />
+      </>,
     );
     const input = screen.getByRole("textbox", { name: "Test label *" });
-    expect(input).toHaveAccessibleDescription("This field is required Test hint");
+    expect(input).toHaveAccessibleDescription("This field is required");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("describes the input with the hint, the error message, and the aria-describedby when all are present", () => {
+    render(
+      <>
+        <DoulaTextInputMask
+          name="testInput"
+          label="Test label"
+          hint="Test hint"
+          aria-describedby="anotherDescriptonID"
+          inputMode="numeric"
+          mask="___-___-____"
+          pattern="\d{3}-\d{3}-\d{4}"
+          required
+          errors={{
+            testInput: {
+              type: "required",
+              message: "This field is required",
+            },
+          }}
+          register={jest.fn()}
+          registerOptions={{
+            required: "This field is required",
+          }}
+        />
+        <span id="anotherDescriptonID">Additional description</span>
+      </>,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAccessibleDescription(
+      "This field is required Test hint Additional description",
+    );
   });
 });

--- a/src/app/form/(formSteps)/components/DoulaTextInputMask.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInputMask.tsx
@@ -1,4 +1,7 @@
-import { ErrorMessage } from "@/app/form/(formSteps)/components/ErrorMessage";
+import {
+  ErrorMessage,
+  type CustomErrorMessage,
+} from "@/app/form/(formSteps)/components/ErrorMessage";
 import { Hint } from "@/app/form/(formSteps)/components/Hint";
 import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
 import {
@@ -16,7 +19,7 @@ import type {
 } from "react-hook-form";
 
 type wrappedAttributes = "type" | "name" | "required";
-type internallySetAttributes = "id" | "validationStatus" | "aria-invalid" | "aria-describedby";
+type internallySetAttributes = "id" | "validationStatus" | "aria-invalid";
 
 interface DoulaTextInputMaskProps<T extends FieldValues>
   extends Omit<TextInputMaskProps, wrappedAttributes | internallySetAttributes> {
@@ -28,15 +31,27 @@ interface DoulaTextInputMaskProps<T extends FieldValues>
   errors?: FieldErrors<T>;
   register: UseFormRegister<T>;
   registerOptions?: RegisterOptions<T>;
+  customErrorMessages?: Array<CustomErrorMessage>;
 }
 
 const DoulaTextInputMask = <T extends FieldValues>(props: DoulaTextInputMaskProps<T>) => {
-  const { name, label, hint, type, required, errors, register, registerOptions, ...otherProps } =
-    props;
+  const {
+    name,
+    label,
+    hint,
+    type,
+    "aria-describedby": ariaDescribedby,
+    required,
+    errors,
+    register,
+    registerOptions,
+    customErrorMessages,
+    ...otherProps
+  } = props;
   const hasError = errors !== undefined && errors[name] !== undefined;
   const internallySetProps: Partial<TextInputMaskProps> = {};
 
-  const describedby = formatDescribedBy(name, errors, hint);
+  const describedby = formatDescribedBy(name, errors, hint, ariaDescribedby);
   if (describedby !== "") {
     internallySetProps["aria-describedby"] = describedby;
   }
@@ -61,7 +76,9 @@ const DoulaTextInputMask = <T extends FieldValues>(props: DoulaTextInputMaskProp
         {...otherProps}
         {...register(name, registerOptions)}
       />
-      {hasError && <ErrorMessage name={name} errors={errors} />}
+      {hasError && (
+        <ErrorMessage name={name} errors={errors} customErrorMessages={customErrorMessages} />
+      )}
     </>
   );
 };

--- a/src/app/form/(formSteps)/components/utils/doulaInput.test.ts
+++ b/src/app/form/(formSteps)/components/utils/doulaInput.test.ts
@@ -1,0 +1,77 @@
+import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
+
+describe("formatDescribedBy", () => {
+  const inputName = "testId";
+  it.each([
+    {
+      description: "there are no descriptions",
+      errors: undefined,
+      hint: undefined,
+      additionalDescriptionIds: undefined,
+      expected: "",
+    },
+    {
+      description: "there is no error for the input",
+      errors: {
+        differentInput: {
+          type: "required",
+          message: "This field is required",
+        },
+      },
+      hint: undefined,
+      additionalDescriptionIds: undefined,
+      expected: "",
+    },
+    {
+      description: "there is an error",
+      errors: {
+        testId: {
+          type: "required",
+          message: "This field is required",
+        },
+      },
+      hint: undefined,
+      additionalDescriptionIds: undefined,
+      expected: "testIdErrorMessage",
+    },
+    {
+      description: "hint is provided",
+      errors: undefined,
+      hint: "test hint",
+      additionalDescriptionIds: undefined,
+      expected: "testIdHint",
+    },
+    {
+      description: "additional description ids is provided",
+      errors: undefined,
+      hint: undefined,
+      additionalDescriptionIds: "descriptionId1 descriptionId2",
+      expected: "descriptionId1 descriptionId2",
+    },
+    {
+      description:
+        "there is an error, a hint is provided, and additional description ids is provided",
+      errors: {
+        testId: {
+          type: "required",
+          message: "This field is required",
+        },
+      },
+      hint: "test hint",
+      additionalDescriptionIds: "descriptionId1 descriptionId2",
+      expected: "testIdErrorMessage testIdHint descriptionId1 descriptionId2",
+    },
+  ])(
+    "correctly formats the description ids when $description",
+    ({ errors, hint, additionalDescriptionIds, expected }) => {
+      expect(
+        formatDescribedBy<{ testId: string; differentInput: string }>(
+          inputName,
+          errors,
+          hint,
+          additionalDescriptionIds,
+        ),
+      ).toEqual(expected);
+    },
+  );
+});

--- a/src/app/form/(formSteps)/components/utils/doulaInput.ts
+++ b/src/app/form/(formSteps)/components/utils/doulaInput.ts
@@ -12,6 +12,7 @@ export const formatDescribedBy = <T extends FieldValues>(
   name: FieldPath<T>,
   errors: FieldErrors<T> | undefined,
   hint: React.ReactNode | undefined,
+  additionalDescriptionIds: string | undefined,
 ) => {
   const describedbys = [];
   if (errors !== undefined && errors[name]) {
@@ -19,6 +20,9 @@ export const formatDescribedBy = <T extends FieldValues>(
   }
   if (hint !== undefined) {
     describedbys.push(formatHintId(name));
+  }
+  if (additionalDescriptionIds !== undefined) {
+    describedbys.push(additionalDescriptionIds);
   }
   return describedbys.join(" ");
 };

--- a/src/app/form/(formSteps)/personal-details/1/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/page.tsx
@@ -108,7 +108,7 @@ const PersonalDetailsStep1 = () => {
                   required
                   validationStatus={errors.dateOfBirthMonth ? "error" : undefined}
                   aria-invalid={errors.dateOfBirthMonth ? "true" : "false"}
-                  aria-describedby="dateOfBirthMonthErrorMessage"
+                  aria-describedby={errors.dateOfBirthMonth ? "dateOfBirthMonthErrorMessage" : ""}
                   {...register("dateOfBirthMonth", {
                     required: `${orderedInputNameToLabel["dateOfBirthMonth"]} is required`,
                   })}

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
+import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
+import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
 import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
 import FormProgressButtons from "@/app/form/(formSteps)/components/FormProgressButtons";
 import PublicInformationExplainer from "@/app/form/(formSteps)/personal-details/2/PublicInformationExplainer";
@@ -9,7 +11,7 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import { type PersonalDetails2Data } from "@form/(formSteps)/personal-details/PersonalDetailsData";
 import { AddressState } from "@form/_utils/inputFields/enums";
 import { getDefaultValue } from "@form/_utils/sessionStorage";
-import { Fieldset, Label, Select, TextInput, TextInputMask } from "@trussworks/react-uswds";
+import { Fieldset, Label, Select } from "@trussworks/react-uswds";
 import { useForm } from "react-hook-form";
 
 const orderedInputNameToLabel: { [key in keyof PersonalDetails2Data]: string } = {
@@ -73,61 +75,40 @@ const PersonalDetailsStep2 = () => {
             <Fieldset legend="Mailing address" legendStyle="srOnly">
               <div className="grid-row grid-gap">
                 <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="streetAddress1" requiredMarker>
-                    {orderedInputNameToLabel["streetAddress1"]}
-                  </Label>
-                  <TextInput
-                    id="streetAddress1"
-                    type="text"
+                  <DoulaTextInput
+                    name="streetAddress1"
+                    label={orderedInputNameToLabel["streetAddress1"]}
                     autoComplete={typecheckAutocomplete("shipping address-line1")}
                     required
-                    validationStatus={errors.streetAddress1 ? "error" : undefined}
-                    aria-invalid={errors.streetAddress1 ? "true" : "false"}
-                    aria-describedby={errors.streetAddress1 && "streetAddress1ErrorMessage"}
-                    {...register("streetAddress1", {
+                    errors={errors}
+                    register={register}
+                    registerOptions={{
                       required: `${orderedInputNameToLabel["streetAddress1"]} is required`,
-                    })}
+                    }}
                   />
-                  {errors.streetAddress1 && (
-                    <span id="streetAddress1ErrorMessage" className="usa-error-message">
-                      {errors.streetAddress1.message}
-                    </span>
-                  )}
                 </div>
                 <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="streetAddress2">
-                    {orderedInputNameToLabel["streetAddress2"]}
-                  </Label>
-                  <TextInput
-                    id="streetAddress2"
-                    type="text"
+                  <DoulaTextInput
+                    name="streetAddress2"
+                    label={orderedInputNameToLabel["streetAddress2"]}
                     autoComplete={typecheckAutocomplete("shipping address-line2")}
-                    {...register("streetAddress2")}
+                    register={register}
                   />
                 </div>
               </div>
               <div className="grid-row grid-gap">
                 <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="city" requiredMarker>
-                    {orderedInputNameToLabel["city"]}
-                  </Label>
-                  <TextInput
-                    id="city"
-                    type="text"
+                  <DoulaTextInput
+                    name="city"
+                    label={orderedInputNameToLabel["city"]}
                     autoComplete={typecheckAutocomplete("shipping address-level2")}
                     required
-                    validationStatus={errors.city ? "error" : undefined}
-                    aria-invalid={errors.city ? "true" : "false"}
-                    aria-describedby={errors.city && "cityErrorMessage"}
-                    {...register("city", {
+                    errors={errors}
+                    register={register}
+                    registerOptions={{
                       required: `${orderedInputNameToLabel["city"]} is required`,
-                    })}
+                    }}
                   />
-                  {errors.city && (
-                    <span id="cityErrorMessage" className="usa-error-message">
-                      {errors.city.message}
-                    </span>
-                  )}
                 </div>
               </div>
               <div className="grid-row grid-gap">
@@ -150,34 +131,25 @@ const PersonalDetailsStep2 = () => {
                   </Select>
                 </div>
                 <div className="mobile-lg:grid-col-4">
-                  <Label htmlFor="zip" requiredMarker>
-                    {orderedInputNameToLabel["zip"]}
-                  </Label>
-                  <TextInputMask
+                  <DoulaTextInputMask
                     className="usa-input--medium"
-                    id="zip"
-                    type="text"
+                    name="zip"
+                    label={orderedInputNameToLabel["zip"]}
                     autoComplete={typecheckAutocomplete("shipping postal-code")}
                     value={zip ?? ""}
                     mask="#####"
                     pattern="\d{5}"
                     required
-                    validationStatus={errors.zip ? "error" : undefined}
-                    aria-invalid={errors.zip ? "true" : "false"}
-                    aria-describedby={errors.zip && "zipErrorMessage"}
-                    {...register("zip", {
+                    errors={errors}
+                    register={register}
+                    registerOptions={{
                       required: `${orderedInputNameToLabel["zip"]} is required`,
                       minLength: {
                         value: 5,
                         message: `${orderedInputNameToLabel["zip"]} must have five digits`,
                       },
-                    })}
+                    }}
                   />
-                  {errors.zip && (
-                    <span id="zipErrorMessage" className="usa-error-message">
-                      {errors.zip.message}
-                    </span>
-                  )}
                 </div>
               </div>
             </Fieldset>
@@ -200,64 +172,37 @@ const PersonalDetailsStep2 = () => {
               <Fieldset legend={<p className="margin-top-5">What&apos;s your billing address?</p>}>
                 <div className="grid-row grid-gap">
                   <div className="mobile-lg:grid-col-6">
-                    <Label htmlFor="billingStreetAddress1" requiredMarker>
-                      {orderedInputNameToLabel["billingStreetAddress1"]}
-                    </Label>
-                    <TextInput
-                      id="billingStreetAddress1"
-                      type="text"
+                    <DoulaTextInput
+                      name="billingStreetAddress1"
+                      label={orderedInputNameToLabel["billingStreetAddress1"]}
                       required
-                      validationStatus={errors.billingStreetAddress1 ? "error" : undefined}
-                      aria-invalid={errors.billingStreetAddress1 ? "true" : "false"}
-                      aria-describedby={
-                        errors.billingStreetAddress1 && "billingStreetAddress1ErrorMessage"
-                      }
-                      {...register("billingStreetAddress1", {
+                      errors={errors}
+                      register={register}
+                      registerOptions={{
                         required: `Billing ${orderedInputNameToLabel["billingStreetAddress1"].toLowerCase()} is required`,
-                      })}
+                      }}
                     />
-                    {errors.billingStreetAddress1 && (
-                      <span
-                        id="billingStreetAddress1ErrorMessage"
-                        className="usa-error-message"
-                        role="alert"
-                      >
-                        {errors.billingStreetAddress1.message}
-                      </span>
-                    )}
                   </div>
                   <div className="mobile-lg:grid-col-6">
-                    <Label htmlFor="billingStreetAddress2">
-                      {orderedInputNameToLabel["billingStreetAddress2"]}
-                    </Label>
-                    <TextInput
-                      id="billingStreetAddress2"
-                      type="text"
-                      {...register("billingStreetAddress2")}
+                    <DoulaTextInput
+                      name="billingStreetAddress2"
+                      label={orderedInputNameToLabel["billingStreetAddress2"]}
+                      register={register}
                     />
                   </div>
                 </div>
                 <div className="grid-row grid-gap">
                   <div className="mobile-lg:grid-col-6">
-                    <Label htmlFor="billingCity" requiredMarker>
-                      {orderedInputNameToLabel["billingCity"]}
-                    </Label>
-                    <TextInput
-                      id="billingCity"
-                      type="text"
+                    <DoulaTextInput
+                      name="billingCity"
+                      label={orderedInputNameToLabel["billingCity"]}
                       required
-                      validationStatus={errors.billingCity ? "error" : undefined}
-                      aria-invalid={errors.billingCity ? "true" : "false"}
-                      aria-describedby={errors.billingCity && "billingCityErrorMessage"}
-                      {...register("billingCity", {
+                      errors={errors}
+                      register={register}
+                      registerOptions={{
                         required: `Billing ${orderedInputNameToLabel["billingCity"].toLowerCase()} is required`,
-                      })}
+                      }}
                     />
-                    {errors.billingCity && (
-                      <span id="billingCityErrorMessage" className="usa-error-message" role="alert">
-                        {errors.billingCity.message}
-                      </span>
-                    )}
                   </div>
                 </div>
                 <div className="grid-row grid-gap">
@@ -279,33 +224,24 @@ const PersonalDetailsStep2 = () => {
                     </Select>
                   </div>
                   <div className="mobile-lg:grid-col-4">
-                    <Label htmlFor="billingZip" requiredMarker>
-                      {orderedInputNameToLabel["billingZip"]}
-                    </Label>
-                    <TextInputMask
+                    <DoulaTextInputMask
                       className="usa-input--medium"
-                      id="billingZip"
-                      type="text"
+                      name="billingZip"
+                      label={orderedInputNameToLabel["billingZip"]}
                       value={billingZip ?? ""}
                       mask="#####"
                       pattern="\d{5}"
                       required
-                      validationStatus={errors.billingZip ? "error" : undefined}
-                      aria-invalid={errors.billingZip ? "true" : "false"}
-                      aria-describedby={errors.billingZip && "billingZipErrorMessage"}
-                      {...register("billingZip", {
+                      errors={errors}
+                      register={register}
+                      registerOptions={{
                         required: `Billing ${orderedInputNameToLabel["billingZip"].toLowerCase()} is required`,
                         minLength: {
                           value: 5,
                           message: `Billing ${orderedInputNameToLabel["billingZip"].toLowerCase()} must have five digits`,
                         },
-                      })}
+                      }}
                     />
-                    {errors.billingZip && (
-                      <span id="billingZipErrorMessage" className="usa-error-message">
-                        {errors.billingZip.message}
-                      </span>
-                    )}
                   </div>
                 </div>
               </Fieldset>

--- a/src/app/form/(formSteps)/personal-details/3/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
+import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
+import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
 import NpiExplainer from "@/app/form/(formSteps)/personal-details/3/NpiExplainer";
 import type { PersonalDetails3Data } from "@/app/form/(formSteps)/personal-details/PersonalDetailsData";
 import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { getDefaultValue } from "@form/_utils/sessionStorage";
-import { Label, TextInput, TextInputMask } from "@trussworks/react-uswds";
 import { useForm } from "react-hook-form";
 
 const orderedInputNameToLabel: { [key in keyof PersonalDetails3Data]: string } = {
@@ -45,45 +46,38 @@ const PersonalDetailsStep3 = () => {
             To be an NJ FamilyCare doula, your NPI must be Type 1 and linked to the doula taxonomy
             code 374J00000X.
           </p>
-          <Label htmlFor="npiNumber" requiredMarker>
-            {orderedInputNameToLabel["npiNumber"]}
-          </Label>
-          <div id="npiNumberHint" className="usa-hint">
-            Enter your 10-digit NPI number.
-          </div>
-          <TextInputMask
-            id="npiNumber"
-            type="text"
+          <DoulaTextInputMask
+            name="npiNumber"
+            label={orderedInputNameToLabel["npiNumber"]}
+            hint={"Enter your 10-digit NPI number."}
             value={npiNumber ?? ""}
             mask="__________"
             pattern="\d{10}"
             required
-            aria-invalid={errors.npiNumber ? "true" : "false"}
-            className={errors.npiNumber ? "usa-input--error" : ""}
-            aria-describedby={`${errors.npiNumber ? "npiNumberErrorMessage npiNumberErrorAlert" : ""} npiNumberHint`}
-            {...register("npiNumber", {
+            errors={errors}
+            register={register}
+            registerOptions={{
               required: true,
               minLength: {
                 value: 10,
                 message: `${orderedInputNameToLabel["npiNumber"]} must have 10 digits`,
               },
-            })}
+            }}
+            customErrorMessages={[
+              {
+                type: "required",
+                message: (
+                  <span>
+                    To be an NJ FamilyCare doula, your need a NPI. You can get yours via{" "}
+                    <a href="https://nppes.cms.hhs.gov/" target="_blank" rel="noopener">
+                      https://nppes.cms.hhs.gov/
+                    </a>
+                    .
+                  </span>
+                ),
+              },
+            ]}
           />
-          {errors.npiNumber && (
-            <span id="npiNumberErrorMessage" className="usa-error-message">
-              {errors.npiNumber?.type === "required" ? (
-                <span>
-                  To be an NJ FamilyCare doula, your need a NPI. You can get yours via{" "}
-                  <a href="https://nppes.cms.hhs.gov/" target="_blank" rel="noopener">
-                    https://nppes.cms.hhs.gov/
-                  </a>
-                  .
-                </span>
-              ) : (
-                errors.npiNumber.message
-              )}
-            </span>
-          )}
         </div>
         <div className="form-explainer desktop:grid-col-4">
           <NpiExplainer />
@@ -94,29 +88,17 @@ const PersonalDetailsStep3 = () => {
         <div className="desktop:grid-col-8">
           <h2 className="font-heading-md">Other identification</h2>
           <p>Leave non-applicable items blank; it won&apos;t affect your application.</p>
-          <Label htmlFor="upinNumber">{orderedInputNameToLabel["upinNumber"]} (optional)</Label>
-          <div id="upinNumberHint" className="usa-hint">
-            Most doulas don&apos;t have this.
-          </div>
-          <TextInput
-            type="text"
-            id="upinNumber"
-            inputMode="text"
-            aria-describedby="upinNumberHint"
-            {...register("upinNumber")}
+          <DoulaTextInput
+            name="upinNumber"
+            label={`${orderedInputNameToLabel["upinNumber"]} (optional)`}
+            hint={"Most doulas don't have this."}
+            register={register}
           />
-          <Label htmlFor="medicareProviderId">
-            {orderedInputNameToLabel["medicareProviderId"]} (optional)
-          </Label>
-          <div id="medicareProviderIdHint" className="usa-hint">
-            Most doulas don&apos;t have this.
-          </div>
-          <TextInput
-            type="text"
-            id="medicareProviderId"
-            inputMode="text"
-            aria-describedby="medicareProviderIdHint"
-            {...register("medicareProviderId")}
+          <DoulaTextInput
+            name="medicareProviderId"
+            label={`${orderedInputNameToLabel["medicareProviderId"]} (optional)`}
+            hint={"Most doulas don't have this."}
+            register={register}
           />
         </div>
       </div>

--- a/src/app/form/(formSteps)/training/1/page.tsx
+++ b/src/app/form/(formSteps)/training/1/page.tsx
@@ -2,20 +2,14 @@
 
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import DoulaRadio from "@/app/form/(formSteps)/components/DoulaRadio";
+import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
+import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
 import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import type { TrainingData } from "@form/(formSteps)/training/TrainingData";
 import { AddressState, StateApprovedTraining } from "@form/_utils/inputFields/enums";
 import { getDefaultValue } from "@form/_utils/sessionStorage";
-import {
-  Alert,
-  Fieldset,
-  Label,
-  RequiredMarker,
-  Select,
-  TextInput,
-  TextInputMask,
-} from "@trussworks/react-uswds";
+import { Alert, Fieldset, Label, RequiredMarker, Select } from "@trussworks/react-uswds";
 import { type FieldPath, useForm } from "react-hook-form";
 import DoulaTrainingExplainer from "./DoulaTrainingExplainer";
 
@@ -100,31 +94,18 @@ const TrainingStep1 = () => {
           </Select>
           {stateApprovedTraining === StateApprovedTraining.NONE && (
             <div>
-              <Label htmlFor="nameOfTrainingOrganization" requiredMarker>
-                {orderedInputNameToLabel["nameOfTrainingOrganization"]}
-              </Label>
-              <TextInput
+              <DoulaTextInput
+                name="nameOfTrainingOrganization"
+                label={orderedInputNameToLabel["nameOfTrainingOrganization"]}
                 className="tablet:grid-col-6"
-                id="nameOfTrainingOrganization"
-                type="text"
                 required
-                validationStatus={errors.nameOfTrainingOrganization ? "error" : undefined}
-                aria-invalid={errors.nameOfTrainingOrganization ? "true" : "false"}
-                aria-describedby={`${errors.nameOfTrainingOrganization ? "nameOfTrainingOrganizationErrorMessage" : ""} nameOfTrainingOrganizationAlert`}
-                {...register("nameOfTrainingOrganization", {
+                aria-describedby="nameOfTrainingOrganizationAlert"
+                errors={errors}
+                register={register}
+                registerOptions={{
                   required: `This question is required`,
-                })}
+                }}
               />
-              {errors.nameOfTrainingOrganization && (
-                <span
-                  id="nameOfTrainingOrganizationErrorMessage"
-                  className="usa-error-message"
-                  role="alert"
-                >
-                  {errors.nameOfTrainingOrganization.message}
-                </span>
-              )}
-
               <Alert id="nameOfTrainingOrganizationAlert" type="info" headingLevel="h3" noIcon>
                 If your training organization isn&apos;t listed, you may not be eligible to apply
                 right now. Contact the Doula Guides at mahs.doulaguide@dhs.nj.gov to learn more.
@@ -170,64 +151,38 @@ const TrainingStep1 = () => {
             >
               <div className="grid-row grid-gap">
                 <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="trainingStreetAddress1" requiredMarker>
-                    {orderedInputNameToLabel["trainingStreetAddress1"]}
-                  </Label>
-                  <TextInput
-                    id="trainingStreetAddress1"
-                    type="text"
+                  <DoulaTextInput
+                    name="trainingStreetAddress1"
+                    label={orderedInputNameToLabel["trainingStreetAddress1"]}
                     required
-                    validationStatus={errors.trainingStreetAddress1 ? "error" : undefined}
-                    aria-invalid={errors.trainingStreetAddress1 ? "true" : "false"}
-                    aria-describedby={
-                      errors.trainingStreetAddress1 && "trainingStreetAddress1ErrorMessage"
-                    }
-                    {...register("trainingStreetAddress1", {
+                    errors={errors}
+                    register={register}
+                    registerOptions={{
                       required: `Training ${orderedInputNameToLabel["trainingStreetAddress1"].toLowerCase()} is required`,
-                    })}
+                    }}
                   />
-                  {errors.trainingStreetAddress1 && (
-                    <span
-                      id="trainingStreetAddress1ErrorMessage"
-                      className="usa-error-message"
-                      role="alert"
-                    >
-                      {errors.trainingStreetAddress1.message}
-                    </span>
-                  )}
                 </div>
                 <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="trainingStreetAddress2">
-                    {orderedInputNameToLabel["trainingStreetAddress2"]}
-                  </Label>
-                  <TextInput
-                    id="trainingStreetAddress2"
-                    type="text"
-                    {...register("trainingStreetAddress2")}
+                  <DoulaTextInput
+                    name="trainingStreetAddress2"
+                    label={orderedInputNameToLabel["trainingStreetAddress2"]}
+                    errors={errors}
+                    register={register}
                   />
                 </div>
               </div>
               <div className="grid-row grid-gap">
                 <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="trainingCity" requiredMarker>
-                    {orderedInputNameToLabel["trainingCity"]}
-                  </Label>
-                  <TextInput
-                    id="trainingCity"
-                    type="text"
+                  <DoulaTextInput
+                    name="trainingCity"
+                    label={orderedInputNameToLabel["trainingCity"]}
                     required
-                    validationStatus={errors.trainingCity ? "error" : undefined}
-                    aria-invalid={errors.trainingCity ? "true" : "false"}
-                    aria-describedby={errors.trainingCity && "trainingCityErrorMessage"}
-                    {...register("trainingCity", {
+                    errors={errors}
+                    register={register}
+                    registerOptions={{
                       required: `Training ${orderedInputNameToLabel["trainingCity"].toLowerCase()} is required`,
-                    })}
+                    }}
                   />
-                  {errors.trainingCity && (
-                    <span id="trainingCityErrorMessage" className="usa-error-message" role="alert">
-                      {errors.trainingCity.message}
-                    </span>
-                  )}
                 </div>
               </div>
               <div className="grid-row grid-gap">
@@ -249,33 +204,24 @@ const TrainingStep1 = () => {
                   </Select>
                 </div>
                 <div className="mobile-lg:grid-col-4">
-                  <Label htmlFor="trainingZip" requiredMarker>
-                    {orderedInputNameToLabel["trainingZip"]}
-                  </Label>
-                  <TextInputMask
+                  <DoulaTextInputMask
+                    name="trainingZip"
+                    label={orderedInputNameToLabel["trainingZip"]}
                     className="usa-input--medium"
-                    id="trainingZip"
-                    type="text"
                     value={trainingZip ?? ""}
                     mask="#####"
                     pattern="\d{5}"
                     required
-                    validationStatus={errors.trainingZip ? "error" : undefined}
-                    aria-invalid={errors.trainingZip ? "true" : "false"}
-                    aria-describedby={errors.trainingZip && "trainingZipErrorMessage"}
-                    {...register("trainingZip", {
+                    errors={errors}
+                    register={register}
+                    registerOptions={{
                       required: `Training ${orderedInputNameToLabel["trainingZip"].toLowerCase()} is required`,
                       minLength: {
                         value: 5,
                         message: `Training ${orderedInputNameToLabel["trainingZip"].toLowerCase()} must have five digits`,
                       },
-                    })}
+                    }}
                   />
-                  {errors.trainingZip && (
-                    <span id="trainingZipErrorMessage" className="usa-error-message">
-                      {errors.trainingZip.message}
-                    </span>
-                  )}
                 </div>
               </div>
             </Fieldset>
@@ -290,106 +236,70 @@ const TrainingStep1 = () => {
 
           <div className="grid-row grid-gap">
             <div className="tablet:grid-col-6">
-              <Label htmlFor="instructorFirstName" requiredMarker>
-                {orderedInputNameToLabel["instructorFirstName"]}
-              </Label>
-              <TextInput
-                id="instructorFirstName"
-                type="text"
+              <DoulaTextInput
+                name="instructorFirstName"
+                label={orderedInputNameToLabel["instructorFirstName"]}
                 required
-                validationStatus={errors.instructorFirstName ? "error" : undefined}
-                aria-invalid={errors.instructorFirstName ? "true" : "false"}
-                aria-describedby={errors.instructorFirstName && "instructorFirstNameErrorMessage"}
-                {...register("instructorFirstName", {
+                errors={errors}
+                register={register}
+                registerOptions={{
                   required: `${orderedInputNameToLabel["instructorFirstName"]} is required`,
-                })}
+                }}
               />
-              {errors.instructorFirstName && (
-                <span id="instructorFirstNameErrorMessage" className="usa-error-message">
-                  {errors.instructorFirstName.message}
-                </span>
-              )}
             </div>
             <div className="tablet:grid-col-6">
-              <Label htmlFor="instructorLastName" requiredMarker>
-                {orderedInputNameToLabel["instructorLastName"]}
-              </Label>
-              <TextInput
-                id="instructorLastName"
-                type="text"
+              <DoulaTextInput
+                name="instructorLastName"
+                label={orderedInputNameToLabel["instructorLastName"]}
                 required
-                validationStatus={errors.instructorLastName ? "error" : undefined}
-                aria-invalid={errors.instructorLastName ? "true" : "false"}
-                aria-describedby={errors.instructorLastName && "instructorLastNameErrorMessage"}
-                {...register("instructorLastName", {
+                errors={errors}
+                register={register}
+                registerOptions={{
                   required: `${orderedInputNameToLabel["instructorLastName"]} is required`,
-                })}
+                }}
               />
-              {errors.instructorLastName && (
-                <span id="instructorLastNameErrorMessage" className="usa-error-message">
-                  {errors.instructorLastName.message}
-                </span>
-              )}
             </div>
           </div>
           <div className="grid-row grid-gap">
             <div className="tablet:grid-col-6">
-              <Label htmlFor="instructorEmail" requiredMarker>
-                {orderedInputNameToLabel["instructorEmail"]}
-              </Label>
-              <TextInput
-                id="instructorEmail"
+              <DoulaTextInput
+                name="instructorEmail"
+                label={orderedInputNameToLabel["instructorEmail"]}
                 autoCorrect="off"
                 autoCapitalize="off"
                 required
-                validationStatus={errors.instructorEmail ? "error" : undefined}
-                aria-invalid={errors.instructorEmail ? "true" : "false"}
-                aria-describedby={errors.instructorEmail && "instructorEmailErrorMessage"}
-                {...register("instructorEmail", {
+                errors={errors}
+                register={register}
+                registerOptions={{
                   required: `${orderedInputNameToLabel["instructorEmail"]} is required`,
                   pattern: {
                     value: /\S+@\S+\.\S+/,
                     message: "Entered value does not match email format",
                   },
-                })}
+                }}
                 type="email"
               />
-              {errors.instructorEmail && (
-                <span id="instructorEmailErrorMessage" className="usa-error-message">
-                  {errors.instructorEmail.message}
-                </span>
-              )}
             </div>
           </div>
           <div className="grid-row grid-gap">
             <div className="tablet:grid-col-6">
-              <Label htmlFor="instructorPhoneNumber">
-                {orderedInputNameToLabel["instructorPhoneNumber"]}
-              </Label>
-              <TextInputMask
-                id="instructorPhoneNumber"
+              <DoulaTextInputMask
+                name="instructorPhoneNumber"
+                label={orderedInputNameToLabel["instructorPhoneNumber"]}
                 type="tel"
                 value={instructorPhoneNumber ?? ""}
                 inputMode="numeric"
                 mask="___-___-____"
                 pattern="\d{3}-\d{3}-\d{4}"
-                validationStatus={errors.instructorPhoneNumber ? "error" : undefined}
-                aria-invalid={errors.instructorPhoneNumber ? "true" : "false"}
-                aria-describedby={
-                  errors.instructorPhoneNumber && "instructorPhoneNumberErrorMessage"
-                }
-                {...register("instructorPhoneNumber", {
+                errors={errors}
+                register={register}
+                registerOptions={{
                   pattern: {
                     value: /\d{3}-\d{3}-\d{4}/,
                     message: "Entered value does not match phone number format",
                   },
-                })}
+                }}
               />
-              {errors.instructorPhoneNumber && (
-                <span id="instructorPhoneNumberErrorMessage" className="usa-error-message">
-                  {errors.instructorPhoneNumber.message}
-                </span>
-              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Link to issue

This commit resolves #[220](https://github.com/newjersey/doula-pm/issues/220).

## What was done?
This commit:
1. Adds the following features to the reusable `DoulaTextInput`, `DoulaTextInputMask`, and `DoulaRadio` components
    - Add to the ability to provide an additional aria-describedby
    - Add support in `DoulaTextInput` and `DoulaTextInputMask` for custom error messages, which `DoulaRadio` already did
2. Updates all pages to use the `DoulaTextInput` and `DoulaTextInputMask` components

It also fixes the broken aria-describedby on date of birth month when the input has no error.

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/, and test it out with and without a screenreader. There are no feature changes, the website should work with appropriate error messages, labels, and descriptions