### PR TITLE
[newjersey/doula-pm#206] Prefactor for whether a user is a supported sole proprietor

### DIFF
--- a/src/app/form/(formSteps)/screening/ScreeningData.test.ts
+++ b/src/app/form/(formSteps)/screening/ScreeningData.test.ts
@@ -3,15 +3,14 @@ import {
   setInSessionStorage,
   setRequiredFieldsInSessionStorage,
 } from "@/app/form/_utils/fillPdf/testUtils/formData";
-import { DisclosingEntity } from "@/app/form/_utils/inputFields/enums";
 
 describe("getScreeningFormData", () => {
   describe("disclosing entity handling", () => {
-    it("sets natureOfDisclosingEntity to SoleProprietor when isSoleProprietor is true", async () => {
+    it("sets isSupportedSoleProprietor to true when isSoleProprietor is true", async () => {
       setRequiredFieldsInSessionStorage();
       setInSessionStorage({ isSoleProprietor: "true" });
       expect(getScreeningFormData()).toMatchObject({
-        natureOfDisclosingEntity: DisclosingEntity.SoleProprietor,
+        isSupportedSoleProprietor: true,
       });
     });
 

--- a/src/app/form/(formSteps)/screening/ScreeningData.ts
+++ b/src/app/form/(formSteps)/screening/ScreeningData.ts
@@ -1,4 +1,3 @@
-import { DisclosingEntity } from "@/app/form/_utils/inputFields/enums";
 import { getBoolean, ValueNotFoundError } from "@/app/form/_utils/sessionStorage";
 
 export interface Screening1Data {
@@ -6,7 +5,7 @@ export interface Screening1Data {
 }
 
 export interface ScreeningFormData {
-  natureOfDisclosingEntity: DisclosingEntity.SoleProprietor;
+  isSupportedSoleProprietor: boolean;
 }
 
 export const getScreeningFormData = (): ScreeningFormData => {
@@ -15,6 +14,6 @@ export const getScreeningFormData = (): ScreeningFormData => {
     throw new ValueNotFoundError(`Expected isSoleProprietor to be true, was ${isSoleProprietor}`);
   }
   return {
-    natureOfDisclosingEntity: DisclosingEntity.SoleProprietor,
+    isSupportedSoleProprietor: true,
   };
 };

--- a/src/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual.test.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual";
 import { generateFormData } from "@/app/form/_utils/fillPdf/testUtils/formData";
 import { type FormData } from "@form/_utils/fillPdf/form";
-import { AddressState, DisclosingEntity } from "@form/_utils/inputFields/enums";
+import { AddressState } from "@form/_utils/inputFields/enums";
 
 describe("mapFfsIndividualFields", () => {
   const testedFormKeys = new Set<string>([]);
@@ -482,7 +482,7 @@ describe("mapFfsIndividualFields", () => {
     describe("when disclosing entity is Sole Proprietorship and business address is the same as mailing address", () => {
       it("fills the page 16 fields", () => {
         const formData: FormData = generateFormData({
-          natureOfDisclosingEntity: DisclosingEntity.SoleProprietor,
+          isSupportedSoleProprietor: true,
           firstName: "First",
           middleName: "Middle",
           lastName: "Last",
@@ -516,7 +516,7 @@ describe("mapFfsIndividualFields", () => {
     describe("when disclosing entity is Sole Proprietorship and business address is different from mailing address", () => {
       it("fills the page 16 fields", () => {
         const formData: FormData = generateFormData({
-          natureOfDisclosingEntity: DisclosingEntity.SoleProprietor,
+          isSupportedSoleProprietor: true,
           firstName: "First",
           middleName: "Middle",
           lastName: "Last",

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page16.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page16.ts
@@ -3,7 +3,6 @@ import {
   formatBusinessAddressLine3,
   formatName,
 } from "@/app/form/_utils/fillPdf/formatters";
-import { DisclosingEntity } from "@/app/form/_utils/inputFields/enums";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
 // Page 16 - disclosure of ownership and control interest statement
@@ -31,7 +30,7 @@ export interface PdfFfsIndividualPage16 {
 }
 
 export const getPage16Fields = (formData: FormData): Partial<PdfFfsIndividualPage16> => {
-  if (formData.natureOfDisclosingEntity == DisclosingEntity.SoleProprietor) {
+  if (formData.isSupportedSoleProprietor === true) {
     const soleProprietorFields = {
       "fd452disclosingentitySole Proprietorship": true,
       fd452nameofdisclosingentity: formatName(formData),

--- a/src/app/form/_utils/fillPdf/testUtils/formData.ts
+++ b/src/app/form/_utils/fillPdf/testUtils/formData.ts
@@ -1,4 +1,4 @@
-import { AddressState, DisclosingEntity } from "@/app/form/_utils/inputFields/enums";
+import { AddressState } from "@/app/form/_utils/inputFields/enums";
 import type { SessionStorageKey } from "@/app/form/_utils/sessionStorage";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
@@ -42,7 +42,7 @@ const defaultFormData = {
   billingCity: null,
   billingState: null,
   billingZip: null,
-  natureOfDisclosingEntity: DisclosingEntity.SoleProprietor,
+  isSupportedSoleProprietor: true,
   hasSameBusinessAddress: true,
   businessStreetAddress1: null,
   businessStreetAddress2: null,

--- a/src/app/form/_utils/inputFields/enums.ts
+++ b/src/app/form/_utils/inputFields/enums.ts
@@ -1,7 +1,3 @@
-export enum DisclosingEntity {
-  "SoleProprietor" = "SoleProprietor",
-}
-
 export enum AddressState {
   "AL" = "AL",
   "AK" = "AK",


### PR DESCRIPTION
## Link to issue

This commit contributes to #[206](https://github.com/newjersey/doula-pm/issues/206).

## What was done?
In anticipation of screening page 2, we expect to have 5 questions that collectively determine whether a user is a supported sole proprietor. If they are, then a bunch of pdf fields should be filled.

The current code just stores whether the user is a sole proprietor. Screening pages 2 and 3 expect to add these 4 additional questions that determine whether a user is "supported".

This commit refactors the `natureOfDisclosingEntity` enum property on `FormData`, to instead be a boolean `isSupportedSoleProprietor` property.

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- No feature changes. One should be able to click through the form, and download a pdf with the sole proprietor box on pg16 checked.