### PR TITLE
[newjersey/doula-pm#21] Update page title to the name of the application used in the landing page figma

### DIFF
--- a/src/app/_utils/title.ts
+++ b/src/app/_utils/title.ts
@@ -1,4 +1,4 @@
-export const APPLICATION_NAME = "Doula Common App";
+export const APPLICATION_NAME = "NJ Doula Assistant";
 
 export const formatTitle = (pageTitle: string) => {
   return `${pageTitle} | ${APPLICATION_NAME}`;

--- a/src/app/form/(formSteps)/FormLayout.test.tsx
+++ b/src/app/form/(formSteps)/FormLayout.test.tsx
@@ -7,14 +7,14 @@ describe("<FormLayout />", () => {
   it("does not show progress bar when shouldShowProgressBar is false", async () => {
     const name = "Welcome";
     renderWithProviders(routes, "/form/welcome");
-    await waitFor(() => expect(document.title).toBe(`${name} | Doula Common App`));
+    await waitFor(() => expect(document.title).toBe(`${name} | NJ Doula Assistant`));
     expect(screen.queryByRole("generic", { name: /progress/i })).not.toBeInTheDocument();
   });
 
   it("shows the progress bar when shouldShowProgressBar is true", async () => {
     const name = "Finish";
     renderWithProviders(routes, "/form/finish");
-    await waitFor(() => expect(document.title).toBe(`${name} | Doula Common App`));
+    await waitFor(() => expect(document.title).toBe(`${name} | NJ Doula Assistant`));
     expect(screen.queryByRole("generic", { name: /progress/i })).toBeInTheDocument();
   });
 
@@ -22,7 +22,9 @@ describe("<FormLayout />", () => {
     renderWithProviders(routes, "/form/personal-details/2");
     const heading1 = screen.getByRole("heading", { level: 1 });
     expect(heading1).toHaveTextContent("2 of 3 Personal details");
-    await waitFor(() => expect(document.title).toBe("Personal details 2 of 3 | Doula Common App"));
+    await waitFor(() =>
+      expect(document.title).toBe("Personal details 2 of 3 | NJ Doula Assistant"),
+    );
   });
 
   it("shows required field indicator text with an asterisk", () => {

--- a/src/app/form/components/ProgressBar.test.tsx
+++ b/src/app/form/components/ProgressBar.test.tsx
@@ -32,7 +32,7 @@ describe("<ProgressBar />", () => {
       .getAllByRole("listitem")
       .map((section) => section.textContent);
     expect(names.includes(name)).toBe(true);
-    await waitFor(() => expect(document.title).toBe(`${name} | Doula Common App`));
+    await waitFor(() => expect(document.title).toBe(`${name} | NJ Doula Assistant`));
 
     const heading1 = screen.getByRole("heading", { level: 1 });
     expect(heading1).not.toHaveTextContent(name);


### PR DESCRIPTION
## Link to issue

This commit is somewhate related to #[21](https://github.com/newjersey/doula-pm/issues/21).

## What was done?

Not sure if this is the "final" application name, but at least make it consistent with the figma https://www.figma.com/design/2R3VxYvZQYsaIxBcWoA1kL/Doula-Prototypes?node-id=4295-12221&t=eVcm7PFZp60XgiSN-0

<img width="264" height="62" alt="image" src="https://github.com/user-attachments/assets/03dcdfe0-92c9-4a74-b034-ba8516225040" />
