### PR TITLE
[newjersey/doula-pm#271] Only allow numeric inputs in insurance coverage amounts

### DIFF
--- a/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
@@ -1,5 +1,9 @@
 import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
+import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
+import { DoulaForm } from "@/app/form/components/DoulaForm";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
 
 describe("DoulaTextInput", () => {
   it("renders the input with a label", () => {
@@ -11,6 +15,40 @@ describe("DoulaTextInput", () => {
     expect(input).toBeInTheDocument();
     expect(input).not.toHaveAttribute("aria-invalid");
     expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("describes the input with a string hint", () => {
+    render(
+      <DoulaTextInput name="testInput" label="Test label" hint="Test hint" register={jest.fn()} />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toHaveAccessibleDescription("Test hint");
+  });
+
+  it("describes the input with the provided describedby", () => {
+    render(
+      <>
+        <DoulaTextInput
+          name="testInput"
+          label="Test label"
+          aria-describedby="anotherDescriptonID"
+          register={jest.fn()}
+        />
+        <span id="anotherDescriptonID">Additional description</span>
+      </>,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toHaveAccessibleDescription("Additional description");
+  });
+
+  it("includes both the input and provided input prefix", () => {
+    render(
+      <DoulaTextInput name="testInput" label="Test label" inputPrefix="$" register={jest.fn()} />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toBeInTheDocument();
+    const inputPrefix = screen.getByText("$", { exact: false });
+    expect(inputPrefix).toAppearBefore(input);
   });
 
   it("sets appropriate attributes when the input is required", () => {
@@ -35,28 +73,41 @@ describe("DoulaTextInput", () => {
     expect(input).not.toHaveAttribute("aria-describedby");
   });
 
-  it("describes the input with a string hint", () => {
-    render(
-      <DoulaTextInput name="testInput" label="Test label" hint="Test hint" register={jest.fn()} />,
-    );
-    const input = screen.getByRole("textbox", { name: "Test label" });
-    expect(input).toHaveAccessibleDescription("Test hint");
-  });
+  it("only allows numeric inputs when numericOnly is set", async () => {
+    interface TestFormData {
+      testInput: string;
+    }
+    const TestForm = () => {
+      const {
+        register,
+        handleSubmit,
+        formState: { errors },
+      } = useForm<TestFormData>({
+        defaultValues: {
+          testInput: "",
+        },
+      });
+      return (
+        <DoulaForm<TestFormData>
+          errors={errors}
+          handleSubmit={handleSubmit}
+          mayHaveThreeOrMoreErrors={false}
+        >
+          <DoulaTextInput name="testInput" label="Test label" numericOnly register={register} />
+        </DoulaForm>
+      );
+    };
 
-  it("it describes the input with the provided describedby", () => {
-    render(
-      <>
-        <DoulaTextInput
-          name="testInput"
-          label="Test label"
-          aria-describedby="anotherDescriptonID"
-          register={jest.fn()}
-        />
-        <span id="anotherDescriptonID">Additional description</span>
-      </>,
-    );
+    const user = userEvent.setup();
+    renderWithProviders(<TestForm />, "/form/personal-details/1");
+
     const input = screen.getByRole("textbox", { name: "Test label" });
-    expect(input).toHaveAccessibleDescription("Additional description");
+    await user.type(input, "aaa");
+    expect(input).toHaveValue("");
+    await user.type(input, "!!");
+    expect(input).toHaveValue("");
+    await user.type(input, "11");
+    expect(input).toHaveValue("11");
   });
 
   it("shows an error message and sets appropriate attributes when there is an error for the input", () => {

--- a/src/app/form/(formSteps)/components/DoulaTextInput.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.tsx
@@ -5,17 +5,22 @@ import {
 import { Hint } from "@/app/form/(formSteps)/components/Hint";
 import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
 import {
+  InputGroup,
+  InputPrefix,
   Label,
   TextInput,
   type TextInputProps,
   type ValidationStatus,
 } from "@trussworks/react-uswds";
 import type {
+  ChangeHandler,
   FieldErrors,
   FieldPath,
   FieldValues,
+  Path,
   RegisterOptions,
   UseFormRegister,
+  UseFormRegisterReturn,
 } from "react-hook-form";
 
 type wrappedAttributes = "type" | "name" | "required";
@@ -26,8 +31,10 @@ interface DoulaTextInputProps<T extends FieldValues>
   name: FieldPath<T>;
   label: React.ReactNode;
   hint?: string;
+  inputPrefix?: string;
   type?: TextInputProps["type"];
   required?: boolean;
+  numericOnly?: boolean;
   hideErrorMessage?: boolean;
   errors?: FieldErrors<T>;
   register: UseFormRegister<T>;
@@ -35,14 +42,35 @@ interface DoulaTextInputProps<T extends FieldValues>
   customErrorMessages?: Array<CustomErrorMessage>;
 }
 
+const wrapRegisterProps = <T extends FieldValues>(
+  registerProps: UseFormRegisterReturn<Path<T>>,
+  numericOnly: boolean | undefined,
+): UseFormRegisterReturn<Path<T>> => {
+  if (numericOnly === true) {
+    const { onChange, ...otherRegisterProps } = registerProps;
+    const wrappedOnChange: ChangeHandler = (e) => {
+      e.target.value = e.target.value.replace(/\D/g, "");
+      return onChange?.(e);
+    };
+    return {
+      ...otherRegisterProps,
+      onChange: wrappedOnChange,
+    };
+  }
+
+  return registerProps;
+};
+
 const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) => {
   const {
     name,
     label,
     hint,
+    inputPrefix,
     type,
     "aria-describedby": ariaDescribedby,
     required,
+    numericOnly,
     errors,
     hideErrorMessage,
     register,
@@ -64,6 +92,25 @@ const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) =>
     internallySetProps.validationStatus = errors[name] ? validationStatusError : undefined;
     internallySetProps["aria-invalid"] = errors[name] ? ("true" as const) : ("false" as const);
   }
+  let input = (
+    <TextInput
+      id={name}
+      type={type ?? "text"}
+      required={required}
+      {...internallySetProps}
+      {...otherProps}
+      {...wrapRegisterProps(register(name, registerOptions), numericOnly)}
+    />
+  );
+
+  if (inputPrefix) {
+    input = (
+      <InputGroup error={hasError}>
+        <InputPrefix>{inputPrefix}</InputPrefix>
+        {input}
+      </InputGroup>
+    );
+  }
 
   return (
     <>
@@ -71,14 +118,7 @@ const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) =>
         {label}
       </Label>
       {hint !== undefined && <Hint name={name} hint={hint} />}
-      <TextInput
-        id={name}
-        type={type ?? "text"}
-        required={required}
-        {...internallySetProps}
-        {...otherProps}
-        {...register(name, registerOptions)}
-      />
+      {input}
       {hasError && hideErrorMessage !== true && (
         <ErrorMessage name={name} errors={errors} customErrorMessages={customErrorMessages} />
       )}

--- a/src/app/form/(formSteps)/insurance/1/InsuranceStep1.test.tsx
+++ b/src/app/form/(formSteps)/insurance/1/InsuranceStep1.test.tsx
@@ -133,7 +133,6 @@ describe("<InsuranceStep1 />", () => {
     );
 
     it.each([
-      { invalidTestValue: "test", expectedErrorMessage: "Amount per occurrence must be a number" },
       {
         invalidTestValue: "999999",
         expectedErrorMessage:
@@ -153,7 +152,6 @@ describe("<InsuranceStep1 />", () => {
     );
 
     it.each([
-      { invalidTestValue: "test", expectedErrorMessage: "Amount per aggregate must be a number" },
       {
         invalidTestValue: "2999999",
         expectedErrorMessage:
@@ -169,6 +167,22 @@ describe("<InsuranceStep1 />", () => {
           renderFunction,
           screen,
         );
+      },
+    );
+
+    it.each([amountPerOccurrenceField, amountPerAggregateField])(
+      "prevents non-numeric inputs in $dataStoreKey",
+      async (testField) => {
+        const user = userEvent.setup();
+        renderFunction();
+        const input = await getInputField(screen, testField);
+
+        await user.type(input, "aaa");
+        expect(input).toHaveValue("");
+        await user.type(input, "!!");
+        expect(input).toHaveValue("");
+        await user.type(input, "11");
+        expect(input).toHaveValue("11");
       },
     );
   });

--- a/src/app/form/(formSteps)/insurance/1/InsuranceStep1.tsx
+++ b/src/app/form/(formSteps)/insurance/1/InsuranceStep1.tsx
@@ -296,21 +296,17 @@ const InsuranceStep1 = () => {
               required
               label={`${orderedInputNameToLabel["insuranceOccurenceAmount"]}`}
               hint={"Minimum should be $1,000,000"}
+              numericOnly
+              inputPrefix="$"
               register={register}
               errors={errors}
               inputMode="numeric"
               registerOptions={{
-                valueAsNumber: true,
                 required: `${orderedInputNameToLabel["insuranceOccurenceAmount"]} is required`,
                 min: {
                   value: 1000000,
                   message:
                     "Your coverage is not enough. You need $1,000,000 minimum coverage per occurrence to qualify.",
-                },
-                validate: (value) => {
-                  if (Number.isNaN(value) || typeof value === "string") {
-                    return `${orderedInputNameToLabel["insuranceOccurenceAmount"]} must be a number`;
-                  }
                 },
               }}
             />
@@ -319,6 +315,8 @@ const InsuranceStep1 = () => {
               required
               label={`${orderedInputNameToLabel["insuranceAggregateAmount"]}`}
               hint={"Minimum should be $3,000,000"}
+              numericOnly
+              inputPrefix="$"
               register={register}
               errors={errors}
               inputMode="numeric"
@@ -328,12 +326,6 @@ const InsuranceStep1 = () => {
                   value: 3000000,
                   message:
                     "Your coverage is not enough. You need a minimum aggregate coverage of $3,000,000 to qualify.",
-                },
-                valueAsNumber: true,
-                validate: (value) => {
-                  if (Number.isNaN(value) || typeof value === "string") {
-                    return `${orderedInputNameToLabel["insuranceAggregateAmount"]} must be a number`;
-                  }
                 },
               }}
             />

--- a/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/2/PersonalDetailsStep2.test.tsx
@@ -90,6 +90,8 @@ describe("<PersonalDetailsStep2 />", () => {
       expect(input).toHaveValue("");
       await user.type(input, "!!");
       expect(input).toHaveValue("");
+      await user.type(input, "11");
+      expect(input).toHaveValue("11");
     });
   });
 

--- a/src/app/form/(formSteps)/personal-details/3/PersonalDetailsStep3.test.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/PersonalDetailsStep3.test.tsx
@@ -66,6 +66,8 @@ describe("<PersonalDetailsStep3 />", () => {
       expect(input).toHaveValue("");
       await user.type(input, "!!");
       expect(input).toHaveValue("");
+      await user.type(input, "11");
+      expect(input).toHaveValue("11");
     });
   });
 


### PR DESCRIPTION
## Link to issue

This commit resolves #[271](https://github.com/newjersey/doula-pm/issues/271).

## What was done?
The insurance coverage amount fields have hint styled as "$1,000,000". Previously, the fields would allow users to enter non-numeric values, e.g. "$1,000,000" into the field. It would then error on form submission, with the message that the input value must be numbers only.

This commit changes prevents non-numeric inputs in the insurance coverage amount fields. It also adds the `$` prefix to the field.

## Accessibility
- [x] I have made sure this works with a screenreader!
    - Validated that the error summary and single-input-error focus works
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/form/insurance/1
- Try to break the two fields under "Coverage amount"

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

<img width="490" height="415" alt="image" src="https://github.com/user-attachments/assets/f7a5eefa-6c7e-41b4-b206-9341fa0f5961" />

</details>


<details>
<summary>After</summary>

Unable to input non-numeric inputs. Also has a $ prefix.

<img width="494" height="349" alt="image" src="https://github.com/user-attachments/assets/79a4e4b6-0cd3-43fc-b645-627f2bf0ca3c" />


</details>