### PR TITLE
[newjersey/doula-pm#206] Screening page 2 part 1

### DIFF
--- a/src/app/form/(formSteps)/screening/1/ScreeningStep1.test.tsx
+++ b/src/app/form/(formSteps)/screening/1/ScreeningStep1.test.tsx
@@ -5,26 +5,6 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
-const getYesSoleProprietorButton = () => {
-  const soleProprietorGroup = screen.getByRole("group", {
-    name: "Do you manage your business as an individual doula operating as a Sole Proprietor? Most NJ FamilyCare doulas operate as Sole Proprietor. Select one *",
-  });
-  const yesSoleProprietorButton = within(soleProprietorGroup).getByRole("radio", {
-    name: "Yes",
-  });
-  return yesSoleProprietorButton;
-};
-
-const getNoSoleProprietorButton = () => {
-  const soleProprietorGroup = screen.getByRole("group", {
-    name: "Do you manage your business as an individual doula operating as a Sole Proprietor? Most NJ FamilyCare doulas operate as Sole Proprietor. Select one *",
-  });
-  const noSoleProprietorButton = within(soleProprietorGroup).getByRole("radio", {
-    name: "No",
-  });
-  return noSoleProprietorButton;
-};
-
 describe("<ScreeningStep1 />", () => {
   const renderWithRouter = () => {
     const mockRouter: Partial<AppRouterInstance> = {
@@ -42,11 +22,15 @@ describe("<ScreeningStep1 />", () => {
   it("saves isSoleProprietor as true when user selects yes for sole proprietor and clicks Next", async () => {
     const user = userEvent.setup();
     const mockRouter = renderWithRouter();
-    const yesSoleProprietorButton = getYesSoleProprietorButton();
-    expect(yesSoleProprietorButton).not.toBeChecked();
-    await user.click(yesSoleProprietorButton);
-    expect(yesSoleProprietorButton).toBeChecked();
-
+    const questionGroup = screen.getByRole("group", {
+      name: "Do you manage your business as an individual doula operating as a Sole Proprietor? Most NJ FamilyCare doulas operate as Sole Proprietor. Select one *",
+    });
+    const yesButton = within(questionGroup).getByRole("radio", {
+      name: "Yes",
+    });
+    expect(yesButton).not.toBeChecked();
+    await user.click(yesButton);
+    expect(yesButton).toBeChecked();
     await user.click(screen.getByRole("button", { name: "Next" }));
 
     expect(getValue("isSoleProprietor", true)).toBe("true");
@@ -57,16 +41,23 @@ describe("<ScreeningStep1 />", () => {
   it("shows an error message when user selects no for sole proprietor and clicks Next", async () => {
     const user = userEvent.setup();
     const mockRouter = renderWithRouter();
-    const noSoleProprietorButton = getNoSoleProprietorButton();
-    expect(noSoleProprietorButton).not.toBeChecked();
-    await user.click(noSoleProprietorButton);
-    expect(noSoleProprietorButton).toBeChecked();
 
+    const questionGroup = screen.getByRole("group", {
+      name: "Do you manage your business as an individual doula operating as a Sole Proprietor? Most NJ FamilyCare doulas operate as Sole Proprietor. Select one *",
+    });
+    const noButton = within(questionGroup).getByRole("radio", {
+      name: "No",
+    });
+    expect(noButton).not.toBeChecked();
+    await user.click(noButton);
+    expect(noButton).toBeChecked();
     await user.click(screen.getByRole("button", { name: "Next" }));
 
-    const yesSoleProprietorButton = getYesSoleProprietorButton();
-    expect(yesSoleProprietorButton).toHaveFocus();
-    expect(yesSoleProprietorButton).toHaveAccessibleDescription(
+    const yesButton = within(questionGroup).getByRole("radio", {
+      name: "Yes",
+    });
+    expect(yesButton).toHaveFocus();
+    expect(yesButton).toHaveAccessibleDescription(
       expect.stringContaining(
         "Currently this site is only for Sole Proprietors. Please use the standard FFS application",
       ),

--- a/src/app/form/(formSteps)/screening/2/ScreeningStep2.test.tsx
+++ b/src/app/form/(formSteps)/screening/2/ScreeningStep2.test.tsx
@@ -1,0 +1,97 @@
+import ScreeningStep2 from "@/app/form/(formSteps)/screening/2/page";
+import { getValue } from "@/app/form/_utils/sessionStorage";
+import { fillAllInputsExcept, type InputField } from "@/app/form/_utils/testUtils/fillInputs";
+import { RouterPathnameProvider } from "@/app/form/_utils/testUtils/RouterPathnameProvider";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+
+const allInputFields: Array<InputField> = [
+  {
+    name: "No",
+    role: "radio",
+    key: "everHadEmployeesNo",
+    withinGroupName: "Have you ever had employees in your doula business? Select one *",
+  },
+  {
+    name: "No",
+    role: "radio",
+    key: "everHadOtherBusinessOwnerNo",
+    withinGroupName:
+      "Did anyone other than you ever own a percentage of your business? Select one *",
+  },
+];
+
+describe("<ScreeningStep2 />", () => {
+  const renderWithRouter = () => {
+    const mockRouter: Partial<AppRouterInstance> = {
+      push: jest.fn(),
+      refresh: jest.fn(),
+    };
+    render(
+      <RouterPathnameProvider pathname="/form/screening/2" router={mockRouter as AppRouterInstance}>
+        <ScreeningStep2 />
+      </RouterPathnameProvider>,
+    );
+    return mockRouter;
+  };
+
+  describe.each([
+    {
+      question: "Have you ever had employees in your doula business?",
+      sessionStorageKey: "everHadEmployees" as const,
+    },
+    {
+      question: "Did anyone other than you ever own a percentage of your business?",
+      sessionStorageKey: "everHadOtherBusinessOwner" as const,
+    },
+  ])("$question", ({ question, sessionStorageKey }) => {
+    it(`saves ${sessionStorageKey} as false when user selects no and clicks Next`, async () => {
+      const user = userEvent.setup();
+      const mockRouter = renderWithRouter();
+      await fillAllInputsExcept(screen, user, allInputFields, new Set([`${sessionStorageKey}No`]));
+
+      const questionGroup = screen.getByRole("group", {
+        name: `${question} Select one *`,
+      });
+      const noButton = within(questionGroup).getByRole("radio", {
+        name: "No",
+      });
+      expect(noButton).not.toBeChecked();
+      await user.click(noButton);
+      expect(noButton).toBeChecked();
+      await user.click(screen.getByRole("button", { name: "Next" }));
+
+      expect(getValue(sessionStorageKey, true)).toBe("false");
+      expect(mockRouter.push).toHaveBeenCalledWith("/form/screening/3");
+      expect(mockRouter.refresh).toHaveBeenCalled();
+    });
+
+    it("shows an error message when user selects yes and clicks Next", async () => {
+      const user = userEvent.setup();
+      const mockRouter = renderWithRouter();
+      await fillAllInputsExcept(screen, user, allInputFields, new Set([`${sessionStorageKey}No`]));
+
+      const questionGroup = screen.getByRole("group", {
+        name: "Have you ever had employees in your doula business? Select one *",
+      });
+      const yesButton = within(questionGroup).getByRole("radio", {
+        name: "Yes",
+      });
+      expect(yesButton).not.toBeChecked();
+      await user.click(yesButton);
+      expect(yesButton).toBeChecked();
+      await user.click(screen.getByRole("button", { name: "Next" }));
+
+      expect(yesButton).toHaveFocus();
+      expect(yesButton).toHaveAccessibleDescription(
+        expect.stringContaining(
+          "Currently this site cannot support your situation. Please use the standard FFS application",
+        ),
+      );
+      expect(getValue(sessionStorageKey, false)).toBe(null);
+      expect(mockRouter.push).not.toHaveBeenCalled();
+      expect(mockRouter.refresh).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/form/(formSteps)/screening/2/page.tsx
+++ b/src/app/form/(formSteps)/screening/2/page.tsx
@@ -1,31 +1,77 @@
 "use client";
 
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
+import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
+import type { Screening2Data } from "@/app/form/(formSteps)/screening/ScreeningData";
+import { unsupportedErrorMessage } from "@/app/form/(formSteps)/screening/_utils/unsupportedErrorMessage";
+import { getDefaultBoolean } from "@/app/form/_utils/sessionStorage";
+import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
-import { routeToNextStep, useFormProgressPosition } from "@form/_utils/formProgressRouting";
-import { Form } from "@trussworks/react-uswds";
-import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 
-const FormSection = () => {
-  const router = useRouter();
-  const formProgressPosition = useFormProgressPosition();
-  const { handleSubmit } = useForm<object>({
-    defaultValues: {},
+const mayHaveThreeOrMoreErrors = false;
+const ScreeningStep2 = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<Screening2Data>({
+    defaultValues: {
+      everHadEmployees: getDefaultBoolean("everHadEmployees"),
+      everHadOtherBusinessOwner: getDefaultBoolean("everHadOtherBusinessOwner"),
+    },
   });
+  const everHadEmployees = watch("everHadEmployees");
+  const everHadOtherBusinessOwner = watch("everHadOtherBusinessOwner");
   return (
-    <div>
-      <Form
-        onSubmit={handleSubmit(() => {
-          routeToNextStep(router, formProgressPosition);
-        })}
-        className="maxw-full"
-      >
-        <HorizontalDivider />
-        <FormProgressButtons />
-      </Form>
-    </div>
+    <DoulaForm<Screening2Data>
+      errors={errors}
+      handleSubmit={handleSubmit}
+      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+    >
+      <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
+        <div className="desktop:grid-col-8">
+          <div>
+            <h2 className="font-heading-md">About your business</h2>
+            <p className="usa-hint">
+              Most individual doulas with a Sole Proprietorship business answer “No” to these
+              questions.
+            </p>
+            <DoulaYesNoRadio
+              name="everHadEmployees"
+              value={everHadEmployees}
+              label="Have you ever had employees in your doula business?"
+              required
+              invalidOption={{
+                label: "Yes",
+                message: unsupportedErrorMessage,
+              }}
+              register={register}
+              errors={errors}
+            />
+          </div>
+
+          <div className="margin-top-5">
+            <DoulaYesNoRadio
+              name="everHadOtherBusinessOwner"
+              value={everHadOtherBusinessOwner}
+              label="Did anyone other than you ever own a percentage of your business?"
+              required
+              invalidOption={{
+                label: "Yes",
+                message: unsupportedErrorMessage,
+              }}
+              register={register}
+              errors={errors}
+            />
+          </div>
+        </div>
+      </div>
+      <HorizontalDivider />
+      <FormProgressButtons />
+    </DoulaForm>
   );
 };
 
-export default FormSection;
+export default ScreeningStep2;

--- a/src/app/form/(formSteps)/screening/ScreeningData.test.ts
+++ b/src/app/form/(formSteps)/screening/ScreeningData.test.ts
@@ -6,19 +6,33 @@ import {
 
 describe("getScreeningFormData", () => {
   describe("disclosing entity handling", () => {
-    it("sets isSupportedSoleProprietor to true when isSoleProprietor is true", async () => {
+    it("sets isSupportedSoleProprietor to true when isSoleProprietor is true, everHadEmployees is false, and everHadOtherBusinessOwner is false", async () => {
       setRequiredFieldsInSessionStorage();
-      setInSessionStorage({ isSoleProprietor: "true" });
+      setInSessionStorage({
+        isSoleProprietor: "true",
+        everHadEmployees: "false",
+        everHadOtherBusinessOwner: "false",
+      });
       expect(getScreeningFormData()).toMatchObject({
         isSupportedSoleProprietor: true,
       });
     });
 
-    it("throws an error when isSoleProprietor is false", async () => {
+    it.each([
+      { key: "isSoleProprietor", value: "false" },
+      { key: "everHadEmployees", value: "true" },
+      { key: "everHadOtherBusinessOwner", value: "true" },
+    ])("throws an error when $key is $value", async ({ key, value }) => {
       setRequiredFieldsInSessionStorage();
-      setInSessionStorage({ isSoleProprietor: "false" });
+      setInSessionStorage({ [key]: value });
+      const expectedValues = {
+        isSoleProprietor: "true",
+        everHadEmployees: "false",
+        everHadOtherBusinessOwner: "false",
+        ...{ [key]: value },
+      };
       expect(() => getScreeningFormData()).toThrow(
-        "Expected isSoleProprietor to be true, was false",
+        `Invalid screening answers: isSoleProprietor: ${expectedValues["isSoleProprietor"]}, everHadEmployees: ${expectedValues["everHadEmployees"]}, everHadOtherBusinessOwner ${expectedValues["everHadOtherBusinessOwner"]}`,
       );
     });
   });

--- a/src/app/form/(formSteps)/screening/ScreeningData.ts
+++ b/src/app/form/(formSteps)/screening/ScreeningData.ts
@@ -4,16 +4,30 @@ export interface Screening1Data {
   isSoleProprietor: "true" | "false" | "";
 }
 
+export interface Screening2Data {
+  everHadEmployees: "true" | "false" | "";
+  everHadOtherBusinessOwner: "true" | "false" | "";
+}
+
 export interface ScreeningFormData {
   isSupportedSoleProprietor: boolean;
 }
 
 export const getScreeningFormData = (): ScreeningFormData => {
   const isSoleProprietor = getBoolean("isSoleProprietor", true);
-  if (isSoleProprietor !== true) {
-    throw new ValueNotFoundError(`Expected isSoleProprietor to be true, was ${isSoleProprietor}`);
+  const everHadEmployees = getBoolean("everHadEmployees", true);
+  const everHadOtherBusinessOwner = getBoolean("everHadOtherBusinessOwner", true);
+  if (
+    isSoleProprietor === true &&
+    everHadEmployees === false &&
+    everHadOtherBusinessOwner === false
+  ) {
+    return {
+      isSupportedSoleProprietor: true,
+    };
   }
-  return {
-    isSupportedSoleProprietor: true,
-  };
+
+  throw new ValueNotFoundError(
+    `Invalid screening answers: isSoleProprietor: ${isSoleProprietor}, everHadEmployees: ${everHadEmployees}, everHadOtherBusinessOwner ${everHadOtherBusinessOwner}`,
+  );
 };

--- a/src/app/form/(formSteps)/screening/_utils/unsupportedErrorMessage.tsx
+++ b/src/app/form/(formSteps)/screening/_utils/unsupportedErrorMessage.tsx
@@ -1,0 +1,9 @@
+export const unsupportedErrorMessage = (
+  <span>
+    Currently this site cannot support your situation. Please use the{" "}
+    <a href="https://www.njmmis.com/providerEnrollment.aspx " target="_blank" rel="noopener">
+      standard FFS application
+    </a>
+    .
+  </span>
+);

--- a/src/app/form/_utils/fillPdf/testUtils/formData.ts
+++ b/src/app/form/_utils/fillPdf/testUtils/formData.ts
@@ -7,6 +7,9 @@ const defaultDateOfBirthMonth = "12";
 const defaultDateOfBirthYear = "1990";
 
 const defaultFormData = {
+  isSupportedSoleProprietor: true,
+  everHadEmployees: false,
+  everHadOtherBusinessOwner: false,
   stateApprovedTraining: "Children's Home Society of NJ (Trenton)",
   nameOfTrainingOrganization: null,
   instructorFirstName: "First",
@@ -42,7 +45,6 @@ const defaultFormData = {
   billingCity: null,
   billingState: null,
   billingZip: null,
-  isSupportedSoleProprietor: true,
   hasSameBusinessAddress: true,
   businessStreetAddress1: null,
   businessStreetAddress2: null,

--- a/src/app/form/_utils/sessionStorage.ts
+++ b/src/app/form/_utils/sessionStorage.ts
@@ -1,4 +1,7 @@
-import type { Screening1Data } from "@/app/form/(formSteps)/screening/ScreeningData";
+import type {
+  Screening1Data,
+  Screening2Data,
+} from "@/app/form/(formSteps)/screening/ScreeningData";
 import type { TrainingData } from "@/app/form/(formSteps)/training/TrainingData";
 import { AddressState } from "@/app/form/_utils/inputFields/enums";
 import type { BusinessDetails1Data } from "@form/(formSteps)/business-details/BusinessDetailsData";
@@ -10,6 +13,7 @@ import type {
 
 export type SessionStorageKey =
   | keyof Screening1Data
+  | keyof Screening2Data
   | keyof TrainingData
   | keyof PersonalDetails1Data
   | keyof PersonalDetails2Data


### PR DESCRIPTION
## Link to issue

This commit contributes to #[206](https://github.com/newjersey/doula-pm/issues/206).

## What was done?
Out of scope, will handle in part 2: fill all the pdf fields specified in https://github.com/newjersey/doula-pm/issues/175

This commit adds the questions for screening page 2, per [the figma](https://www.figma.com/design/2R3VxYvZQYsaIxBcWoA1kL/Doula-Prototypes?node-id=3328-24801&p=f&t=NH5fnOEDFTjUZsIT-0)

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/form/screening/2
- Both questions are required, clicking Next without filling either should show an error message that they are required, and move focus
- Selecting "Yes" for either question and clicking Next should show an error message, move focus to the question with the error, and prevent progress
- Selecting "No" for both should allow progress to step 3
- For part 1, no changes to how the pdf is filled

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

<img width="2244" height="1754" alt="main d20cvhuc4595ep amplifyapp com_form_screening_2" src="https://github.com/user-attachments/assets/55531bab-4270-4b50-80f5-21d5d4384ba5" />


</details>


<details>
<summary>After</summary>

<img width="2214" height="1934" alt="localhost_3000_form_screening_2" src="https://github.com/user-attachments/assets/5e9a104f-9c0d-45cb-92c1-4c252d5bff4e" />

<img width="2214" height="2024" alt="localhost_3000_form_screening_2 (1)" src="https://github.com/user-attachments/assets/00e83a5c-db69-4a4b-bd8d-1078568047b7" />

<img width="2214" height="2114" alt="localhost_3000_form_screening_2 (2)" src="https://github.com/user-attachments/assets/6c2052d6-a9ea-4dc8-8516-7462ae719424" />

</details>