### PR TITLE
[newjersey/doula-pm#210] Add skeleton business details pages

### DIFF
--- a/src/app/form/(formSteps)/business-details/1/BusinessDetails1.test.tsx
+++ b/src/app/form/(formSteps)/business-details/1/BusinessDetails1.test.tsx
@@ -72,7 +72,7 @@ describe("<BusinessDetailsStep1 />", () => {
 
     expect(getValue("hasSameBusinessAddress", true)).toBe("true");
 
-    expect(mockRouter.push).toHaveBeenCalledWith("/form/finish");
+    expect(mockRouter.push).toHaveBeenCalledWith("/form/business-details/2");
     expect(mockRouter.refresh).toHaveBeenCalled();
   });
 
@@ -122,7 +122,7 @@ describe("<BusinessDetailsStep1 />", () => {
       );
     }
     expect(window.sessionStorage.getItem("businessState")).toEqual("PA");
-    expect(mockRouter.push).toHaveBeenCalledWith("/form/finish");
+    expect(mockRouter.push).toHaveBeenCalledWith("/form/business-details/2");
     expect(mockRouter.refresh).toHaveBeenCalled();
   });
 

--- a/src/app/form/(formSteps)/business-details/2/page.tsx
+++ b/src/app/form/(formSteps)/business-details/2/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { HorizontalDivider } from "@/app/components/HorizontalDivider";
+import { DoulaForm } from "@/app/form/components/DoulaForm";
+import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
+import { useForm } from "react-hook-form";
+
+const mayHaveThreeOrMoreErrors = false;
+const FormStep = () => {
+  const {
+    formState: { errors },
+    handleSubmit,
+  } = useForm<object>({
+    defaultValues: {},
+    shouldFocusError: !mayHaveThreeOrMoreErrors,
+  });
+
+  return (
+    <DoulaForm<object>
+      errors={errors}
+      handleSubmit={handleSubmit}
+      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+    >
+      <HorizontalDivider />
+      <FormProgressButtons />
+    </DoulaForm>
+  );
+};
+
+export default FormStep;

--- a/src/app/form/(formSteps)/business-details/3/page.tsx
+++ b/src/app/form/(formSteps)/business-details/3/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { HorizontalDivider } from "@/app/components/HorizontalDivider";
+import { DoulaForm } from "@/app/form/components/DoulaForm";
+import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
+import { useForm } from "react-hook-form";
+
+const mayHaveThreeOrMoreErrors = false;
+const FormStep = () => {
+  const {
+    formState: { errors },
+    handleSubmit,
+  } = useForm<object>({
+    defaultValues: {},
+    shouldFocusError: !mayHaveThreeOrMoreErrors,
+  });
+
+  return (
+    <DoulaForm<object>
+      errors={errors}
+      handleSubmit={handleSubmit}
+      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+    >
+      <HorizontalDivider />
+      <FormProgressButtons />
+    </DoulaForm>
+  );
+};
+
+export default FormStep;

--- a/src/app/form/(formSteps)/business-details/4/page.tsx
+++ b/src/app/form/(formSteps)/business-details/4/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { HorizontalDivider } from "@/app/components/HorizontalDivider";
+import { DoulaForm } from "@/app/form/components/DoulaForm";
+import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
+import { useForm } from "react-hook-form";
+
+const mayHaveThreeOrMoreErrors = false;
+const FormStep = () => {
+  const {
+    formState: { errors },
+    handleSubmit,
+  } = useForm<object>({
+    defaultValues: {},
+    shouldFocusError: !mayHaveThreeOrMoreErrors,
+  });
+
+  return (
+    <DoulaForm<object>
+      errors={errors}
+      handleSubmit={handleSubmit}
+      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+    >
+      <HorizontalDivider />
+      <FormProgressButtons />
+    </DoulaForm>
+  );
+};
+
+export default FormStep;

--- a/src/app/form/(formSteps)/components/FormProgressButtons.test.tsx
+++ b/src/app/form/(formSteps)/components/FormProgressButtons.test.tsx
@@ -80,7 +80,7 @@ describe("<FormProgressButtons />", () => {
 
     expect(screen.getByRole("link", { name: "Previous" })).toHaveAttribute(
       "href",
-      "/form/business-details/1",
+      "/form/business-details/4",
     );
   });
 });

--- a/src/app/form/_utils/formProgress.ts
+++ b/src/app/form/_utils/formProgress.ts
@@ -37,7 +37,7 @@ export const allSections: Array<Section> = [
     id: "business-details",
     progressBarTitle: "Business details",
     heading: "Business details",
-    numSteps: 1,
+    numSteps: 4,
   },
   {
     id: "finish",


### PR DESCRIPTION
## Link to issue

This commit contributes to #[210](https://github.com/newjersey/doula-pm/issues/210).

## What was done?
Add skeleton business details pages.
To help with test conflicts while working on the pages in parallel.

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/form/business-details/2, http://localhost:3000/form/business-details/3, http://localhost:3000/form/business-details/4. They should be blank pages but should exist.

## Screenshots (for visual changes)

Added skeleton pages like the following

<img width="1041" height="404" alt="image" src="https://github.com/user-attachments/assets/3f652391-66e1-45ae-8dc0-67dcad0dd5b1" />
