### PR TITLE
[newjersey/doula-pm#221] Create and use reusable address component

### DIFF
--- a/src/app/form/(formSteps)/components/DoulaAddress.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddress.test.tsx
@@ -1,0 +1,260 @@
+import {
+  DoulaAddress,
+  type DoulaAddressProps,
+} from "@/app/form/(formSteps)/components/DoulaAddress";
+import FormProgressButtons from "@/app/form/(formSteps)/components/FormProgressButtons";
+import { fillAllInputsExcept, getInputField } from "@/app/form/_utils/testUtils/fillInputs";
+import { RouterPathnameProvider } from "@/app/form/_utils/testUtils/RouterPathnameProvider";
+import { DoulaForm } from "@/app/form/components/DoulaForm";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+
+interface TestFormData {
+  testStreetAddress1: string;
+  testStreetAddress2: string;
+  testCity: string;
+  testState: string;
+  testZip: string;
+}
+const testFormOrderedInputNameToLabel = {
+  testStreetAddress1: "Street address",
+  testStreetAddress2: "Street address line 2",
+  testCity: "City",
+  testState: "State",
+  testZip: "ZIP code",
+};
+
+const allInputFields = [
+  {
+    name: "Street address *",
+    sessionStorageKey: "testStreetAddress1",
+    role: "textbox" as const,
+    testValue: "55 Cherry St",
+  },
+  {
+    name: "Street address line 2",
+    sessionStorageKey: "testStreetAddress2",
+    role: "textbox" as const,
+    testValue: "Apt 4",
+  },
+  { name: "City *", sessionStorageKey: "testCity", role: "textbox" as const, testValue: "Newark" },
+  { name: "State *", sessionStorageKey: "testState", role: "combobox" as const, testValue: "PA" },
+  {
+    name: "ZIP code *",
+    sessionStorageKey: "testZip",
+    role: "textbox" as const,
+    testValue: "08609",
+  },
+];
+
+const TestForm = (
+  props: Omit<
+    DoulaAddressProps<TestFormData>,
+    "zipValue" | "orderedInputNameToLabel" | "errors" | "register"
+  >,
+) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setFocus,
+    watch,
+  } = useForm<TestFormData>({
+    defaultValues: {
+      testStreetAddress1: "",
+      testStreetAddress2: "",
+      testCity: "",
+      testState: "NJ",
+      testZip: "",
+    },
+  });
+  const testZip = watch("testZip");
+  return (
+    <RouterPathnameProvider pathname="/form/personal-details/2">
+      <DoulaForm<TestFormData>
+        orderedInputNameToLabel={testFormOrderedInputNameToLabel}
+        errors={errors}
+        setFocus={setFocus}
+        handleSubmit={handleSubmit}
+        mayHaveThreeOrMoreErrors={true}
+      >
+        <DoulaAddress
+          {...props}
+          zipValue={testZip}
+          orderedInputNameToLabel={testFormOrderedInputNameToLabel}
+          errors={errors}
+          register={register}
+        />
+        <FormProgressButtons />
+      </DoulaForm>
+    </RouterPathnameProvider>
+  );
+};
+
+describe("DoulaAddress", () => {
+  it("renders all expected address inputs", async () => {
+    render(
+      <DoulaAddress
+        fieldsetProps={{
+          legend: "What is your address?",
+        }}
+        addressKeys={{
+          streetAddress1: "testStreetAddress1",
+          streetAddress2: "testStreetAddress2",
+          city: "testCity",
+          state: "testState",
+          zip: "testZip",
+        }}
+        zipValue={"11111"}
+        orderedInputNameToLabel={{
+          testStreetAddress1: "Street address",
+          testStreetAddress2: "Street address line 2",
+          testCity: "City",
+          testState: "State",
+          testZip: "ZIP code",
+        }}
+        errors={{}}
+        register={jest.fn()}
+      />,
+    );
+    const streetAddress1Input = await getInputField(screen, {
+      name: "Street address *",
+      withinGroupName: "What is your address?",
+    });
+    const streetAddress2Input = await getInputField(screen, {
+      name: "Street address line 2",
+      withinGroupName: "What is your address?",
+    });
+    const cityInput = await getInputField(screen, {
+      name: "City *",
+      withinGroupName: "What is your address?",
+    });
+    const stateInput = await getInputField(screen, {
+      name: "State *",
+      role: "combobox",
+      withinGroupName: "What is your address?",
+    });
+    const zipInput = await getInputField(screen, {
+      name: "ZIP code *",
+      withinGroupName: "What is your address?",
+    });
+
+    for (const input of [streetAddress1Input, cityInput, stateInput, zipInput]) {
+      expect(input).toBeRequired();
+    }
+    expect(streetAddress2Input).not.toBeRequired();
+  });
+
+  it("sets autocomplete if provided", () => {
+    render(
+      <DoulaAddress
+        fieldsetProps={{
+          legend: "What is your address?",
+        }}
+        addressKeys={{
+          streetAddress1: "testStreetAddress1",
+          streetAddress2: "testStreetAddress2",
+          city: "testCity",
+          state: "testState",
+          zip: "testZip",
+        }}
+        zipValue={"11111"}
+        orderedInputNameToLabel={{
+          testStreetAddress1: "Street address",
+          testStreetAddress2: "Street address line 2",
+          testCity: "City",
+          testState: "State",
+          testZip: "ZIP code",
+        }}
+        autocomplete="shipping"
+        errors={{}}
+        register={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "Street address *" })).toHaveAttribute(
+      "autocomplete",
+      "shipping address-line1",
+    );
+    expect(screen.getByRole("textbox", { name: "Street address line 2" })).toHaveAttribute(
+      "autocomplete",
+      "shipping address-line2",
+    );
+    expect(screen.getByRole("textbox", { name: "City *" })).toHaveAttribute(
+      "autocomplete",
+      "shipping address-level2",
+    );
+    expect(screen.getByRole("combobox", { name: "State *" })).toHaveAttribute(
+      "autocomplete",
+      "shipping address-level1",
+    );
+    expect(screen.getByRole("textbox", { name: "ZIP code *" })).toHaveAttribute(
+      "autocomplete",
+      "shipping postal-code",
+    );
+  });
+
+  it("displays an error message if zip has fewer than five digits", async () => {
+    const user = userEvent.setup();
+    render(
+      <TestForm
+        fieldsetProps={{
+          legend: "What is your address?",
+        }}
+        addressKeys={{
+          streetAddress1: "testStreetAddress1",
+          streetAddress2: "testStreetAddress2",
+          city: "testCity",
+          state: "testState",
+          zip: "testZip",
+        }}
+      />,
+    );
+    await fillAllInputsExcept(screen, user, allInputFields, new Set(["testZip"]));
+    const zipInput = await getInputField(screen, { name: "ZIP code *" });
+    await user.type(zipInput, "1");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(zipInput).toHaveAccessibleDescription("ZIP code must have five digits");
+  });
+
+  it("displays error messages that includes a prefix if provided", async () => {
+    const user = userEvent.setup();
+    render(
+      <TestForm
+        fieldsetProps={{
+          legend: "What is your address?",
+        }}
+        addressKeys={{
+          streetAddress1: "testStreetAddress1",
+          streetAddress2: "testStreetAddress2",
+          city: "testCity",
+          state: "testState",
+          zip: "testZip",
+        }}
+        errorLabelPrefix="Test"
+      />,
+    );
+    const streetAddress1Input = await getInputField(screen, {
+      name: "Street address *",
+    });
+    const cityInput = await getInputField(screen, {
+      name: "City *",
+    });
+    const zipInput = await getInputField(screen, {
+      name: "ZIP code *",
+    });
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    for (const testCase of [
+      { input: streetAddress1Input, expectedErrorMessage: "Test street address is required" },
+      { input: cityInput, expectedErrorMessage: "Test city is required" },
+      { input: zipInput, expectedErrorMessage: "Test zip code is required" },
+    ]) {
+      expect(testCase.input).toHaveAccessibleDescription(testCase.expectedErrorMessage);
+    }
+
+    await user.type(zipInput, "1");
+    expect(zipInput).toHaveAccessibleDescription("Test zip code must have five digits");
+  });
+});

--- a/src/app/form/(formSteps)/components/DoulaAddress.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddress.tsx
@@ -1,0 +1,127 @@
+import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
+import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
+import { AddressState } from "@/app/form/_utils/inputFields/enums";
+import { typecheckAutocomplete } from "@/app/form/_utils/types/autocomplete";
+import { Fieldset, Label, Select, type FieldsetProps } from "@trussworks/react-uswds";
+import type { FieldErrors, FieldPath, FieldValues, UseFormRegister } from "react-hook-form";
+
+export interface DoulaAddressProps<T extends FieldValues> {
+  fieldsetProps: Omit<FieldsetProps, "children">;
+  addressKeys: {
+    streetAddress1: FieldPath<T>;
+    streetAddress2: FieldPath<T>;
+    city: FieldPath<T>;
+    state: FieldPath<T>;
+    zip: FieldPath<T>;
+  };
+  zipValue: string;
+  orderedInputNameToLabel: {
+    [key in FieldPath<T>]: string;
+  };
+  autocomplete?: "shipping";
+  errorLabelPrefix?: string;
+  errors: FieldErrors<T>;
+  register: UseFormRegister<T>;
+}
+const formatInputErrorLabel = (label: string, errorLabelPrefix: string | undefined) => {
+  if (errorLabelPrefix !== undefined) {
+    return `${errorLabelPrefix} ${label.toLowerCase()}`;
+  }
+  return label;
+};
+
+export const DoulaAddress = <T extends FieldValues>(props: DoulaAddressProps<T>) => {
+  return (
+    <Fieldset {...props.fieldsetProps}>
+      <div className="grid-row grid-gap">
+        <div className="mobile-lg:grid-col-6">
+          <DoulaTextInput
+            name={props.addressKeys.streetAddress1}
+            label={props.orderedInputNameToLabel[props.addressKeys.streetAddress1]}
+            {...(props.autocomplete !== undefined && {
+              autoComplete: typecheckAutocomplete(`${props.autocomplete} address-line1`),
+            })}
+            required
+            errors={props.errors}
+            register={props.register}
+            registerOptions={{
+              required: `${formatInputErrorLabel(props.orderedInputNameToLabel[props.addressKeys.streetAddress1], props.errorLabelPrefix)} is required`,
+            }}
+          />
+        </div>
+        <div className="mobile-lg:grid-col-6">
+          <DoulaTextInput
+            name={props.addressKeys.streetAddress2}
+            label={props.orderedInputNameToLabel[props.addressKeys.streetAddress2]}
+            {...(props.autocomplete !== undefined && {
+              autoComplete: typecheckAutocomplete(`${props.autocomplete} address-line2`),
+            })}
+            register={props.register}
+          />
+        </div>
+      </div>
+      <div className="grid-row grid-gap">
+        <div className="mobile-lg:grid-col-6">
+          <DoulaTextInput
+            name={props.addressKeys.city}
+            label={props.orderedInputNameToLabel[props.addressKeys.city]}
+            {...(props.autocomplete !== undefined && {
+              autoComplete: typecheckAutocomplete(`${props.autocomplete} address-level2`),
+            })}
+            required
+            errors={props.errors}
+            register={props.register}
+            registerOptions={{
+              required: `${formatInputErrorLabel(props.orderedInputNameToLabel[props.addressKeys.city], props.errorLabelPrefix)} is required`,
+            }}
+          />
+        </div>
+      </div>
+      <div className="grid-row grid-gap">
+        <div className="mobile-lg:grid-col-6">
+          <Label htmlFor={props.addressKeys.state} requiredMarker>
+            {props.orderedInputNameToLabel[props.addressKeys.state]}
+          </Label>
+          <Select
+            className="usa-select"
+            id={props.addressKeys.state}
+            {...(props.autocomplete !== undefined && {
+              autoComplete: typecheckAutocomplete(`${props.autocomplete} address-level1`),
+            })}
+            required
+            {...props.register(props.addressKeys.state)}
+          >
+            {Object.keys(AddressState).map((state) => (
+              <option key={state} value={state}>
+                {state}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="mobile-lg:grid-col-4">
+          <DoulaTextInputMask
+            className="usa-input--medium"
+            name={props.addressKeys.zip}
+            label={props.orderedInputNameToLabel[props.addressKeys.zip]}
+            {...(props.autocomplete !== undefined && {
+              autoComplete: typecheckAutocomplete(`${props.autocomplete} postal-code`),
+            })}
+            value={props.zipValue ?? ""}
+            mask="#####"
+            pattern="\d{5}"
+            required
+            errors={props.errors}
+            register={props.register}
+            registerOptions={{
+              required: `${formatInputErrorLabel(props.orderedInputNameToLabel[props.addressKeys.zip], props.errorLabelPrefix)} is required`,
+              minLength: {
+                value: 5,
+                message: `${formatInputErrorLabel(props.orderedInputNameToLabel[props.addressKeys.zip], props.errorLabelPrefix)} must have five digits`,
+              },
+            }}
+          />
+        </div>
+      </div>
+    </Fieldset>
+  );
+};

--- a/src/app/form/(formSteps)/personal-details/2/page.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/page.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
-import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
-import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
+import { DoulaAddress } from "@/app/form/(formSteps)/components/DoulaAddress";
 import DoulaYesNoRadio from "@/app/form/(formSteps)/components/DoulaYesNoRadio";
 import FormProgressButtons from "@/app/form/(formSteps)/components/FormProgressButtons";
 import PublicInformationExplainer from "@/app/form/(formSteps)/personal-details/2/PublicInformationExplainer";
-import { typecheckAutocomplete } from "@/app/form/_utils/types/autocomplete";
 import { DoulaForm } from "@/app/form/components/DoulaForm";
 import { type PersonalDetails2Data } from "@form/(formSteps)/personal-details/PersonalDetailsData";
-import { AddressState } from "@form/_utils/inputFields/enums";
 import { getDefaultValue } from "@form/_utils/sessionStorage";
-import { Fieldset, Label, Select } from "@trussworks/react-uswds";
 import { useForm } from "react-hook-form";
 
 const orderedInputNameToLabel: { [key in keyof PersonalDetails2Data]: string } = {
@@ -68,96 +64,30 @@ const PersonalDetailsStep2 = () => {
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">
           <div>
-            <Fieldset
-              legend={
-                <div>
-                  <h2 className="font-heading-md">Mailing address</h2>
-                  <p className="usa-hint">
-                    We will send official mail here. It can be your home address.
-                  </p>
-                </div>
-              }
-            >
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <DoulaTextInput
-                    name="streetAddress1"
-                    label={orderedInputNameToLabel["streetAddress1"]}
-                    autoComplete={typecheckAutocomplete("shipping address-line1")}
-                    required
-                    errors={errors}
-                    register={register}
-                    registerOptions={{
-                      required: `${orderedInputNameToLabel["streetAddress1"]} is required`,
-                    }}
-                  />
-                </div>
-                <div className="mobile-lg:grid-col-6">
-                  <DoulaTextInput
-                    name="streetAddress2"
-                    label={orderedInputNameToLabel["streetAddress2"]}
-                    autoComplete={typecheckAutocomplete("shipping address-line2")}
-                    register={register}
-                  />
-                </div>
-              </div>
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <DoulaTextInput
-                    name="city"
-                    label={orderedInputNameToLabel["city"]}
-                    autoComplete={typecheckAutocomplete("shipping address-level2")}
-                    required
-                    errors={errors}
-                    register={register}
-                    registerOptions={{
-                      required: `${orderedInputNameToLabel["city"]} is required`,
-                    }}
-                  />
-                </div>
-              </div>
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="state" requiredMarker>
-                    {orderedInputNameToLabel["state"]}
-                  </Label>
-                  <Select
-                    className="usa-select"
-                    id="state"
-                    autoComplete={typecheckAutocomplete("shipping address-level1")}
-                    required
-                    {...register("state")}
-                  >
-                    {Object.keys(AddressState).map((state) => (
-                      <option key={state} value={state}>
-                        {state}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-                <div className="mobile-lg:grid-col-4">
-                  <DoulaTextInputMask
-                    className="usa-input--medium"
-                    name="zip"
-                    label={orderedInputNameToLabel["zip"]}
-                    autoComplete={typecheckAutocomplete("shipping postal-code")}
-                    value={zip ?? ""}
-                    mask="#####"
-                    pattern="\d{5}"
-                    required
-                    errors={errors}
-                    register={register}
-                    registerOptions={{
-                      required: `${orderedInputNameToLabel["zip"]} is required`,
-                      minLength: {
-                        value: 5,
-                        message: `${orderedInputNameToLabel["zip"]} must have five digits`,
-                      },
-                    }}
-                  />
-                </div>
-              </div>
-            </Fieldset>
+            <DoulaAddress<PersonalDetails2Data>
+              fieldsetProps={{
+                legend: (
+                  <div>
+                    <h2 className="font-heading-md">Mailing address</h2>
+                    <p className="usa-hint">
+                      We will send official mail here. It can be your home address.
+                    </p>
+                  </div>
+                ),
+              }}
+              addressKeys={{
+                streetAddress1: "streetAddress1",
+                streetAddress2: "streetAddress2",
+                city: "city",
+                state: "state",
+                zip: "zip",
+              }}
+              zipValue={zip}
+              autocomplete="shipping"
+              orderedInputNameToLabel={orderedInputNameToLabel}
+              errors={errors}
+              register={register}
+            />
           </div>
           <div className="margin-top-5">
             <h2 className="font-heading-md">Billing address</h2>
@@ -174,82 +104,23 @@ const PersonalDetailsStep2 = () => {
             />
 
             {hasSameBillingMailingAddress === "false" && (
-              <Fieldset legend={<p className="margin-top-5">What&apos;s your billing address?</p>}>
-                <div className="grid-row grid-gap">
-                  <div className="mobile-lg:grid-col-6">
-                    <DoulaTextInput
-                      name="billingStreetAddress1"
-                      label={orderedInputNameToLabel["billingStreetAddress1"]}
-                      required
-                      errors={errors}
-                      register={register}
-                      registerOptions={{
-                        required: `Billing ${orderedInputNameToLabel["billingStreetAddress1"].toLowerCase()} is required`,
-                      }}
-                    />
-                  </div>
-                  <div className="mobile-lg:grid-col-6">
-                    <DoulaTextInput
-                      name="billingStreetAddress2"
-                      label={orderedInputNameToLabel["billingStreetAddress2"]}
-                      register={register}
-                    />
-                  </div>
-                </div>
-                <div className="grid-row grid-gap">
-                  <div className="mobile-lg:grid-col-6">
-                    <DoulaTextInput
-                      name="billingCity"
-                      label={orderedInputNameToLabel["billingCity"]}
-                      required
-                      errors={errors}
-                      register={register}
-                      registerOptions={{
-                        required: `Billing ${orderedInputNameToLabel["billingCity"].toLowerCase()} is required`,
-                      }}
-                    />
-                  </div>
-                </div>
-                <div className="grid-row grid-gap">
-                  <div className="mobile-lg:grid-col-6">
-                    <Label htmlFor="billingState" requiredMarker>
-                      {orderedInputNameToLabel["billingState"]}
-                    </Label>
-                    <Select
-                      className="usa-select"
-                      id="billingState"
-                      required
-                      {...register("billingState")}
-                    >
-                      {Object.keys(AddressState).map((billingState) => (
-                        <option key={billingState} value={billingState}>
-                          {billingState}
-                        </option>
-                      ))}
-                    </Select>
-                  </div>
-                  <div className="mobile-lg:grid-col-4">
-                    <DoulaTextInputMask
-                      className="usa-input--medium"
-                      name="billingZip"
-                      label={orderedInputNameToLabel["billingZip"]}
-                      value={billingZip ?? ""}
-                      mask="#####"
-                      pattern="\d{5}"
-                      required
-                      errors={errors}
-                      register={register}
-                      registerOptions={{
-                        required: `Billing ${orderedInputNameToLabel["billingZip"].toLowerCase()} is required`,
-                        minLength: {
-                          value: 5,
-                          message: `Billing ${orderedInputNameToLabel["billingZip"].toLowerCase()} must have five digits`,
-                        },
-                      }}
-                    />
-                  </div>
-                </div>
-              </Fieldset>
+              <DoulaAddress<PersonalDetails2Data>
+                fieldsetProps={{
+                  legend: <p className="margin-top-5">What&apos;s your billing address?</p>,
+                }}
+                addressKeys={{
+                  streetAddress1: "billingStreetAddress1",
+                  streetAddress2: "billingStreetAddress2",
+                  city: "billingCity",
+                  state: "billingState",
+                  zip: "billingZip",
+                }}
+                zipValue={billingZip}
+                orderedInputNameToLabel={orderedInputNameToLabel}
+                errorLabelPrefix="Billing"
+                errors={errors}
+                register={register}
+              />
             )}
           </div>
         </div>

--- a/src/app/form/(formSteps)/training/1/page.tsx
+++ b/src/app/form/(formSteps)/training/1/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
+import { DoulaAddress } from "@/app/form/(formSteps)/components/DoulaAddress";
 import DoulaRadio from "@/app/form/(formSteps)/components/DoulaRadio";
 import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
 import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
 import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import type { TrainingData } from "@form/(formSteps)/training/TrainingData";
-import { AddressState, StateApprovedTraining } from "@form/_utils/inputFields/enums";
+import { StateApprovedTraining } from "@form/_utils/inputFields/enums";
 import { getDefaultValue } from "@form/_utils/sessionStorage";
-import { Alert, Fieldset, Label, RequiredMarker, Select } from "@trussworks/react-uswds";
+import { Alert, Label, RequiredMarker, Select } from "@trussworks/react-uswds";
 import { type FieldPath, useForm } from "react-hook-form";
 import DoulaTrainingExplainer from "./DoulaTrainingExplainer";
 
@@ -142,89 +143,27 @@ const TrainingStep1 = () => {
           />
 
           {isDoulaTrainingInPerson === "true" && (
-            <Fieldset
-              legend={
-                <p className="margin-top-3">
-                  What is the address of your training organization? <RequiredMarker />
-                </p>
-              }
-            >
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <DoulaTextInput
-                    name="trainingStreetAddress1"
-                    label={orderedInputNameToLabel["trainingStreetAddress1"]}
-                    required
-                    errors={errors}
-                    register={register}
-                    registerOptions={{
-                      required: `Training ${orderedInputNameToLabel["trainingStreetAddress1"].toLowerCase()} is required`,
-                    }}
-                  />
-                </div>
-                <div className="mobile-lg:grid-col-6">
-                  <DoulaTextInput
-                    name="trainingStreetAddress2"
-                    label={orderedInputNameToLabel["trainingStreetAddress2"]}
-                    errors={errors}
-                    register={register}
-                  />
-                </div>
-              </div>
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <DoulaTextInput
-                    name="trainingCity"
-                    label={orderedInputNameToLabel["trainingCity"]}
-                    required
-                    errors={errors}
-                    register={register}
-                    registerOptions={{
-                      required: `Training ${orderedInputNameToLabel["trainingCity"].toLowerCase()} is required`,
-                    }}
-                  />
-                </div>
-              </div>
-              <div className="grid-row grid-gap">
-                <div className="mobile-lg:grid-col-6">
-                  <Label htmlFor="trainingState" requiredMarker>
-                    {orderedInputNameToLabel["trainingState"]}
-                  </Label>
-                  <Select
-                    className="usa-select"
-                    id="trainingState"
-                    required
-                    {...register("trainingState")}
-                  >
-                    {Object.keys(AddressState).map((trainingState) => (
-                      <option key={trainingState} value={trainingState}>
-                        {trainingState}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-                <div className="mobile-lg:grid-col-4">
-                  <DoulaTextInputMask
-                    name="trainingZip"
-                    label={orderedInputNameToLabel["trainingZip"]}
-                    className="usa-input--medium"
-                    value={trainingZip ?? ""}
-                    mask="#####"
-                    pattern="\d{5}"
-                    required
-                    errors={errors}
-                    register={register}
-                    registerOptions={{
-                      required: `Training ${orderedInputNameToLabel["trainingZip"].toLowerCase()} is required`,
-                      minLength: {
-                        value: 5,
-                        message: `Training ${orderedInputNameToLabel["trainingZip"].toLowerCase()} must have five digits`,
-                      },
-                    }}
-                  />
-                </div>
-              </div>
-            </Fieldset>
+            <DoulaAddress<TrainingData>
+              fieldsetProps={{
+                legend: (
+                  <p className="margin-top-3">
+                    What is the address of your training organization? <RequiredMarker />
+                  </p>
+                ),
+              }}
+              addressKeys={{
+                streetAddress1: "trainingStreetAddress1",
+                streetAddress2: "trainingStreetAddress2",
+                city: "trainingCity",
+                state: "trainingState",
+                zip: "trainingZip",
+              }}
+              zipValue={trainingZip}
+              errorLabelPrefix="Training"
+              orderedInputNameToLabel={orderedInputNameToLabel}
+              errors={errors}
+              register={register}
+            />
           )}
         </div>
       </div>

--- a/src/app/form/_utils/testUtils/fillInputs.ts
+++ b/src/app/form/_utils/testUtils/fillInputs.ts
@@ -26,7 +26,7 @@ export const getInputField = async (
 export const fillField = async (
   screen: Screen,
   user: UserEvent,
-  fieldToFill: TestField,
+  fieldToFill: { name: string; role?: Role; withinGroupName?: string },
   value: string,
 ) => {
   const inputField = await getInputField(screen, fieldToFill);
@@ -56,7 +56,14 @@ export const fillAllInputs = async (
 export const fillAllInputsExcept = async (
   screen: Screen,
   user: UserEvent,
-  allInputs: Array<TestField>,
+  allInputs: Array<{
+    name: string;
+    sessionStorageKey: string;
+    testValue: string;
+    role?: Role;
+    withinGroupName?: string;
+    prerequisiteField?: { name: string; role?: Role; withinGroupName?: string; testValue: string };
+  }>,
   keysToSkip: Set<string>,
 ) => {
   for (const input of allInputs) {


### PR DESCRIPTION
## Link to issue

This commit contributes to #[221](https://github.com/newjersey/doula-pm/issues/221) and #[180](https://github.com/newjersey/doula-pm/issues/180).

## What was done?
This commit creates a reusable address component, and uses it in personal details 2 and training. It does not use this component in business details 1. That will be handled as part 2 of https://github.com/newjersey/doula-medicaid/pull/137.

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`
- This is a refactor with no feature changes
- Go to http://localhost:3000/form/training/1 and http://localhost:3000/form/personal-details/2, and try to break the address components

## Screenshots (for visual changes)

No visual changes