### PR TITLE
fix: add HOSTNAME support in Dockerfile and Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,16 @@ COPY package.json package-lock.json* ./
 RUN npm ci
 COPY . .
 
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
 # Production image
 FROM node:lts-alpine AS runtime
 WORKDIR /app
-ENV NODE_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
 
 # Build arguments
 ARG BUILDTIME
@@ -42,8 +44,8 @@ LABEL version="${VERSION}"
 LABEL build.date="${BUILDTIME}"
 LABEL build.revision="${REVISION}"
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+RUN addgroup --system --gid 1001 nodejs \
+  && adduser --system --uid 1001 --ingroup nodejs nextjs
 
 # Install curl for health check
 RUN apk add --no-cache curl
@@ -66,7 +68,7 @@ EXPOSE 3000
 
 # Health check using curl
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:3000/api/health || exit 1
+  CMD curl -f http://127.0.0.1:3000/api/health || exit 1
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  doula-medicaid:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # optional build-time metadata; populate via .env or CI
+        VERSION: ${VERSION:-dev}
+        BUILDTIME: ${BUILDTIME:-unknown}
+        REVISION: ${REVISION:-unknown}
+    image: newjersey/doula-medicaid:${VERSION:-dev}
+    container_name: doula-medicaid
+    restart: "${RESTART_POLICY:-unless-stopped}"
+    networks:
+      - doula-medicaid-network
+    ports:
+      - "${HOST_PORT:-3000}:3000"
+    env_file:
+      - .env
+    environment:
+      - NODE_ENV=production
+      - NEXT_TELEMETRY_DISABLED=1
+      - HOSTNAME=${HOSTNAME:-0.0.0.0}
+      - PORT=${PORT:-3000}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    volumes:
+      # Fast tmpfs for Next.js cache
+      - doula-next-cache:/app/.next/cache
+      # Optional: persistent volume for any data that needs to survive restarts
+      - doula-data:/app/data
+
+networks:
+  doula-medicaid-network:
+    driver: bridge
+    name: doula-medicaid-network
+
+volumes:
+  doula-next-cache:
+    # tmpfs for Next.js cache - faster builds, cleaner restarts
+    name: doula-next-cache
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: "size=1024m"
+  doula-data:
+    # persistent volume for any data that needs to survive restarts
+    name: doula-data
+    driver: local


### PR DESCRIPTION
## What was done?

Introduce HOSTNAME environment variable support in the Dockerfile and Docker Compose configuration to enhance container networking flexibility. Adjustments ensure proper health checks and environment variable handling.

## How should a reviewer test?

```shell
docker compose up -d
docker compose ps
```