### PR TITLE
[newjersey/doula-pm#204] Fix ErrorSummary padding

### DIFF
--- a/src/app/form/components/DoulaForm.tsx
+++ b/src/app/form/components/DoulaForm.tsx
@@ -78,7 +78,7 @@ export const DoulaForm = <T extends FieldValues>(props: DoulaFormProps<T>) => {
       {isDataLoaded && (
         <Form onSubmit={onSubmitHandler} className="maxw-full" noValidate>
           {props.mayHaveThreeOrMoreErrors && (
-            <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
+            <div className={`grid-row grid-gap-3 ${shouldSummarizeErrors && "margin-top-3"}`}>
               <div className="desktop:grid-col-8">
                 <ErrorSummary<T>
                   shouldSummarizeErrors={shouldSummarizeErrors}


### PR DESCRIPTION
## Link to issue

This commit resolves #[204](https://github.com/newjersey/doula-pm/issues/204).

## What was done?
This commit fixes excessive padding at the top of the form when the form may have an error summary but the error summary is not shown. Per our [CSS layout guidelines](https://docs.google.com/document/d/1vbU6yRzLMM2wPBbZVFdUbjNEscmwzIxK0F65qFXLIHs/edit?tab=t.vgvdvraykpa#heading=h.tpngmvy1a2d), it keeps a consistent ~2.5em margin on the top of form parts.

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/form/personal-details/2

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

Without error summary:
<img width="2564" height="2292" alt="main d20cvhuc4595ep amplifyapp com_form_personal-details_2 (3)" src="https://github.com/user-attachments/assets/3b5b2e1b-50aa-4aac-ab21-e96b30cf5e08" />


With error summary:
<img width="2564" height="2860" alt="main d20cvhuc4595ep amplifyapp com_form_personal-details_2 (4)" src="https://github.com/user-attachments/assets/68409958-9053-4549-bdb6-80d593e3c656" />

</details>


<details>
<summary>After</summary>
Without error summary:
<img width="2564" height="2212" alt="localhost_3000_form_personal-details_2 (5)" src="https://github.com/user-attachments/assets/a9eb2b9d-9152-4a15-97a6-3f2c156a305c" />


With error summary:
<img width="2564" height="2828" alt="localhost_3000_form_personal-details_2 (4)" src="https://github.com/user-attachments/assets/e184e831-cf84-46c1-a8d1-e9cb8896d6ac" />


</details>