### PR TITLE
[newjersey/doula-pm#244] Improve renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,43 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "timezone": "US/Eastern",
+  "minimumReleaseAge": "3 days",
   "extends": ["config:recommended", ":maintainLockFilesWeekly"],
   "automergeSchedule": ["* * * * 0,6", "* 0-6 * * 1"],
   "ignorePaths": ["**/scripts/**"],
+  "labels": ["renovate"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "matchPackagePrefixes": ["cypress"],
+      "groupName": "cypress"
+    },
+    {
+      "matchPackageNames": ["@types/jest", "ts-jest"],
+      "matchPackagePrefixes": ["jest"],
+      "groupName": "jest"
+    },
+    {
+      "matchPackageNames": ["@types/eslint", "babel-eslint"],
+      "matchPackagePrefixes": ["@typescript-eslint/", "eslint"],
+      "groupName": "linting"
+    },
+    {
+      "matchPackageNames": ["@types/react", "focus-trap-react", "@types/react-dom"],
+      "matchPackagePrefixes": ["react"],
+      "groupName": "react"
+    },
+    {
+      "matchPackagePrefixes": ["@testing-library"],
+      "groupName": "testing-library"
+    },
+    {
+      "matchPackageNames": ["actions/*"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "GH Action Artifacts"
     }
   ]
 }


### PR DESCRIPTION
## Link to issue

This commit resolves #[244](https://github.com/newjersey/doula-pm/issues/244).

## What was done?
As inspired by the eng deep dive. The groups (`groupName`) at the bottom part of the code change creates a [dependency group](https://docs.renovatebot.com/configuration-options/#groupname) that I think groups related packages into one PR, so that their versions update together.

Compared with [bizX](https://github.com/newjersey/navigator.business.nj.gov/blob/main/renovate.json) and [CCM](https://github.com/newjersey/aws-connect-ccm-platform/blob/main/renovate.json) renovate configs.

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).
