### PR TITLE
[newjersey/doula-pm#84] Refactor test fields into separate files

### DIFF
--- a/src/app/form/(formSteps)/business-details/1/BusinessDetailsStep1.test.tsx
+++ b/src/app/form/(formSteps)/business-details/1/BusinessDetailsStep1.test.tsx
@@ -1,91 +1,22 @@
 import BusinessDetailsStep1 from "@/app/form/(formSteps)/business-details/1/BusinessDetailsStep1";
+import {
+  billingBusinessAddressSameAsOtherAddress,
+  businessAddressFields,
+  differentBusinessAddressSameAsOtherAddress,
+  mailingBusinessAddressSameAsOtherAddress,
+  maximalTestFields,
+  minimalTestFields,
+} from "@/app/form/(formSteps)/business-details/1/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestField,
-  createTestFields,
   testConditionalRender,
   testFillFromDataStore,
   testRequiredField,
   testSaveFieldsToDataStore,
-  type TestField,
 } from "@/app/form/_utils/testUtils/sharedTests";
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
-const businessAddressQuestion = "What is your business address?";
-
-const mailingBusinessAddressSameAsOtherAddress: TestField = createTestField({
-  name: /Mailing address/i,
-  dataStoreKey: "businessAddressSameAsOtherAddress",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "radio",
-  testValue: "mailing",
-});
-const billingBusinessAddressSameAsOtherAddress: TestField = createTestField({
-  name: /Billing address/i,
-  dataStoreKey: "businessAddressSameAsOtherAddress",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "radio",
-  testValue: "billing",
-});
-const differentBusinessAddressSameAsOtherAddress: TestField = createTestField({
-  name: "I wish to enter a new address",
-  dataStoreKey: "businessAddressSameAsOtherAddress",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "radio",
-  testValue: "different",
-});
-
-const businessAddressFields = createTestFields([
-  {
-    name: "Street address *",
-    dataStoreKey: "businessStreetAddress1",
-    required: true,
-    testValue: "Test address 1",
-    withinGroupName: businessAddressQuestion,
-    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
-  },
-  {
-    name: "Street address line 2",
-    dataStoreKey: "businessStreetAddress2",
-    required: false,
-    testValue: "Test address 2",
-    withinGroupName: businessAddressQuestion,
-    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
-  },
-  {
-    name: "City *",
-    dataStoreKey: "businessCity",
-    required: true,
-    testValue: "Test city",
-    withinGroupName: businessAddressQuestion,
-    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
-  },
-  {
-    name: "State *",
-    dataStoreKey: "businessState",
-    required: false,
-    role: "combobox",
-    testValue: "PA",
-    withinGroupName: businessAddressQuestion,
-    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
-  },
-  {
-    name: "ZIP code *",
-    dataStoreKey: "businessZip",
-    required: true,
-    testValue: "12345",
-    withinGroupName: businessAddressQuestion,
-    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
-  },
-]);
-
-const minimalTestFields = [mailingBusinessAddressSameAsOtherAddress];
-const allTestFields = [differentBusinessAddressSameAsOtherAddress, ...businessAddressFields];
 
 const mailingAddress = {
   streetAddress1: "123 Main St",
@@ -178,7 +109,7 @@ describe("<BusinessDetailsStep1 />", () => {
         const renderFunction = getRenderWithExistingData(mailingAddress);
         await testSaveFieldsToDataStore(
           [differentBusinessAddressSameAsOtherAddress, ...businessAddressFields],
-          allTestFields,
+          maximalTestFields,
           renderFunction,
           screen,
         );
@@ -200,7 +131,7 @@ describe("<BusinessDetailsStep1 />", () => {
         "when business address is different and $dataStoreKey is not filled in",
         async (field) => {
           const renderFunction = getRenderWithExistingData(mailingAddress);
-          await testRequiredField(field, allTestFields, renderFunction, screen);
+          await testRequiredField(field, maximalTestFields, renderFunction, screen);
         },
       );
     });

--- a/src/app/form/(formSteps)/business-details/1/testFields.ts
+++ b/src/app/form/(formSteps)/business-details/1/testFields.ts
@@ -1,0 +1,82 @@
+import {
+  createTestField,
+  createTestFields,
+  type TestField,
+} from "@/app/form/_utils/testUtils/sharedTests";
+
+const businessAddressQuestion = "What is your business address?";
+
+export const mailingBusinessAddressSameAsOtherAddress: TestField = createTestField({
+  name: /Mailing address/i,
+  dataStoreKey: "businessAddressSameAsOtherAddress",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "radio",
+  testValue: "mailing",
+});
+export const billingBusinessAddressSameAsOtherAddress: TestField = createTestField({
+  name: /Billing address/i,
+  dataStoreKey: "businessAddressSameAsOtherAddress",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "radio",
+  testValue: "billing",
+});
+export const differentBusinessAddressSameAsOtherAddress: TestField = createTestField({
+  name: "I wish to enter a new address",
+  dataStoreKey: "businessAddressSameAsOtherAddress",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "radio",
+  testValue: "different",
+});
+
+export const businessAddressFields = createTestFields([
+  {
+    name: "Street address *",
+    dataStoreKey: "businessStreetAddress1",
+    required: true,
+    testValue: "Test address 1",
+    withinGroupName: businessAddressQuestion,
+    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
+  },
+  {
+    name: "Street address line 2",
+    dataStoreKey: "businessStreetAddress2",
+    required: false,
+    testValue: "Test address 2",
+    withinGroupName: businessAddressQuestion,
+    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
+  },
+  {
+    name: "City *",
+    dataStoreKey: "businessCity",
+    required: true,
+    testValue: "Test city",
+    withinGroupName: businessAddressQuestion,
+    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
+  },
+  {
+    name: "State *",
+    dataStoreKey: "businessState",
+    required: false,
+    role: "combobox",
+    testValue: "PA",
+    withinGroupName: businessAddressQuestion,
+    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
+  },
+  {
+    name: "ZIP code *",
+    dataStoreKey: "businessZip",
+    required: true,
+    testValue: "12345",
+    withinGroupName: businessAddressQuestion,
+    prerequisiteField: differentBusinessAddressSameAsOtherAddress,
+  },
+]);
+
+export const minimalTestFields = [mailingBusinessAddressSameAsOtherAddress];
+export const maximalTestFields = [
+  differentBusinessAddressSameAsOtherAddress,
+  ...businessAddressFields,
+];

--- a/src/app/form/(formSteps)/business-details/2/BusinessDetailsStep2.test.tsx
+++ b/src/app/form/(formSteps)/business-details/2/BusinessDetailsStep2.test.tsx
@@ -1,4 +1,11 @@
 import BusinessDetailsStep2 from "@/app/form/(formSteps)/business-details/2/BusinessDetailsStep2";
+import {
+  einField,
+  maximalTestFields,
+  minimalTestFields,
+  noHasEin,
+  yesHasEin,
+} from "@/app/form/(formSteps)/business-details/2/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { fillField, getInputField } from "@/app/form/_utils/testUtils/fillInputs";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
@@ -13,42 +20,6 @@ import {
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const yesHasEin: TestField = {
-  name: "Yes",
-  dataStoreKey: "hasEin",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "true",
-  expectedValue: "true",
-  withinGroupName: "Do you have an Employee Identification Number (EIN)? Select one *",
-};
-const noHasEin: TestField = {
-  name: "No",
-  dataStoreKey: "hasEin",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "false",
-  expectedValue: "false",
-  withinGroupName: "Do you have an Employee Identification Number (EIN)? Select one *",
-};
-
-const minimalTestFields = [noHasEin];
-
-const einField: TestField = {
-  name: "EIN *",
-  dataStoreKey: "ein",
-  required: true,
-  requiredErrorMessage: "EIN is required",
-  role: "textbox",
-  testValue: "111111111",
-  expectedValue: "11-1111111",
-  prerequisiteField: yesHasEin,
-};
-
-const allTestFields = [yesHasEin, einField];
-
 describe("<BusinessDetailsStep2 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>
     renderWithProviders(<BusinessDetailsStep2 />, "/form/business-details/2", dataStore);
@@ -58,7 +29,7 @@ describe("<BusinessDetailsStep2 />", () => {
       await testSaveFieldsToDataStore(minimalTestFields, minimalTestFields, renderFunction, screen);
     });
     it("when the user does has an EIN", async () => {
-      await testSaveFieldsToDataStore(allTestFields, allTestFields, renderFunction, screen);
+      await testSaveFieldsToDataStore(maximalTestFields, maximalTestFields, renderFunction, screen);
     });
   });
   describe("marks fields as required and displays an error message", () => {
@@ -67,11 +38,11 @@ describe("<BusinessDetailsStep2 />", () => {
     });
 
     it("when the user has an EIN and EIN is not filled in", async () => {
-      await testRequiredField(einField, allTestFields, renderFunction, screen);
+      await testRequiredField(einField, maximalTestFields, renderFunction, screen);
     });
   });
 
-  it.each(allTestFields)(
+  it.each(maximalTestFields)(
     "fills $dataStoreKey from the data store when page is loaded",
     async (field: TestField) => {
       await testFillFromDataStore(field, renderFunction, screen);
@@ -86,7 +57,7 @@ describe("<BusinessDetailsStep2 />", () => {
     await testInvalidField(
       { ...einField, testValue: "111" },
       "Entered value does not match the EIN format",
-      allTestFields,
+      maximalTestFields,
       renderFunction,
       screen,
     );

--- a/src/app/form/(formSteps)/business-details/2/testFields.ts
+++ b/src/app/form/(formSteps)/business-details/2/testFields.ts
@@ -1,0 +1,37 @@
+import { type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+
+export const yesHasEin: TestField = {
+  name: "Yes",
+  dataStoreKey: "hasEin",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "true",
+  expectedValue: "true",
+  withinGroupName: "Do you have an Employee Identification Number (EIN)? Select one *",
+};
+export const noHasEin: TestField = {
+  name: "No",
+  dataStoreKey: "hasEin",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "false",
+  expectedValue: "false",
+  withinGroupName: "Do you have an Employee Identification Number (EIN)? Select one *",
+};
+
+export const minimalTestFields = [noHasEin];
+
+export const einField: TestField = {
+  name: "EIN *",
+  dataStoreKey: "ein",
+  required: true,
+  requiredErrorMessage: "EIN is required",
+  role: "textbox",
+  testValue: "111111111",
+  expectedValue: "11-1111111",
+  prerequisiteField: yesHasEin,
+};
+
+export const maximalTestFields = [yesHasEin, einField];

--- a/src/app/form/(formSteps)/business-details/3/BusinessDetailsStep3.test.tsx
+++ b/src/app/form/(formSteps)/business-details/3/BusinessDetailsStep3.test.tsx
@@ -1,72 +1,16 @@
 import BusinessDetailsStep3 from "@/app/form/(formSteps)/business-details/3/BusinessDetailsStep3";
+import {
+  maximalTestFields,
+  minimalTestFields,
+} from "@/app/form/(formSteps)/business-details/3/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
   testFillFromDataStore,
   testRequiredField,
   testSaveFieldsToDataStore,
-  type TestField,
 } from "@/app/form/_utils/testUtils/sharedTests";
 import { screen } from "@testing-library/react";
-
-const noHasUncollectedDebt: TestField = {
-  name: "No",
-  dataStoreKey: "hasUncollectedDebt",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "false",
-  expectedValue: "false",
-  withinGroupName:
-    "Do you have any uncollected debt to Medicare, Medicaid/NJ FamilyCare, or CHIP (Children's Health Insurance Program)? Select one *",
-};
-
-const yesHasUncollectedDebt: TestField = {
-  name: "Yes",
-  dataStoreKey: "hasUncollectedDebt",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "true",
-  expectedValue: "true",
-  withinGroupName:
-    "Do you have any uncollected debt to Medicare, Medicaid/NJ FamilyCare, or CHIP (Children's Health Insurance Program)? Select one *",
-};
-
-const noIsSubjectToPaymentSuspension: TestField = {
-  name: "No",
-  dataStoreKey: "isSubjectToPaymentSuspension",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "false",
-  expectedValue: "false",
-  withinGroupName:
-    "Have you ever been subject to a payment suspension under a federal health care program? Select one *",
-};
-
-const yesIsSubjectToPaymentSuspension: TestField = {
-  name: "Yes",
-  dataStoreKey: "isSubjectToPaymentSuspension",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "true",
-  expectedValue: "true",
-  withinGroupName:
-    "Have you ever been subject to a payment suspension under a federal health care program? Select one *",
-};
-
-const minimalTestFields: Array<TestField> = [
-  yesHasUncollectedDebt,
-  yesIsSubjectToPaymentSuspension,
-];
-const allTestFields: Array<TestField> = [
-  noHasUncollectedDebt,
-  noIsSubjectToPaymentSuspension,
-  yesHasUncollectedDebt,
-  yesIsSubjectToPaymentSuspension,
-];
 
 describe("<BusinessDetailsStep3 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>
@@ -83,7 +27,7 @@ describe("<BusinessDetailsStep3 />", () => {
     },
   );
 
-  it.each(allTestFields)(
+  it.each(maximalTestFields)(
     "fills $dataStoreKey from the data store when page is loaded",
     async (field) => {
       await testFillFromDataStore(field, renderFunction, screen);

--- a/src/app/form/(formSteps)/business-details/3/testFields.ts
+++ b/src/app/form/(formSteps)/business-details/3/testFields.ts
@@ -1,0 +1,60 @@
+import { type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+
+const noHasUncollectedDebt: TestField = {
+  name: "No",
+  dataStoreKey: "hasUncollectedDebt",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "false",
+  expectedValue: "false",
+  withinGroupName:
+    "Do you have any uncollected debt to Medicare, Medicaid/NJ FamilyCare, or CHIP (Children's Health Insurance Program)? Select one *",
+};
+
+const yesHasUncollectedDebt: TestField = {
+  name: "Yes",
+  dataStoreKey: "hasUncollectedDebt",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "true",
+  expectedValue: "true",
+  withinGroupName:
+    "Do you have any uncollected debt to Medicare, Medicaid/NJ FamilyCare, or CHIP (Children's Health Insurance Program)? Select one *",
+};
+
+const noIsSubjectToPaymentSuspension: TestField = {
+  name: "No",
+  dataStoreKey: "isSubjectToPaymentSuspension",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "false",
+  expectedValue: "false",
+  withinGroupName:
+    "Have you ever been subject to a payment suspension under a federal health care program? Select one *",
+};
+
+const yesIsSubjectToPaymentSuspension: TestField = {
+  name: "Yes",
+  dataStoreKey: "isSubjectToPaymentSuspension",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "true",
+  expectedValue: "true",
+  withinGroupName:
+    "Have you ever been subject to a payment suspension under a federal health care program? Select one *",
+};
+
+export const minimalTestFields: Array<TestField> = [
+  yesHasUncollectedDebt,
+  yesIsSubjectToPaymentSuspension,
+];
+export const maximalTestFields: Array<TestField> = [
+  noHasUncollectedDebt,
+  noIsSubjectToPaymentSuspension,
+  yesHasUncollectedDebt,
+  yesIsSubjectToPaymentSuspension,
+];

--- a/src/app/form/(formSteps)/business-details/4/BusinessDetailsStep4.test.tsx
+++ b/src/app/form/(formSteps)/business-details/4/BusinessDetailsStep4.test.tsx
@@ -1,72 +1,16 @@
 import BusinessDetailsStep4 from "@/app/form/(formSteps)/business-details/4/BusinessDetailsStep4";
+import {
+  maximalTestFields,
+  minimalTestFields,
+} from "@/app/form/(formSteps)/business-details/4/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
   testFillFromDataStore,
   testRequiredField,
   testSaveFieldsToDataStore,
-  type TestField,
 } from "@/app/form/_utils/testUtils/sharedTests";
 import { screen } from "@testing-library/react";
-
-const noHasBeenExcludedFromMedicaid: TestField = {
-  name: "No",
-  dataStoreKey: "hasBeenExcludedFromMedicaid",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "false",
-  expectedValue: "false",
-  withinGroupName:
-    "Have you ever been excluded or suspended by OIG (Office of Inspector General) from participation in Medicare, Medicaid/NJ FamilyCare, or CHIP? Select one *",
-};
-
-const yesHasBeenExcludedFromMedicaid: TestField = {
-  name: "Yes",
-  dataStoreKey: "hasBeenExcludedFromMedicaid",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "true",
-  expectedValue: "true",
-  withinGroupName:
-    "Have you ever been excluded or suspended by OIG (Office of Inspector General) from participation in Medicare, Medicaid/NJ FamilyCare, or CHIP? Select one *",
-};
-
-const noHasBeenSuspendedFromMedicaid: TestField = {
-  name: "No",
-  dataStoreKey: "hasBeenSuspendedFromMedicaid",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "false",
-  expectedValue: "false",
-  withinGroupName:
-    "Have you ever had Medicare, Medicaid/NJ FamilyCare, or CHIP enrollment/participation suspended, denied, revoked, or terminated? Select one *",
-};
-
-const yesHasBeenSuspendedFromMedicaid: TestField = {
-  name: "Yes",
-  dataStoreKey: "hasBeenSuspendedFromMedicaid",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "true",
-  expectedValue: "true",
-  withinGroupName:
-    "Have you ever had Medicare, Medicaid/NJ FamilyCare, or CHIP enrollment/participation suspended, denied, revoked, or terminated? Select one *",
-};
-
-const minimalTestFields: Array<TestField> = [
-  yesHasBeenExcludedFromMedicaid,
-  yesHasBeenSuspendedFromMedicaid,
-];
-const allTestFields: Array<TestField> = [
-  noHasBeenExcludedFromMedicaid,
-  noHasBeenSuspendedFromMedicaid,
-  yesHasBeenExcludedFromMedicaid,
-  yesHasBeenSuspendedFromMedicaid,
-];
 
 describe("<BusinessDetailsStep4 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>
@@ -83,7 +27,7 @@ describe("<BusinessDetailsStep4 />", () => {
     },
   );
 
-  it.each(allTestFields)(
+  it.each(maximalTestFields)(
     "fills $dataStoreKey from the data store when page is loaded",
     async (field) => {
       await testFillFromDataStore(field, renderFunction, screen);

--- a/src/app/form/(formSteps)/business-details/4/testFields.ts
+++ b/src/app/form/(formSteps)/business-details/4/testFields.ts
@@ -1,0 +1,60 @@
+import { type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+
+const noHasBeenExcludedFromMedicaid: TestField = {
+  name: "No",
+  dataStoreKey: "hasBeenExcludedFromMedicaid",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "false",
+  expectedValue: "false",
+  withinGroupName:
+    "Have you ever been excluded or suspended by OIG (Office of Inspector General) from participation in Medicare, Medicaid/NJ FamilyCare, or CHIP? Select one *",
+};
+
+const yesHasBeenExcludedFromMedicaid: TestField = {
+  name: "Yes",
+  dataStoreKey: "hasBeenExcludedFromMedicaid",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "true",
+  expectedValue: "true",
+  withinGroupName:
+    "Have you ever been excluded or suspended by OIG (Office of Inspector General) from participation in Medicare, Medicaid/NJ FamilyCare, or CHIP? Select one *",
+};
+
+const noHasBeenSuspendedFromMedicaid: TestField = {
+  name: "No",
+  dataStoreKey: "hasBeenSuspendedFromMedicaid",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "false",
+  expectedValue: "false",
+  withinGroupName:
+    "Have you ever had Medicare, Medicaid/NJ FamilyCare, or CHIP enrollment/participation suspended, denied, revoked, or terminated? Select one *",
+};
+
+const yesHasBeenSuspendedFromMedicaid: TestField = {
+  name: "Yes",
+  dataStoreKey: "hasBeenSuspendedFromMedicaid",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "true",
+  expectedValue: "true",
+  withinGroupName:
+    "Have you ever had Medicare, Medicaid/NJ FamilyCare, or CHIP enrollment/participation suspended, denied, revoked, or terminated? Select one *",
+};
+
+export const minimalTestFields: Array<TestField> = [
+  yesHasBeenExcludedFromMedicaid,
+  yesHasBeenSuspendedFromMedicaid,
+];
+export const maximalTestFields: Array<TestField> = [
+  noHasBeenExcludedFromMedicaid,
+  noHasBeenSuspendedFromMedicaid,
+  yesHasBeenExcludedFromMedicaid,
+  yesHasBeenSuspendedFromMedicaid,
+];

--- a/src/app/form/(formSteps)/insurance/1/InsuranceStep1.test.tsx
+++ b/src/app/form/(formSteps)/insurance/1/InsuranceStep1.test.tsx
@@ -1,10 +1,19 @@
 import InsuranceStep1 from "@/app/form/(formSteps)/insurance/1/InsuranceStep1";
+import {
+  amountPerAggregateField,
+  amountPerOccurrenceField,
+  coverageAmountFields,
+  insuranceCoverageFields,
+  insuranceEndDateDayField,
+  insuranceEndDateYearField,
+  insuranceStartDateDayField,
+  insuranceStartDateYearField,
+  testFields,
+} from "@/app/form/(formSteps)/insurance/1/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { getInputField } from "@/app/form/_utils/testUtils/fillInputs";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestField,
-  createTestFields,
   type TestField,
   testFillFromDataStore,
   testInvalidField,
@@ -13,94 +22,6 @@ import {
 } from "@/app/form/_utils/testUtils/sharedTests";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
-const insuranceStartDateDayField = createTestField({
-  name: "Day *",
-  dataStoreKey: "insuranceStartDateDay",
-  required: true,
-  testValue: "6",
-  withinGroupName: "Start date *",
-});
-
-const insuranceStartDateMonthField = createTestField({
-  name: "Month *",
-  dataStoreKey: "insuranceStartDateMonth",
-  required: true,
-  testValue: "07 - July",
-  expectedValue: "7",
-  role: "combobox",
-  withinGroupName: "Start date *",
-});
-
-const insuranceStartDateYearField = createTestField({
-  name: "Year *",
-  dataStoreKey: "insuranceStartDateYear",
-  required: true,
-  testValue: "1988",
-  withinGroupName: "Start date *",
-});
-
-const insuranceEndDateDayField = createTestField({
-  name: "Day *",
-  dataStoreKey: "insuranceEndDateDay",
-  required: true,
-  testValue: "30",
-  withinGroupName: "End date *",
-});
-
-const insuranceEndDateMonthField = createTestField({
-  name: "Month *",
-  dataStoreKey: "insuranceEndDateMonth",
-  required: true,
-  testValue: "02 - February",
-  expectedValue: "2",
-  role: "combobox",
-  withinGroupName: "End date *",
-});
-
-const insuranceEndDateYearField = createTestField({
-  name: "Year *",
-  dataStoreKey: "insuranceEndDateYear",
-  required: true,
-  testValue: "2025",
-  withinGroupName: "End date *",
-});
-
-const insuranceCoverageFields: Array<TestField> = createTestFields([
-  insuranceStartDateDayField,
-  insuranceStartDateMonthField,
-  insuranceStartDateYearField,
-  insuranceEndDateDayField,
-  insuranceEndDateMonthField,
-  insuranceEndDateYearField,
-]);
-
-const amountPerOccurrenceField: TestField = {
-  name: "Amount per occurrence *",
-  dataStoreKey: "insuranceOccurenceAmount",
-  requiredErrorMessage: "Amount per occurrence is required",
-  role: "textbox",
-  required: true,
-  testValue: "1000005",
-  expectedValue: "1000005",
-};
-
-const amountPerAggregateField: TestField = {
-  name: "Amount per aggregate *",
-  dataStoreKey: "insuranceAggregateAmount",
-  requiredErrorMessage: "Amount per aggregate is required",
-  role: "textbox",
-  required: true,
-  testValue: "3000300",
-  expectedValue: "3000300",
-};
-
-const coverageAmountFields: Array<TestField> = createTestFields([
-  amountPerOccurrenceField,
-  amountPerAggregateField,
-]);
-
-const testFields: Array<TestField> = [...insuranceCoverageFields, ...coverageAmountFields];
 
 describe("<InsuranceStep1 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>

--- a/src/app/form/(formSteps)/insurance/1/testFields.ts
+++ b/src/app/form/(formSteps)/insurance/1/testFields.ts
@@ -1,0 +1,93 @@
+import {
+  createTestField,
+  createTestFields,
+  type TestField,
+} from "@/app/form/_utils/testUtils/sharedTests";
+
+export const insuranceStartDateDayField = createTestField({
+  name: "Day *",
+  dataStoreKey: "insuranceStartDateDay",
+  required: true,
+  testValue: "6",
+  withinGroupName: "Start date *",
+});
+
+const insuranceStartDateMonthField = createTestField({
+  name: "Month *",
+  dataStoreKey: "insuranceStartDateMonth",
+  required: true,
+  testValue: "07 - July",
+  expectedValue: "7",
+  role: "combobox",
+  withinGroupName: "Start date *",
+});
+
+export const insuranceStartDateYearField = createTestField({
+  name: "Year *",
+  dataStoreKey: "insuranceStartDateYear",
+  required: true,
+  testValue: "1988",
+  withinGroupName: "Start date *",
+});
+
+export const insuranceEndDateDayField = createTestField({
+  name: "Day *",
+  dataStoreKey: "insuranceEndDateDay",
+  required: true,
+  testValue: "30",
+  withinGroupName: "End date *",
+});
+
+const insuranceEndDateMonthField = createTestField({
+  name: "Month *",
+  dataStoreKey: "insuranceEndDateMonth",
+  required: true,
+  testValue: "02 - February",
+  expectedValue: "2",
+  role: "combobox",
+  withinGroupName: "End date *",
+});
+
+export const insuranceEndDateYearField = createTestField({
+  name: "Year *",
+  dataStoreKey: "insuranceEndDateYear",
+  required: true,
+  testValue: "2025",
+  withinGroupName: "End date *",
+});
+
+export const insuranceCoverageFields: Array<TestField> = createTestFields([
+  insuranceStartDateDayField,
+  insuranceStartDateMonthField,
+  insuranceStartDateYearField,
+  insuranceEndDateDayField,
+  insuranceEndDateMonthField,
+  insuranceEndDateYearField,
+]);
+
+export const amountPerOccurrenceField: TestField = {
+  name: "Amount per occurrence *",
+  dataStoreKey: "insuranceOccurenceAmount",
+  requiredErrorMessage: "Amount per occurrence is required",
+  role: "textbox",
+  required: true,
+  testValue: "1000005",
+  expectedValue: "1000005",
+};
+
+export const amountPerAggregateField: TestField = {
+  name: "Amount per aggregate *",
+  dataStoreKey: "insuranceAggregateAmount",
+  requiredErrorMessage: "Amount per aggregate is required",
+  role: "textbox",
+  required: true,
+  testValue: "3000300",
+  expectedValue: "3000300",
+};
+
+export const coverageAmountFields: Array<TestField> = createTestFields([
+  amountPerOccurrenceField,
+  amountPerAggregateField,
+]);
+
+export const testFields: Array<TestField> = [...insuranceCoverageFields, ...coverageAmountFields];

--- a/src/app/form/(formSteps)/insurance/2/InsuranceStep2.test.tsx
+++ b/src/app/form/(formSteps)/insurance/2/InsuranceStep2.test.tsx
@@ -1,75 +1,19 @@
 import InsuranceStep2 from "@/app/form/(formSteps)/insurance/2/InsuranceStep2";
+import {
+  insuranceAddressFields,
+  insuranceDetailsFields,
+  testFields,
+} from "@/app/form/(formSteps)/insurance/2/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { fillAllInputsExcept } from "@/app/form/_utils/testUtils/fillInputs";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestFields,
   testFillFromDataStore,
   testRequiredField,
   testSaveFieldsToDataStore,
-  type TestField,
 } from "@/app/form/_utils/testUtils/sharedTests";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
-const insuranceAddressGroupName =
-  "Insurance address This is the office location of your insurance carrier.";
-
-const insuranceDetailsFields: TestField[] = createTestFields([
-  {
-    name: "Name of your insurance carrier *",
-    required: true,
-    dataStoreKey: "insuranceCarrierName",
-    testValue: "Test insurance carrier",
-  },
-  {
-    name: "Policy number *",
-    required: true,
-    dataStoreKey: "insurancePolicyNumber",
-    testValue: "ABC-12345",
-  },
-]);
-
-const insuranceAddressFields: TestField[] = createTestFields([
-  {
-    name: "Street address *",
-    required: true,
-    dataStoreKey: "insuranceStreetAddress1",
-    testValue: "Test insurance address 1",
-    withinGroupName: insuranceAddressGroupName,
-  },
-  {
-    name: "Street address line 2",
-    required: false,
-    dataStoreKey: "insuranceStreetAddress2",
-    testValue: "Test insurance address 2",
-    withinGroupName: insuranceAddressGroupName,
-  },
-  {
-    name: "City *",
-    required: true,
-    dataStoreKey: "insuranceCity",
-    testValue: "Test insurance city",
-    withinGroupName: insuranceAddressGroupName,
-  },
-  {
-    name: "State *",
-    required: false,
-    role: "combobox",
-    testValue: "NJ",
-    dataStoreKey: "insuranceState",
-    withinGroupName: insuranceAddressGroupName,
-  },
-  {
-    name: "ZIP code *",
-    required: true,
-    dataStoreKey: "insuranceZip",
-    testValue: "12345",
-    withinGroupName: insuranceAddressGroupName,
-  },
-]);
-
-const allTestFields = [...insuranceDetailsFields, ...insuranceAddressFields];
 
 const renderFunction = (dataStore: DataStore = {}) =>
   renderWithProviders(<InsuranceStep2 />, "/form/insurance/2", dataStore);
@@ -77,18 +21,13 @@ const renderFunction = (dataStore: DataStore = {}) =>
 describe("<InsuranceStep2 />", () => {
   describe("insurance details fields", () => {
     it("saves fields to the data store on submit", async () => {
-      await testSaveFieldsToDataStore(
-        insuranceDetailsFields,
-        allTestFields,
-        renderFunction,
-        screen,
-      );
+      await testSaveFieldsToDataStore(insuranceDetailsFields, testFields, renderFunction, screen);
     });
 
     it.each(insuranceDetailsFields)(
       "marks $dataStoreKey as required and displays an error message if it is not filed in",
       async (field) => {
-        await testRequiredField(field, allTestFields, renderFunction, screen);
+        await testRequiredField(field, testFields, renderFunction, screen);
       },
     );
 
@@ -102,18 +41,13 @@ describe("<InsuranceStep2 />", () => {
 
   describe("insurance address fields", () => {
     it("saves fields to the data store on submit", async () => {
-      await testSaveFieldsToDataStore(
-        insuranceAddressFields,
-        allTestFields,
-        renderFunction,
-        screen,
-      );
+      await testSaveFieldsToDataStore(insuranceAddressFields, testFields, renderFunction, screen);
     });
 
     it.each(insuranceAddressFields.filter((field) => field.required === true))(
       "marks $dataStoreKey as required and displays an error message if it is not filed in",
       async (field) => {
-        await testRequiredField(field, allTestFields, renderFunction, screen);
+        await testRequiredField(field, testFields, renderFunction, screen);
       },
     );
 
@@ -132,7 +66,7 @@ describe("<InsuranceStep2 />", () => {
       });
       expect(combobox).toHaveValue("NJ");
 
-      await fillAllInputsExcept(screen, user, allTestFields, new Set("insuranceState"));
+      await fillAllInputsExcept(screen, user, testFields, new Set("insuranceState"));
       await user.click(screen.getByRole("button", { name: "Next" }));
 
       expect(mockUpdateDataStore).toHaveBeenCalledWith(

--- a/src/app/form/(formSteps)/insurance/2/testFields.ts
+++ b/src/app/form/(formSteps)/insurance/2/testFields.ts
@@ -1,0 +1,60 @@
+import { createTestFields, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+
+const insuranceAddressGroupName =
+  "Insurance address This is the office location of your insurance carrier.";
+
+export const insuranceDetailsFields: TestField[] = createTestFields([
+  {
+    name: "Name of your insurance carrier *",
+    required: true,
+    dataStoreKey: "insuranceCarrierName",
+    testValue: "Test insurance carrier",
+  },
+  {
+    name: "Policy number *",
+    required: true,
+    dataStoreKey: "insurancePolicyNumber",
+    testValue: "ABC-12345",
+  },
+]);
+
+export const insuranceAddressFields: TestField[] = createTestFields([
+  {
+    name: "Street address *",
+    required: true,
+    dataStoreKey: "insuranceStreetAddress1",
+    testValue: "Test insurance address 1",
+    withinGroupName: insuranceAddressGroupName,
+  },
+  {
+    name: "Street address line 2",
+    required: false,
+    dataStoreKey: "insuranceStreetAddress2",
+    testValue: "Test insurance address 2",
+    withinGroupName: insuranceAddressGroupName,
+  },
+  {
+    name: "City *",
+    required: true,
+    dataStoreKey: "insuranceCity",
+    testValue: "Test insurance city",
+    withinGroupName: insuranceAddressGroupName,
+  },
+  {
+    name: "State *",
+    required: false,
+    role: "combobox",
+    testValue: "NJ",
+    dataStoreKey: "insuranceState",
+    withinGroupName: insuranceAddressGroupName,
+  },
+  {
+    name: "ZIP code *",
+    required: true,
+    dataStoreKey: "insuranceZip",
+    testValue: "12345",
+    withinGroupName: insuranceAddressGroupName,
+  },
+]);
+
+export const testFields = [...insuranceDetailsFields, ...insuranceAddressFields];

--- a/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.test.tsx
@@ -1,9 +1,17 @@
 import PersonalDetailsStep1 from "@/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1";
+import {
+  contactInformationFields,
+  dateOfBirthDayField,
+  dateOfBirthYearField,
+  emailField,
+  personalIdentificationFields,
+  phoneNumberField,
+  socialSecurityNumberField,
+  testFields,
+} from "@/app/form/(formSteps)/personal-details/1/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestField,
-  createTestFields,
   type TestField,
   testFillFromDataStore,
   testInvalidField,
@@ -13,85 +21,6 @@ import {
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const dateOfBirthDayField = createTestField({
-  name: "Day *",
-  dataStoreKey: "dateOfBirthDay",
-  required: true,
-  testValue: "6",
-});
-const dateOfBirthMonthField = createTestField({
-  name: "Month *",
-  dataStoreKey: "dateOfBirthMonth",
-  required: true,
-  testValue: "07 - July",
-  expectedValue: "7",
-  role: "combobox",
-});
-const dateOfBirthYearField = createTestField({
-  name: "Year *",
-  dataStoreKey: "dateOfBirthYear",
-  required: true,
-  testValue: "1988",
-});
-
-const socialSecurityNumberField = createTestField({
-  name: "Social security number *",
-  dataStoreKey: "socialSecurityNumber",
-  required: true,
-  testValue: "123456789",
-  expectedValue: "123-45-6789",
-  role: "textbox",
-});
-
-const personalIdentificationFields: Array<TestField> = [
-  ...createTestFields([
-    {
-      name: "First name *",
-      dataStoreKey: "firstName",
-      required: true,
-      testValue: "Test first name",
-    },
-    {
-      name: "Middle name",
-      dataStoreKey: "middleName",
-      required: false,
-      testValue: "Test middle name",
-    },
-    {
-      name: "Last name *",
-      dataStoreKey: "lastName",
-      required: true,
-      testValue: "Test last name",
-    },
-  ]),
-  dateOfBirthDayField,
-  dateOfBirthMonthField,
-  dateOfBirthYearField,
-  socialSecurityNumberField,
-];
-
-const emailField = createTestField({
-  name: "Email address *",
-  dataStoreKey: "email",
-  testValue: "test@test.com",
-  required: true,
-});
-
-const phoneNumberField = createTestField({
-  name: "Phone number *",
-  dataStoreKey: "phoneNumber",
-  testValue: "3211234567",
-  expectedValue: "321-123-4567",
-  required: true,
-});
-
-const contactInformationFields: Array<TestField> = [emailField, phoneNumberField];
-
-const allTestFields: Array<TestField> = [
-  ...personalIdentificationFields,
-  ...contactInformationFields,
-];
-
 describe("<PersonalDetailsStep1 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>
     renderWithProviders(<PersonalDetailsStep1 />, "/form/personal-details/1", dataStore);
@@ -100,7 +29,7 @@ describe("<PersonalDetailsStep1 />", () => {
     it("saves fields to the data store on submit", async () => {
       await testSaveFieldsToDataStore(
         personalIdentificationFields,
-        allTestFields,
+        testFields,
         renderFunction,
         screen,
       );
@@ -109,7 +38,7 @@ describe("<PersonalDetailsStep1 />", () => {
     it.each(personalIdentificationFields.filter((field) => field.required))(
       "marks $dataStoreKey as required and displays an error message if it is not filled in",
       async (field: TestField) => {
-        await testRequiredField(field, allTestFields, renderFunction, screen);
+        await testRequiredField(field, testFields, renderFunction, screen);
       },
     );
 
@@ -130,7 +59,7 @@ describe("<PersonalDetailsStep1 />", () => {
         await testInvalidField(
           { ...dateOfBirthDayField, testValue: invalidTestValue },
           expectedErrorMessage,
-          allTestFields,
+          testFields,
           renderFunction,
           screen,
         );
@@ -146,7 +75,7 @@ describe("<PersonalDetailsStep1 />", () => {
         await testInvalidField(
           { ...dateOfBirthYearField, testValue: invalidTestValue },
           expectedErrorMessage,
-          allTestFields,
+          testFields,
           renderFunction,
           screen,
         );
@@ -156,18 +85,13 @@ describe("<PersonalDetailsStep1 />", () => {
 
   describe("contact info fields", () => {
     it("saves fields to the data store on submit", async () => {
-      await testSaveFieldsToDataStore(
-        contactInformationFields,
-        allTestFields,
-        renderFunction,
-        screen,
-      );
+      await testSaveFieldsToDataStore(contactInformationFields, testFields, renderFunction, screen);
     });
 
     it.each(contactInformationFields.filter((field) => field.required))(
       "marks $dataStoreKey as required and displays an error message if it is not filled in",
       async (field: TestField) => {
-        await testRequiredField(field, allTestFields, renderFunction, screen);
+        await testRequiredField(field, testFields, renderFunction, screen);
       },
     );
 
@@ -182,7 +106,7 @@ describe("<PersonalDetailsStep1 />", () => {
       await testInvalidField(
         { ...phoneNumberField, testValue: "123" },
         "Entered value does not match phone number format",
-        allTestFields,
+        testFields,
         renderFunction,
         screen,
       );
@@ -192,7 +116,7 @@ describe("<PersonalDetailsStep1 />", () => {
       await testInvalidField(
         { ...socialSecurityNumberField, testValue: "123" },
         "Entered value does not match social security number format",
-        allTestFields,
+        testFields,
         renderFunction,
         screen,
       );
@@ -204,7 +128,7 @@ describe("<PersonalDetailsStep1 />", () => {
         await testInvalidField(
           { ...emailField, testValue: invalidTestValue },
           "Entered value does not match email format",
-          allTestFields,
+          testFields,
           renderFunction,
           screen,
         );

--- a/src/app/form/(formSteps)/personal-details/1/testFields.ts
+++ b/src/app/form/(formSteps)/personal-details/1/testFields.ts
@@ -1,0 +1,84 @@
+import {
+  createTestField,
+  createTestFields,
+  type TestField,
+} from "@/app/form/_utils/testUtils/sharedTests";
+
+export const dateOfBirthDayField = createTestField({
+  name: "Day *",
+  dataStoreKey: "dateOfBirthDay",
+  required: true,
+  testValue: "6",
+});
+const dateOfBirthMonthField = createTestField({
+  name: "Month *",
+  dataStoreKey: "dateOfBirthMonth",
+  required: true,
+  testValue: "07 - July",
+  expectedValue: "7",
+  role: "combobox",
+});
+export const dateOfBirthYearField = createTestField({
+  name: "Year *",
+  dataStoreKey: "dateOfBirthYear",
+  required: true,
+  testValue: "1988",
+});
+
+export const socialSecurityNumberField = createTestField({
+  name: "Social security number *",
+  dataStoreKey: "socialSecurityNumber",
+  required: true,
+  testValue: "123456789",
+  expectedValue: "123-45-6789",
+  role: "textbox",
+});
+
+export const personalIdentificationFields: Array<TestField> = [
+  ...createTestFields([
+    {
+      name: "First name *",
+      dataStoreKey: "firstName",
+      required: true,
+      testValue: "Test first name",
+    },
+    {
+      name: "Middle name",
+      dataStoreKey: "middleName",
+      required: false,
+      testValue: "Test middle name",
+    },
+    {
+      name: "Last name *",
+      dataStoreKey: "lastName",
+      required: true,
+      testValue: "Test last name",
+    },
+  ]),
+  dateOfBirthDayField,
+  dateOfBirthMonthField,
+  dateOfBirthYearField,
+  socialSecurityNumberField,
+];
+
+export const emailField = createTestField({
+  name: "Email address *",
+  dataStoreKey: "email",
+  testValue: "test@test.com",
+  required: true,
+});
+
+export const phoneNumberField = createTestField({
+  name: "Phone number *",
+  dataStoreKey: "phoneNumber",
+  testValue: "3211234567",
+  expectedValue: "321-123-4567",
+  required: true,
+});
+
+export const contactInformationFields: Array<TestField> = [emailField, phoneNumberField];
+
+export const testFields: Array<TestField> = [
+  ...personalIdentificationFields,
+  ...contactInformationFields,
+];

--- a/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
@@ -1,11 +1,19 @@
 import PersonalDetailsStep2 from "@/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2";
+import {
+  billingAddressFields,
+  mailingAddressFields,
+  mailingAddressQuestion,
+  minimalTestFields,
+  noSameBillingMailingAddress,
+  testFields,
+  yesSameBillingMailingAddress,
+  zipCodeField,
+} from "@/app/form/(formSteps)/personal-details/2/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { expectAddressHasAutocomplete } from "@/app/form/_utils/testUtils/autocomplete";
 import { getInputField } from "@/app/form/_utils/testUtils/fillInputs";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestField,
-  createTestFields,
   testConditionalRender,
   type TestField,
   testFillFromDataStore,
@@ -15,129 +23,6 @@ import {
 } from "@/app/form/_utils/testUtils/sharedTests";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
-const mailingAddressQuestion =
-  "Mailing address We will send official mail here. It can be your home address.";
-const billingAddressQuestion = "What is your billing address?";
-
-const mailingAddressFields = createTestFields([
-  {
-    name: "Street address *",
-    dataStoreKey: "streetAddress1",
-    required: true,
-    testValue: "Test address 1",
-    withinGroupName: mailingAddressQuestion,
-  },
-  {
-    name: "Street address line 2",
-    dataStoreKey: "streetAddress2",
-    required: false,
-    testValue: "Test address 2",
-    withinGroupName: mailingAddressQuestion,
-  },
-  {
-    name: "City *",
-    dataStoreKey: "city",
-    required: true,
-    testValue: "Test city",
-    withinGroupName: mailingAddressQuestion,
-  },
-  {
-    name: "State *",
-    dataStoreKey: "state",
-    required: false,
-    role: "combobox",
-    testValue: "PA",
-    withinGroupName: mailingAddressQuestion,
-  },
-  {
-    name: "ZIP code *",
-    dataStoreKey: "zip",
-    required: true,
-    testValue: "12345",
-    withinGroupName: mailingAddressQuestion,
-  },
-]);
-
-const yesSameBillingMailingAddress: TestField = {
-  name: "Yes",
-  dataStoreKey: "hasSameBillingMailingAddress",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "true",
-  expectedValue: "true",
-  withinGroupName: "Are your billing and residential addresses the same? Select one *",
-};
-const noSameBillingMailingAddress: TestField = {
-  name: "No",
-  dataStoreKey: "hasSameBillingMailingAddress",
-  required: true,
-  requiredErrorMessage: "This question is required",
-  role: "radio",
-  testValue: "false",
-  expectedValue: "false",
-  withinGroupName: "Are your billing and residential addresses the same? Select one *",
-};
-
-const minimalTestFields = [...mailingAddressFields, yesSameBillingMailingAddress];
-
-const zipCodeField = createTestField({
-  name: "ZIP code *",
-  dataStoreKey: "billingZip",
-  required: true,
-  testValue: "12345",
-  withinGroupName: billingAddressQuestion,
-  alternateRequiredFieldError: "Billing zip code is required",
-  prerequisiteField: noSameBillingMailingAddress,
-});
-
-const billingAddressFields = [
-  ...createTestFields([
-    {
-      name: "Street address *",
-      dataStoreKey: "billingStreetAddress1",
-      required: true,
-      testValue: "Test address 1",
-      withinGroupName: billingAddressQuestion,
-      alternateRequiredFieldError: "Billing street address is required",
-      prerequisiteField: noSameBillingMailingAddress,
-    },
-    {
-      name: "Street address line 2",
-      dataStoreKey: "billingStreetAddress2",
-      required: false,
-      testValue: "Test address 2",
-      withinGroupName: billingAddressQuestion,
-      prerequisiteField: noSameBillingMailingAddress,
-    },
-    {
-      name: "City *",
-      dataStoreKey: "billingCity",
-      required: true,
-      testValue: "Houston",
-      withinGroupName: billingAddressQuestion,
-      alternateRequiredFieldError: "Billing city is required",
-      prerequisiteField: noSameBillingMailingAddress,
-    },
-    {
-      name: "State *",
-      dataStoreKey: "billingState",
-      required: false,
-      role: "combobox",
-      testValue: "TX",
-      withinGroupName: billingAddressQuestion,
-      prerequisiteField: noSameBillingMailingAddress,
-    },
-  ]),
-  zipCodeField,
-];
-
-const allTestFields = [
-  ...mailingAddressFields,
-  noSameBillingMailingAddress,
-  ...billingAddressFields,
-];
 
 describe("<PersonalDetailsStep2 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>
@@ -188,7 +73,7 @@ describe("<PersonalDetailsStep2 />", () => {
       await testInvalidField(
         { ...zipCodeField, testValue: "1" },
         "Billing zip code must have five digits",
-        allTestFields,
+        testFields,
         renderFunction,
         screen,
       );
@@ -221,7 +106,7 @@ describe("<PersonalDetailsStep2 />", () => {
       it("when billing address is different from mailing address", async () => {
         await testSaveFieldsToDataStore(
           [noSameBillingMailingAddress, ...billingAddressFields],
-          allTestFields,
+          testFields,
           renderFunction,
           screen,
         );
@@ -241,7 +126,7 @@ describe("<PersonalDetailsStep2 />", () => {
       it.each(billingAddressFields.filter((field) => field.required))(
         "when mailing and billing address are different and $dataStoreKey is not filled in",
         async (field: TestField) => {
-          await testRequiredField(field, allTestFields, renderFunction, screen);
+          await testRequiredField(field, testFields, renderFunction, screen);
         },
       );
     });

--- a/src/app/form/(formSteps)/personal-details/2/testFields.ts
+++ b/src/app/form/(formSteps)/personal-details/2/testFields.ts
@@ -1,0 +1,128 @@
+import {
+  createTestField,
+  createTestFields,
+  type TestField,
+} from "@/app/form/_utils/testUtils/sharedTests";
+
+export const mailingAddressQuestion =
+  "Mailing address We will send official mail here. It can be your home address.";
+const billingAddressQuestion = "What is your billing address?";
+
+export const mailingAddressFields = createTestFields([
+  {
+    name: "Street address *",
+    dataStoreKey: "streetAddress1",
+    required: true,
+    testValue: "Test address 1",
+    withinGroupName: mailingAddressQuestion,
+  },
+  {
+    name: "Street address line 2",
+    dataStoreKey: "streetAddress2",
+    required: false,
+    testValue: "Test address 2",
+    withinGroupName: mailingAddressQuestion,
+  },
+  {
+    name: "City *",
+    dataStoreKey: "city",
+    required: true,
+    testValue: "Test city",
+    withinGroupName: mailingAddressQuestion,
+  },
+  {
+    name: "State *",
+    dataStoreKey: "state",
+    required: false,
+    role: "combobox",
+    testValue: "PA",
+    withinGroupName: mailingAddressQuestion,
+  },
+  {
+    name: "ZIP code *",
+    dataStoreKey: "zip",
+    required: true,
+    testValue: "12345",
+    withinGroupName: mailingAddressQuestion,
+  },
+]);
+
+export const yesSameBillingMailingAddress: TestField = {
+  name: "Yes",
+  dataStoreKey: "hasSameBillingMailingAddress",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "true",
+  expectedValue: "true",
+  withinGroupName: "Are your billing and residential addresses the same? Select one *",
+};
+export const noSameBillingMailingAddress: TestField = {
+  name: "No",
+  dataStoreKey: "hasSameBillingMailingAddress",
+  required: true,
+  requiredErrorMessage: "This question is required",
+  role: "radio",
+  testValue: "false",
+  expectedValue: "false",
+  withinGroupName: "Are your billing and residential addresses the same? Select one *",
+};
+
+export const minimalTestFields = [...mailingAddressFields, yesSameBillingMailingAddress];
+
+export const zipCodeField = createTestField({
+  name: "ZIP code *",
+  dataStoreKey: "billingZip",
+  required: true,
+  testValue: "12345",
+  withinGroupName: billingAddressQuestion,
+  alternateRequiredFieldError: "Billing zip code is required",
+  prerequisiteField: noSameBillingMailingAddress,
+});
+
+export const billingAddressFields = [
+  ...createTestFields([
+    {
+      name: "Street address *",
+      dataStoreKey: "billingStreetAddress1",
+      required: true,
+      testValue: "Test address 1",
+      withinGroupName: billingAddressQuestion,
+      alternateRequiredFieldError: "Billing street address is required",
+      prerequisiteField: noSameBillingMailingAddress,
+    },
+    {
+      name: "Street address line 2",
+      dataStoreKey: "billingStreetAddress2",
+      required: false,
+      testValue: "Test address 2",
+      withinGroupName: billingAddressQuestion,
+      prerequisiteField: noSameBillingMailingAddress,
+    },
+    {
+      name: "City *",
+      dataStoreKey: "billingCity",
+      required: true,
+      testValue: "Houston",
+      withinGroupName: billingAddressQuestion,
+      alternateRequiredFieldError: "Billing city is required",
+      prerequisiteField: noSameBillingMailingAddress,
+    },
+    {
+      name: "State *",
+      dataStoreKey: "billingState",
+      required: false,
+      role: "combobox",
+      testValue: "TX",
+      withinGroupName: billingAddressQuestion,
+      prerequisiteField: noSameBillingMailingAddress,
+    },
+  ]),
+  zipCodeField,
+];
+
+export const testFields = [
+  ...mailingAddressFields,
+  noSameBillingMailingAddress,
+  ...billingAddressFields,
+];

--- a/src/app/form/(formSteps)/personal-details/3/PersonalDetailsStep3.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/PersonalDetailsStep3.test.tsx
@@ -1,9 +1,13 @@
 import PersonalDetailsStep3 from "@/app/form/(formSteps)/personal-details/3/PersonalDetailsStep3";
+import {
+  doulaProviderIdentificationFields,
+  npiNumberField,
+  otherIdentificationFields,
+  testFields,
+} from "@/app/form/(formSteps)/personal-details/3/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestField,
-  createTestFields,
   type TestField,
   testFillFromDataStore,
   testInvalidField,
@@ -13,34 +17,6 @@ import {
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const npiNumberField = createTestField({
-  name: "National Provider Identifier (NPI) *",
-  required: true,
-  alternateRequiredFieldError:
-    "To be an NJ FamilyCare doula, you need a NPI. You can get yours via https://nppes.cms.hhs.gov/ . Enter your 10-digit NPI number.",
-  dataStoreKey: "npiNumber",
-  testValue: "1111111111",
-});
-
-const doulaProviderIdentificationFields = [npiNumberField];
-
-const otherIdentificationFields = createTestFields([
-  {
-    name: "UPIN number (optional)",
-    required: false,
-    dataStoreKey: "upinNumber",
-    testValue: "12345",
-  },
-  {
-    name: "Medicare provider ID (optional)",
-    required: false,
-    dataStoreKey: "medicareProviderId",
-    testValue: "ABC12345",
-  },
-]);
-
-const allTestFields = [...doulaProviderIdentificationFields, ...otherIdentificationFields];
-
 describe("<PersonalDetailsStep3 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>
     renderWithProviders(<PersonalDetailsStep3 />, "/form/personal-details/3", dataStore);
@@ -49,7 +25,7 @@ describe("<PersonalDetailsStep3 />", () => {
     it("saves fields to the data store on submit", async () => {
       await testSaveFieldsToDataStore(
         doulaProviderIdentificationFields,
-        allTestFields,
+        testFields,
         renderFunction,
         screen,
       );
@@ -58,7 +34,7 @@ describe("<PersonalDetailsStep3 />", () => {
     it.each(doulaProviderIdentificationFields.filter((field) => field.required))(
       "marks $dataStoreKey as required and displays an error message if it is not filled in",
       async (field: TestField) => {
-        await testRequiredField(field, allTestFields, renderFunction, screen);
+        await testRequiredField(field, testFields, renderFunction, screen);
       },
     );
 
@@ -73,7 +49,7 @@ describe("<PersonalDetailsStep3 />", () => {
       await testInvalidField(
         { ...npiNumberField, testValue: "1" },
         "National Provider Identifier (NPI) must have 10 digits",
-        allTestFields,
+        testFields,
         renderFunction,
         screen,
       );
@@ -97,7 +73,7 @@ describe("<PersonalDetailsStep3 />", () => {
     it("saves fields to the data store on submit", async () => {
       await testSaveFieldsToDataStore(
         otherIdentificationFields,
-        allTestFields,
+        testFields,
         renderFunction,
         screen,
       );

--- a/src/app/form/(formSteps)/personal-details/3/testFields.ts
+++ b/src/app/form/(formSteps)/personal-details/3/testFields.ts
@@ -1,0 +1,29 @@
+import { createTestField, createTestFields } from "@/app/form/_utils/testUtils/sharedTests";
+
+export const npiNumberField = createTestField({
+  name: "National Provider Identifier (NPI) *",
+  required: true,
+  alternateRequiredFieldError:
+    "To be an NJ FamilyCare doula, you need a NPI. You can get yours via https://nppes.cms.hhs.gov/ . Enter your 10-digit NPI number.",
+  dataStoreKey: "npiNumber",
+  testValue: "1111111111",
+});
+
+export const doulaProviderIdentificationFields = [npiNumberField];
+
+export const otherIdentificationFields = createTestFields([
+  {
+    name: "UPIN number (optional)",
+    required: false,
+    dataStoreKey: "upinNumber",
+    testValue: "12345",
+  },
+  {
+    name: "Medicare provider ID (optional)",
+    required: false,
+    dataStoreKey: "medicareProviderId",
+    testValue: "ABC12345",
+  },
+]);
+
+export const testFields = [...doulaProviderIdentificationFields, ...otherIdentificationFields];

--- a/src/app/form/(formSteps)/screening/1/ScreeningStep1.test.tsx
+++ b/src/app/form/(formSteps)/screening/1/ScreeningStep1.test.tsx
@@ -1,51 +1,30 @@
 import ScreeningStep1 from "@/app/form/(formSteps)/screening/1/ScreeningStep1";
+import {
+  noIsSoleProprietor,
+  testFields,
+  yesIsSoleProprietor,
+} from "@/app/form/(formSteps)/screening/1/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestField,
   testInvalidField,
   testSaveFieldsToDataStore,
-  type TestField,
 } from "@/app/form/_utils/testUtils/sharedTests";
 import { screen } from "@testing-library/react";
-
-const yesIsSoleProprietor: TestField = createTestField({
-  name: "Yes",
-  dataStoreKey: "isSoleProprietor",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "radio",
-  testValue: "true",
-  withinGroupName:
-    "Do you manage your business as an individual doula operating as a Sole Proprietor? Most NJ FamilyCare doulas operate as Sole Proprietor. Select one *",
-});
-
-const noIsSoleProprietor: TestField = createTestField({
-  name: "No",
-  dataStoreKey: "isSoleProprietor",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "radio",
-  testValue: "false",
-  withinGroupName:
-    "Do you manage your business as an individual doula operating as a Sole Proprietor? Most NJ FamilyCare doulas operate as Sole Proprietor. Select one *",
-});
-
-const allTestFields: Array<TestField> = [yesIsSoleProprietor];
 
 describe("<ScreeningStep1 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>
     renderWithProviders(<ScreeningStep1 />, "/form/screening/1", dataStore);
 
   it("saves fields to the data store on submit", async () => {
-    await testSaveFieldsToDataStore(allTestFields, allTestFields, renderFunction, screen);
+    await testSaveFieldsToDataStore(testFields, testFields, renderFunction, screen);
   });
 
   it("displays an error message if isSoleProprietor is no", async () => {
     await testInvalidField(
       noIsSoleProprietor,
       "Currently this site is only for Sole Proprietors. Please use the standard FFS application",
-      allTestFields,
+      testFields,
       renderFunction,
       screen,
       yesIsSoleProprietor,

--- a/src/app/form/(formSteps)/screening/1/testFields.ts
+++ b/src/app/form/(formSteps)/screening/1/testFields.ts
@@ -1,0 +1,25 @@
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+
+export const yesIsSoleProprietor: TestField = createTestField({
+  name: "Yes",
+  dataStoreKey: "isSoleProprietor",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "radio",
+  testValue: "true",
+  withinGroupName:
+    "Do you manage your business as an individual doula operating as a Sole Proprietor? Most NJ FamilyCare doulas operate as Sole Proprietor. Select one *",
+});
+
+export const noIsSoleProprietor: TestField = createTestField({
+  name: "No",
+  dataStoreKey: "isSoleProprietor",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "radio",
+  testValue: "false",
+  withinGroupName:
+    "Do you manage your business as an individual doula operating as a Sole Proprietor? Most NJ FamilyCare doulas operate as Sole Proprietor. Select one *",
+});
+
+export const testFields: Array<TestField> = [yesIsSoleProprietor];

--- a/src/app/form/(formSteps)/screening/2/ScreeningStep2.test.tsx
+++ b/src/app/form/(formSteps)/screening/2/ScreeningStep2.test.tsx
@@ -1,56 +1,23 @@
 import ScreeningStep2 from "@/app/form/(formSteps)/screening/2/ScreeningStep2";
+import {
+  testFields,
+  yesEverHadEmployees,
+  yesEverHadOtherBusinessOwner,
+} from "@/app/form/(formSteps)/screening/2/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestField,
   testInvalidField,
   testSaveFieldsToDataStore,
-  type TestField,
 } from "@/app/form/_utils/testUtils/sharedTests";
 import { screen } from "@testing-library/react";
-
-const noEverHadEmployees = createTestField({
-  name: "No",
-  role: "radio",
-  required: true,
-  dataStoreKey: "everHadEmployees",
-  testValue: "false",
-  withinGroupName: "Have you ever had employees in your doula business? Select one *",
-});
-const yesEverHadEmployees = createTestField({
-  name: "Yes",
-  role: "radio",
-  required: true,
-  dataStoreKey: "everHadEmployees",
-  testValue: "true",
-  withinGroupName: "Have you ever had employees in your doula business? Select one *",
-});
-
-const noEverHadOtherBusinessOwner = createTestField({
-  name: "No",
-  role: "radio",
-  required: true,
-  dataStoreKey: "everHadOtherBusinessOwner",
-  testValue: "false",
-  withinGroupName: "Did anyone other than you ever own a percentage of your business? Select one *",
-});
-const yesEverHadOtherBusinessOwner = createTestField({
-  name: "Yes",
-  role: "radio",
-  required: true,
-  dataStoreKey: "everHadOtherBusinessOwner",
-  testValue: "true",
-  withinGroupName: "Did anyone other than you ever own a percentage of your business? Select one *",
-});
-
-const allTestFields: Array<TestField> = [noEverHadEmployees, noEverHadOtherBusinessOwner];
 
 describe("<ScreeningStep2 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>
     renderWithProviders(<ScreeningStep2 />, "/form/screening/2", dataStore);
 
   it("saves fields to the data store on submit", async () => {
-    await testSaveFieldsToDataStore(allTestFields, allTestFields, renderFunction, screen);
+    await testSaveFieldsToDataStore(testFields, testFields, renderFunction, screen);
   });
 
   it.each([[yesEverHadEmployees], [yesEverHadOtherBusinessOwner]])(
@@ -59,7 +26,7 @@ describe("<ScreeningStep2 />", () => {
       await testInvalidField(
         invalidField,
         "Currently this site cannot support your situation. Please use the standard FFS application",
-        allTestFields,
+        testFields,
         renderFunction,
         screen,
         invalidField,

--- a/src/app/form/(formSteps)/screening/2/testFields.ts
+++ b/src/app/form/(formSteps)/screening/2/testFields.ts
@@ -1,0 +1,37 @@
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+
+const noEverHadEmployees = createTestField({
+  name: "No",
+  role: "radio",
+  required: true,
+  dataStoreKey: "everHadEmployees",
+  testValue: "false",
+  withinGroupName: "Have you ever had employees in your doula business? Select one *",
+});
+export const yesEverHadEmployees = createTestField({
+  name: "Yes",
+  role: "radio",
+  required: true,
+  dataStoreKey: "everHadEmployees",
+  testValue: "true",
+  withinGroupName: "Have you ever had employees in your doula business? Select one *",
+});
+
+const noEverHadOtherBusinessOwner = createTestField({
+  name: "No",
+  role: "radio",
+  required: true,
+  dataStoreKey: "everHadOtherBusinessOwner",
+  testValue: "false",
+  withinGroupName: "Did anyone other than you ever own a percentage of your business? Select one *",
+});
+export const yesEverHadOtherBusinessOwner = createTestField({
+  name: "Yes",
+  role: "radio",
+  required: true,
+  dataStoreKey: "everHadOtherBusinessOwner",
+  testValue: "true",
+  withinGroupName: "Did anyone other than you ever own a percentage of your business? Select one *",
+});
+
+export const testFields: Array<TestField> = [noEverHadEmployees, noEverHadOtherBusinessOwner];

--- a/src/app/form/(formSteps)/screening/3/ScreeningStep3.test.tsx
+++ b/src/app/form/(formSteps)/screening/3/ScreeningStep3.test.tsx
@@ -1,60 +1,23 @@
 import ScreeningStep3 from "@/app/form/(formSteps)/screening/3/ScreeningStep3";
+import {
+  testFields,
+  yesHadDhmasBusiness,
+  yesHaveOtherBusinessOwnerNextYear,
+} from "@/app/form/(formSteps)/screening/3/testFields";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestField,
   testInvalidField,
   testSaveFieldsToDataStore,
-  type TestField,
 } from "@/app/form/_utils/testUtils/sharedTests";
 import { screen } from "@testing-library/react";
-
-const noHaveOtherBusinessOwnerNextYear = createTestField({
-  name: "No",
-  role: "radio",
-  required: true,
-  dataStoreKey: "haveOtherBusinessOwnerNextYear",
-  testValue: "false",
-  withinGroupName:
-    "Do you anticipate anyone else having a percentage of your business in the next year? Select one *",
-});
-const yesHaveOtherBusinessOwnerNextYear = createTestField({
-  name: "Yes",
-  role: "radio",
-  required: true,
-  dataStoreKey: "haveOtherBusinessOwnerNextYear",
-  testValue: "true",
-  withinGroupName:
-    "Do you anticipate anyone else having a percentage of your business in the next year? Select one *",
-});
-
-const noHadDhmasBusiness = createTestField({
-  name: "No",
-  role: "radio",
-  required: true,
-  dataStoreKey: "hadDhmasBusiness",
-  testValue: "false",
-  withinGroupName:
-    "In the last 5 years, have you owned any percentage of companies that do business with the Division of Medical Assistance and Health Services? Select one *",
-});
-const yesHadDhmasBusiness = createTestField({
-  name: "Yes",
-  role: "radio",
-  required: true,
-  dataStoreKey: "hadDhmasBusiness",
-  testValue: "true",
-  withinGroupName:
-    "In the last 5 years, have you owned any percentage of companies that do business with the Division of Medical Assistance and Health Services? Select one *",
-});
-
-const allTestFields: Array<TestField> = [noHaveOtherBusinessOwnerNextYear, noHadDhmasBusiness];
 
 describe("<ScreeningStep3 />", () => {
   const renderFunction = (dataStore: DataStore = {}) =>
     renderWithProviders(<ScreeningStep3 />, "/form/screening/3", dataStore);
 
   it("saves fields to the data store on submit", async () => {
-    await testSaveFieldsToDataStore(allTestFields, allTestFields, renderFunction, screen);
+    await testSaveFieldsToDataStore(testFields, testFields, renderFunction, screen);
   });
 
   it.each([[yesHaveOtherBusinessOwnerNextYear], [yesHadDhmasBusiness]])(
@@ -63,7 +26,7 @@ describe("<ScreeningStep3 />", () => {
       await testInvalidField(
         invalidField,
         "Currently this site cannot support your situation. Please use the standard FFS application",
-        allTestFields,
+        testFields,
         renderFunction,
         screen,
         invalidField,

--- a/src/app/form/(formSteps)/screening/3/testFields.ts
+++ b/src/app/form/(formSteps)/screening/3/testFields.ts
@@ -1,0 +1,41 @@
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+
+const noHaveOtherBusinessOwnerNextYear = createTestField({
+  name: "No",
+  role: "radio",
+  required: true,
+  dataStoreKey: "haveOtherBusinessOwnerNextYear",
+  testValue: "false",
+  withinGroupName:
+    "Do you anticipate anyone else having a percentage of your business in the next year? Select one *",
+});
+export const yesHaveOtherBusinessOwnerNextYear = createTestField({
+  name: "Yes",
+  role: "radio",
+  required: true,
+  dataStoreKey: "haveOtherBusinessOwnerNextYear",
+  testValue: "true",
+  withinGroupName:
+    "Do you anticipate anyone else having a percentage of your business in the next year? Select one *",
+});
+
+const noHadDhmasBusiness = createTestField({
+  name: "No",
+  role: "radio",
+  required: true,
+  dataStoreKey: "hadDhmasBusiness",
+  testValue: "false",
+  withinGroupName:
+    "In the last 5 years, have you owned any percentage of companies that do business with the Division of Medical Assistance and Health Services? Select one *",
+});
+export const yesHadDhmasBusiness = createTestField({
+  name: "Yes",
+  role: "radio",
+  required: true,
+  dataStoreKey: "hadDhmasBusiness",
+  testValue: "true",
+  withinGroupName:
+    "In the last 5 years, have you owned any percentage of companies that do business with the Division of Medical Assistance and Health Services? Select one *",
+});
+
+export const testFields: Array<TestField> = [noHaveOtherBusinessOwnerNextYear, noHadDhmasBusiness];

--- a/src/app/form/(formSteps)/training/1/TrainingStep1.test.tsx
+++ b/src/app/form/(formSteps)/training/1/TrainingStep1.test.tsx
@@ -1,9 +1,18 @@
+import {
+  childrensFuturesTrainingOrganization,
+  maximalTestFields,
+  minimalTestFields,
+  nameOfTrainingOrganization,
+  noDoulaTrainingInPerson,
+  noneTrainingOrganization,
+  trainingAddressFields,
+  trainingInstructorFields,
+  yesDoulaTrainingInPerson,
+} from "@/app/form/(formSteps)/training/1/testFields";
 import TrainingStep1 from "@/app/form/(formSteps)/training/1/TrainingStep1";
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  createTestField,
-  createTestFields,
   testConditionalRender,
   testFillFromDataStore,
   testRequiredField,
@@ -13,145 +22,6 @@ import {
 import { fillField } from "@form/_utils/testUtils/fillInputs";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
-const trainingAddressGroupName = "What is the address of your training organization? *";
-
-const childrensFuturesTrainingOrganization: TestField = createTestField({
-  name: "Which state-approved training did you complete? Select one *",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "combobox",
-  testValue: "Children's Futures (Trenton)",
-  dataStoreKey: "stateApprovedTraining",
-});
-
-const noneTrainingOrganization: TestField = createTestField({
-  name: "Which state-approved training did you complete? Select one *",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "combobox",
-  testValue: "None of these",
-  dataStoreKey: "stateApprovedTraining",
-});
-
-const nameOfTrainingOrganization: TestField = createTestField({
-  name: "What is the name of your training organization? *",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "textbox",
-  testValue: "Test organization",
-  dataStoreKey: "nameOfTrainingOrganization",
-  prerequisiteField: noneTrainingOrganization,
-});
-
-const yesDoulaTrainingInPerson: TestField = createTestField({
-  name: "Yes, in person or hybrid",
-  dataStoreKey: "isDoulaTrainingInPerson",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "radio",
-  testValue: "true",
-  withinGroupName: "Did you attend your doula training classes in person? Select one *",
-});
-
-const noDoulaTrainingInPerson: TestField = createTestField({
-  name: "No, it was virtual",
-  dataStoreKey: "isDoulaTrainingInPerson",
-  required: true,
-  alternateRequiredFieldError: "This question is required",
-  role: "radio",
-  testValue: "false",
-  withinGroupName: "Did you attend your doula training classes in person? Select one *",
-});
-
-const trainingAddressFields: TestField[] = createTestFields([
-  {
-    name: "Street address *",
-    required: true,
-    dataStoreKey: "trainingStreetAddress1",
-    alternateRequiredFieldError: "Training street address is required",
-    testValue: "Test address 1",
-    withinGroupName: trainingAddressGroupName,
-    prerequisiteField: yesDoulaTrainingInPerson,
-  },
-  {
-    name: "Street address line 2",
-    required: false,
-    dataStoreKey: "trainingStreetAddress2",
-    testValue: "Test address 2",
-    withinGroupName: trainingAddressGroupName,
-    prerequisiteField: yesDoulaTrainingInPerson,
-  },
-  {
-    name: "City *",
-    required: true,
-    alternateRequiredFieldError: "Training city is required",
-    dataStoreKey: "trainingCity",
-    testValue: "Test city",
-    withinGroupName: trainingAddressGroupName,
-    prerequisiteField: yesDoulaTrainingInPerson,
-  },
-  {
-    name: "State *",
-    required: false,
-    alternateRequiredFieldError: "Training state is required",
-    role: "combobox",
-    testValue: "NJ",
-    dataStoreKey: "trainingState",
-    withinGroupName: trainingAddressGroupName,
-    prerequisiteField: yesDoulaTrainingInPerson,
-  },
-  {
-    name: "ZIP code *",
-    required: true,
-    alternateRequiredFieldError: "Training zip code is required",
-    dataStoreKey: "trainingZip",
-    testValue: "12345",
-    withinGroupName: trainingAddressGroupName,
-    prerequisiteField: yesDoulaTrainingInPerson,
-  },
-]);
-
-const trainingInstructorFields: TestField[] = createTestFields([
-  {
-    name: "First name *",
-    required: true,
-    dataStoreKey: "instructorFirstName",
-    testValue: "Jane",
-  },
-  {
-    name: "Last name *",
-    required: true,
-    dataStoreKey: "instructorLastName",
-    testValue: "Doe",
-  },
-  {
-    name: "Email address *",
-    required: true,
-    dataStoreKey: "instructorEmail",
-    testValue: "test@example.com",
-  },
-  {
-    name: "Phone number",
-    required: false,
-    dataStoreKey: "instructorPhoneNumber",
-    testValue: "111-111-1111",
-  },
-]);
-
-const minimalTestFields = [
-  childrensFuturesTrainingOrganization,
-  noDoulaTrainingInPerson,
-  ...trainingInstructorFields,
-];
-
-const allTestFields = [
-  noneTrainingOrganization,
-  nameOfTrainingOrganization,
-  yesDoulaTrainingInPerson,
-  ...trainingAddressFields,
-  ...trainingInstructorFields,
-];
 
 const renderFunction = (dataStore: DataStore = {}) =>
   renderWithProviders(<TrainingStep1 />, "/form/training/1", dataStore);
@@ -171,7 +41,7 @@ describe("<TrainingStep1 />", () => {
       it("when 'None of these' is selected and the training organization name is provided", async () => {
         await testSaveFieldsToDataStore(
           [noneTrainingOrganization, nameOfTrainingOrganization],
-          allTestFields,
+          maximalTestFields,
           renderFunction,
           screen,
         );
@@ -188,7 +58,12 @@ describe("<TrainingStep1 />", () => {
         );
       });
       it("when None of the these is selected and nameOfTrainingOrganization is not filled in", async () => {
-        await testRequiredField(nameOfTrainingOrganization, allTestFields, renderFunction, screen);
+        await testRequiredField(
+          nameOfTrainingOrganization,
+          maximalTestFields,
+          renderFunction,
+          screen,
+        );
       });
     });
 
@@ -236,7 +111,7 @@ describe("<TrainingStep1 />", () => {
       it("when training was in person or hybrid", async () => {
         await testSaveFieldsToDataStore(
           [yesDoulaTrainingInPerson, ...trainingAddressFields],
-          allTestFields,
+          maximalTestFields,
           renderFunction,
           screen,
         );
@@ -255,7 +130,7 @@ describe("<TrainingStep1 />", () => {
       it.each(trainingAddressFields.filter((field) => field.required))(
         "when training was in person or hybrid and $dataStoreKey is not filled in",
         async (field: TestField) => {
-          await testRequiredField(field, allTestFields, renderFunction, screen);
+          await testRequiredField(field, maximalTestFields, renderFunction, screen);
         },
       );
     });
@@ -263,7 +138,7 @@ describe("<TrainingStep1 />", () => {
     it.each(trainingAddressFields.filter((field) => field.required))(
       "marks $dataStoreKey as required and displays an error message if it is not filled in",
       async (field: TestField) => {
-        await testRequiredField(field, allTestFields, renderFunction, screen);
+        await testRequiredField(field, maximalTestFields, renderFunction, screen);
       },
     );
 

--- a/src/app/form/(formSteps)/training/1/testFields.ts
+++ b/src/app/form/(formSteps)/training/1/testFields.ts
@@ -1,0 +1,144 @@
+import {
+  createTestField,
+  createTestFields,
+  type TestField,
+} from "@/app/form/_utils/testUtils/sharedTests";
+
+const trainingAddressGroupName = "What is the address of your training organization? *";
+
+export const childrensFuturesTrainingOrganization: TestField = createTestField({
+  name: "Which state-approved training did you complete? Select one *",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "combobox",
+  testValue: "Children's Futures (Trenton)",
+  dataStoreKey: "stateApprovedTraining",
+});
+
+export const noneTrainingOrganization: TestField = createTestField({
+  name: "Which state-approved training did you complete? Select one *",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "combobox",
+  testValue: "None of these",
+  dataStoreKey: "stateApprovedTraining",
+});
+
+export const nameOfTrainingOrganization: TestField = createTestField({
+  name: "What is the name of your training organization? *",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "textbox",
+  testValue: "Test organization",
+  dataStoreKey: "nameOfTrainingOrganization",
+  prerequisiteField: noneTrainingOrganization,
+});
+
+export const yesDoulaTrainingInPerson: TestField = createTestField({
+  name: "Yes, in person or hybrid",
+  dataStoreKey: "isDoulaTrainingInPerson",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "radio",
+  testValue: "true",
+  withinGroupName: "Did you attend your doula training classes in person? Select one *",
+});
+
+export const noDoulaTrainingInPerson: TestField = createTestField({
+  name: "No, it was virtual",
+  dataStoreKey: "isDoulaTrainingInPerson",
+  required: true,
+  alternateRequiredFieldError: "This question is required",
+  role: "radio",
+  testValue: "false",
+  withinGroupName: "Did you attend your doula training classes in person? Select one *",
+});
+
+export const trainingAddressFields: TestField[] = createTestFields([
+  {
+    name: "Street address *",
+    required: true,
+    dataStoreKey: "trainingStreetAddress1",
+    alternateRequiredFieldError: "Training street address is required",
+    testValue: "Test address 1",
+    withinGroupName: trainingAddressGroupName,
+    prerequisiteField: yesDoulaTrainingInPerson,
+  },
+  {
+    name: "Street address line 2",
+    required: false,
+    dataStoreKey: "trainingStreetAddress2",
+    testValue: "Test address 2",
+    withinGroupName: trainingAddressGroupName,
+    prerequisiteField: yesDoulaTrainingInPerson,
+  },
+  {
+    name: "City *",
+    required: true,
+    alternateRequiredFieldError: "Training city is required",
+    dataStoreKey: "trainingCity",
+    testValue: "Test city",
+    withinGroupName: trainingAddressGroupName,
+    prerequisiteField: yesDoulaTrainingInPerson,
+  },
+  {
+    name: "State *",
+    required: false,
+    alternateRequiredFieldError: "Training state is required",
+    role: "combobox",
+    testValue: "NJ",
+    dataStoreKey: "trainingState",
+    withinGroupName: trainingAddressGroupName,
+    prerequisiteField: yesDoulaTrainingInPerson,
+  },
+  {
+    name: "ZIP code *",
+    required: true,
+    alternateRequiredFieldError: "Training zip code is required",
+    dataStoreKey: "trainingZip",
+    testValue: "12345",
+    withinGroupName: trainingAddressGroupName,
+    prerequisiteField: yesDoulaTrainingInPerson,
+  },
+]);
+
+export const trainingInstructorFields: TestField[] = createTestFields([
+  {
+    name: "First name *",
+    required: true,
+    dataStoreKey: "instructorFirstName",
+    testValue: "Jane",
+  },
+  {
+    name: "Last name *",
+    required: true,
+    dataStoreKey: "instructorLastName",
+    testValue: "Doe",
+  },
+  {
+    name: "Email address *",
+    required: true,
+    dataStoreKey: "instructorEmail",
+    testValue: "test@example.com",
+  },
+  {
+    name: "Phone number",
+    required: false,
+    dataStoreKey: "instructorPhoneNumber",
+    testValue: "111-111-1111",
+  },
+]);
+
+export const minimalTestFields = [
+  childrensFuturesTrainingOrganization,
+  noDoulaTrainingInPerson,
+  ...trainingInstructorFields,
+];
+
+export const maximalTestFields = [
+  noneTrainingOrganization,
+  nameOfTrainingOrganization,
+  yesDoulaTrainingInPerson,
+  ...trainingAddressFields,
+  ...trainingInstructorFields,
+];


### PR DESCRIPTION
## Link to issue

This commit contributes to #[84](https://github.com/newjersey/doula-pm/issues/84) and resolves #[255](https://github.com/newjersey/doula-pm/issues/255).

## What was done?
Both cypress and unit tests want to be able to fill the entire form and progress. Previously, form fields for unit tests were specified within the unit test file.

This commit
- Refactors the specification of these test form fields into a separate file, to enable cypress tests in the future to import and re-use them.
- Renames `allTestFields` variables to either just `testFields` if there's only one set of testFields in the file, or `maximalTestFields` if there is a `minimalTestFields` variable (see #[255](https://github.com/newjersey/doula-pm/issues/255) )

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- This is a test refactor. Consider code organization
