### PR TITLE
[newjersey/doula-pm#267] Add analytics events

### DIFF
--- a/src/app/form/(formSteps)/components/FormProgressButtons.test.tsx
+++ b/src/app/form/(formSteps)/components/FormProgressButtons.test.tsx
@@ -1,7 +1,10 @@
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
+import * as nextThirdPartiesGoogle from "@next/third-parties/google";
 import { within } from "@testing-library/dom";
 import { screen } from "@testing-library/react";
+
+const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
 
 const getFormProgressButtonsList = () => {
   const allLists = screen.getAllByRole("list");
@@ -19,40 +22,58 @@ const getFormProgressButtonsList = () => {
 };
 
 describe("<FormProgressButtons />", () => {
-  it("shows only the next button when on the first step", async () => {
-    renderWithProviders(<FormProgressButtons />, "/form/welcome");
+  describe("shows appropriate buttons depending on the page", () => {
+    it("shows only the next button when on the first step", async () => {
+      renderWithProviders(<FormProgressButtons />, "/form/welcome");
 
-    const formProgressButtonGroup = getFormProgressButtonsList();
-    expect(within(formProgressButtonGroup).getAllByRole("listitem").length).toEqual(1);
+      const formProgressButtonGroup = getFormProgressButtonsList();
+      expect(within(formProgressButtonGroup).getAllByRole("listitem").length).toEqual(1);
 
-    expect(screen.queryByRole("link", { name: "Previous" })).not.toBeInTheDocument();
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    expect(nextButton).toHaveAttribute("type", "submit");
+      expect(screen.queryByRole("link", { name: "Previous" })).not.toBeInTheDocument();
+      const nextButton = screen.getByRole("button", { name: "Next" });
+      expect(nextButton).toHaveAttribute("type", "submit");
+    });
+
+    it("shows both previous and next buttons when on a middle step", async () => {
+      renderWithProviders(<FormProgressButtons />, "/form/personal-details/2");
+
+      const formProgressButtonGroup = getFormProgressButtonsList();
+      expect(within(formProgressButtonGroup).getAllByRole("listitem").length).toEqual(2);
+
+      expect(screen.getByRole("link", { name: "Previous" })).toHaveAttribute(
+        "href",
+        "/form/personal-details/1",
+      );
+      const nextButton = screen.getByRole("button", { name: "Next" });
+      expect(nextButton).toHaveAttribute("type", "submit");
+    });
+
+    it("shows only the previous button when on the last step", () => {
+      renderWithProviders(<FormProgressButtons />, "/form/finish");
+
+      const formProgressButtonGroup = getFormProgressButtonsList();
+      expect(within(formProgressButtonGroup).getAllByRole("listitem").length).toEqual(1);
+
+      expect(screen.getByRole("link", { name: "Previous" })).toHaveAttribute(
+        "href",
+        "/form/business-details/4",
+      );
+    });
   });
 
-  it("shows both previous and next buttons when on a middle step", async () => {
-    renderWithProviders(<FormProgressButtons />, "/form/personal-details/2");
-
-    const formProgressButtonGroup = getFormProgressButtonsList();
-    expect(within(formProgressButtonGroup).getAllByRole("listitem").length).toEqual(2);
-
-    expect(screen.getByRole("link", { name: "Previous" })).toHaveAttribute(
-      "href",
-      "/form/personal-details/1",
-    );
-    const nextButton = screen.getByRole("button", { name: "Next" });
-    expect(nextButton).toHaveAttribute("type", "submit");
-  });
-
-  it("shows only the previous button when on the last step", () => {
-    renderWithProviders(<FormProgressButtons />, "/form/finish");
-
-    const formProgressButtonGroup = getFormProgressButtonsList();
-    expect(within(formProgressButtonGroup).getAllByRole("listitem").length).toEqual(1);
-
-    expect(screen.getByRole("link", { name: "Previous" })).toHaveAttribute(
-      "href",
-      "/form/business-details/4",
-    );
+  describe("sends GA events", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+    it("when Next is clicked", async () => {
+      renderWithProviders(<FormProgressButtons />, "/form/personal-details/2");
+      await screen.getByRole("button", { name: "Next" }).click();
+      expect(mockSendGAEvent).toHaveBeenCalledWith("event", "buttonClicked", { name: "next" });
+    });
+    it("when Previous is clicked", async () => {
+      renderWithProviders(<FormProgressButtons />, "/form/personal-details/2");
+      await screen.getByRole("link", { name: "Previous" }).click();
+      expect(mockSendGAEvent).toHaveBeenCalledWith("event", "buttonClicked", { name: "previous" });
+    });
   });
 });

--- a/src/app/form/(formSteps)/components/FormProgressButtons.tsx
+++ b/src/app/form/(formSteps)/components/FormProgressButtons.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { formatFormProgressUrl, useFormProgressPosition } from "@form/_utils/formProgressRouting";
+import { sendGAEvent } from "@next/third-parties/google";
 import { Button, ButtonGroup } from "@trussworks/react-uswds";
 import { NavLink } from "react-router";
 
@@ -14,6 +15,7 @@ const FormProgressButtons = (props: { overrideClassNames?: string }) => {
         key="previous"
         to={formatFormProgressUrl(formProgressPosition.previous)}
         className="usa-button usa-button--outline margin-top-0"
+        onClick={() => sendGAEvent("event", "buttonClicked", { name: "previous" })}
       >
         Previous
       </NavLink>,
@@ -21,7 +23,12 @@ const FormProgressButtons = (props: { overrideClassNames?: string }) => {
   }
   if (formProgressPosition.next !== null) {
     buttons.push(
-      <Button key="next" type="submit" className="margin-top-0">
+      <Button
+        key="next"
+        type="submit"
+        className="margin-top-0"
+        onClick={() => sendGAEvent("event", "buttonClicked", { name: "next" })}
+      >
         Next
       </Button>,
     );

--- a/src/app/form/(formSteps)/finish/FinishSection.test.tsx
+++ b/src/app/form/(formSteps)/finish/FinishSection.test.tsx
@@ -3,6 +3,7 @@ import { type DataStore } from "@/app/form/_utils/dataStore";
 import { generateDataStoreWithRequiredFields } from "@/app/form/_utils/fillPdf/testUtils/formData";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import { jest } from "@jest/globals";
+import * as nextThirdPartiesGoogle from "@next/third-parties/google";
 import { screen, waitFor } from "@testing-library/react";
 
 jest.mock("@form/_utils/fillPdf/form", () => ({
@@ -14,6 +15,7 @@ jest.mock("@form/_utils/fillPdf/form", () => ({
 
 const mockCreateObjectURL = jest.fn();
 (global.URL.createObjectURL as jest.Mock) = mockCreateObjectURL;
+const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
 
 const renderFunction = (dataStore: DataStore) =>
   renderWithProviders(<FinishSection />, "/form/finish/1", dataStore);
@@ -32,12 +34,17 @@ describe("<FinishSection />", () => {
     expect(screen.queryByRole("link", { name: "Next" })).not.toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getByText("Download your application")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Download your application" })).toBeInTheDocument();
     });
 
     const downloadLink = screen.getByRole("link", { name: "Download your application" });
     expect(downloadLink).toHaveAttribute("href", "mock-blob-url");
     expect(downloadLink).toHaveAttribute("download", "Fee For Service Application.pdf");
+
+    await downloadLink.click();
+    expect(mockSendGAEvent).toHaveBeenCalledWith("event", "buttonClicked", {
+      name: "downloadApplication",
+    });
   });
 
   it("shows a message if not all required fields have been filled", async () => {

--- a/src/app/form/(formSteps)/finish/FinishSection.tsx
+++ b/src/app/form/(formSteps)/finish/FinishSection.tsx
@@ -5,6 +5,7 @@ import { useDataStore } from "@/app/form/_utils/DataStoreProvider";
 import { fillFfsIndividualForm } from "@/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { getFormData } from "@form/_utils/fillPdf/form";
+import { sendGAEvent } from "@next/third-parties/google";
 import { useEffect, useState } from "react";
 
 const FinishSection = () => {
@@ -69,6 +70,7 @@ const FinishSection = () => {
               href={downloadData.url}
               download={downloadData.filename}
               className="usa-button margin-right-0 margin-top-4"
+              onClick={() => sendGAEvent("event", "buttonClicked", { name: "downloadApplication" })}
             >
               Download your application
             </a>

--- a/src/app/form/(formSteps)/welcome/WelcomeSection.test.tsx
+++ b/src/app/form/(formSteps)/welcome/WelcomeSection.test.tsx
@@ -1,0 +1,18 @@
+import WelcomeSection from "@/app/form/(formSteps)/welcome/WelcomeSection";
+import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
+import * as nextThirdPartiesGoogle from "@next/third-parties/google";
+import { screen } from "@testing-library/react";
+
+const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
+
+describe("<WelcomeSection />", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sends a GA event when Start Now is clicked", async () => {
+    renderWithProviders(<WelcomeSection />, "/form/welcome");
+    await screen.getByRole("link", { name: "Start now" }).click();
+    expect(mockSendGAEvent).toHaveBeenCalledWith("event", "buttonClicked", { name: "startNow" });
+  });
+});

--- a/src/app/form/(formSteps)/welcome/WelcomeSection.tsx
+++ b/src/app/form/(formSteps)/welcome/WelcomeSection.tsx
@@ -3,6 +3,7 @@ import {
   formatFormProgressUrl,
   useFormProgressPosition,
 } from "@/app/form/_utils/formProgressRouting";
+import { sendGAEvent } from "@next/third-parties/google";
 import {
   Accordion,
   Icon,
@@ -109,6 +110,7 @@ const WelcomeSection = () => {
             key="start"
             to={formatFormProgressUrl(formProgressPosition.next)}
             className="usa-button margin-top-0"
+            onClick={() => sendGAEvent("event", "buttonClicked", { name: "startNow" })}
           >
             Start now
           </NavLink>

--- a/src/app/form/components/DoulaForm.test.tsx
+++ b/src/app/form/components/DoulaForm.test.tsx
@@ -7,6 +7,7 @@ import {
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import { createTestFields, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
 import { DoulaForm } from "@/app/form/components/DoulaForm";
+import * as nextThirdPartiesGoogle from "@next/third-parties/google";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Label, TextInput } from "@trussworks/react-uswds";
@@ -146,6 +147,7 @@ const doulaTestFormFields: TestField[] = createTestFields([
 ]);
 
 const mockNavigate = jest.fn();
+const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
 
 describe("submission behavior", () => {
   beforeEach(() => {
@@ -181,12 +183,23 @@ describe("submission behavior", () => {
     await fillAllInputsExcept(screen, user, doulaTestFormFields, new Set(["field1"]));
     await user.click(screen.getByRole("button", { name: "Next" }));
 
+    expect(mockSendGAEvent).toHaveBeenCalledWith("event", "formValidationError", {
+      fieldName: "field1",
+      type: "required",
+    });
+    expect(mockSendGAEvent).not.toHaveBeenCalledWith("event", "formValidationError", {
+      fieldName: "field2",
+      type: "required",
+    });
     expect(mockUpdateDataStore).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 });
 
 describe("error summary", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   describe("when mayHaveThreeOrMoreErrors is true", () => {
     it("shows an error summary if there are 3 or more errors", async () => {
       const user = userEvent.setup();
@@ -211,6 +224,19 @@ describe("error summary", () => {
       for (const errorMessage of expectedErrorMessages) {
         expect(focusedElement).toHaveTextContent(errorMessage);
       }
+
+      expect(mockSendGAEvent).toHaveBeenCalledWith("event", "formValidationError", {
+        fieldName: "field1",
+        type: "required",
+      });
+      expect(mockSendGAEvent).toHaveBeenCalledWith("event", "formValidationError", {
+        fieldName: "field2",
+        type: "required",
+      });
+      expect(mockSendGAEvent).toHaveBeenCalledWith("event", "formValidationError", {
+        fieldName: "field3",
+        type: "required",
+      });
     });
 
     it("does not show an error summary if there are fewer than 3 errors, instead it focuses on the first error", async () => {
@@ -237,6 +263,19 @@ describe("error summary", () => {
       const errorMessage = "Label 2 is required";
       const focusedElement = document.activeElement as HTMLElement;
       expect(focusedElement).toHaveAccessibleDescription(errorMessage);
+
+      expect(mockSendGAEvent).not.toHaveBeenCalledWith("event", "formValidationError", {
+        fieldName: "field1",
+        type: "required",
+      });
+      expect(mockSendGAEvent).toHaveBeenCalledWith("event", "formValidationError", {
+        fieldName: "field2",
+        type: "required",
+      });
+      expect(mockSendGAEvent).toHaveBeenCalledWith("event", "formValidationError", {
+        fieldName: "field3",
+        type: "required",
+      });
     });
   });
 

--- a/src/app/form/components/DoulaForm.tsx
+++ b/src/app/form/components/DoulaForm.tsx
@@ -2,6 +2,7 @@ import ErrorSummary from "@/app/form/(formSteps)/components/ErrorSummary";
 import {} from "@/app/form/_utils/dataStore";
 import { useDataStore } from "@/app/form/_utils/DataStoreProvider";
 import { formatFormProgressUrl, useFormProgressPosition } from "@form/_utils/formProgressRouting";
+import { sendGAEvent } from "@next/third-parties/google";
 import { Form } from "@trussworks/react-uswds";
 import { useEffect, useRef, useState } from "react";
 import type {
@@ -32,7 +33,6 @@ type DoulaFormProps<T extends FieldValues> =
     };
 
 export const DoulaForm = <T extends FieldValues>(props: DoulaFormProps<T>) => {
-  let onSubmitHandler;
   const navigate = useNavigate();
   const formProgressPosition = useFormProgressPosition();
   const [shouldSummarizeErrors, setShouldSummarizeErrors] = useState(false);
@@ -55,9 +55,14 @@ export const DoulaForm = <T extends FieldValues>(props: DoulaFormProps<T>) => {
       navigate(formatFormProgressUrl(formProgressPosition.next));
     }
   };
-
-  if (props.mayHaveThreeOrMoreErrors) {
-    const onError = (errors: FieldErrors<T>) => {
+  const onError = (errors: FieldErrors<T>) => {
+    for (const name of Object.keys(errors)) {
+      sendGAEvent("event", "formValidationError", {
+        fieldName: name,
+        type: errors[name]?.type,
+      });
+    }
+    if (props.mayHaveThreeOrMoreErrors) {
       if (Object.keys(errors).length >= 3) {
         setShouldSummarizeErrors(true);
         errorSummaryRef.current?.focus();
@@ -71,12 +76,9 @@ export const DoulaForm = <T extends FieldValues>(props: DoulaFormProps<T>) => {
           }
         }
       }
-    };
-
-    onSubmitHandler = props.handleSubmit(onSubmit, onError);
-  } else {
-    onSubmitHandler = props.handleSubmit(onSubmit);
-  }
+    }
+  };
+  const onSubmitHandler = props.handleSubmit(onSubmit, onError);
 
   return (
     <div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import WipBanner from "@/app/form/(formSteps)/welcome/WipBanner";
 import "@/app/globals.css";
 import "@newjersey/njwds/dist/css/styles.css";
 import njStateSeal from "@newjersey/njwds/dist/img/nj_state_seal.png";
-import { GoogleTagManager } from "@next/third-parties/google";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import { Footer, Logo } from "@trussworks/react-uswds";
 import type { Metadata } from "next";
 import Head from "next/head";
@@ -27,7 +27,6 @@ export default function RootLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
       </Head>
-      <GoogleTagManager gtmId="G-H21NZ18V1E" />
       <body>
         <a className="usa-skipnav" href="#main-content">
           Skip to main content
@@ -109,6 +108,7 @@ export default function RootLayout({
           }
         />
       </body>
+      <GoogleAnalytics gaId="G-WG8QWF0K43" />
     </html>
   );
 }


### PR DESCRIPTION
## Link to issue

This commit resolves #[267](https://github.com/newjersey/doula-pm/issues/267). It implements items 1-5, and updated the ticket for 6.

## What was done?

Add analytics events including when start now is clicked, a user form validation error happens, and download application is clicked.

It takes 24 hours for data to move to non-realtime reports. After that wait time, will verify that we can do the following
- Filter by hostname in reports
- View the custom formValidationError events in reports

and figure out views to achieve what we are interested.


## Accessibility

- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Open the network tab. Verify that GA network requests are fired
    - <img width="280" height="122" alt="image" src="https://github.com/user-attachments/assets/f0d4ebd1-84f1-4268-b7bc-21b149228366" />
- If you have access to the doula project GA account, verify that the event shows up in reports (left sidebar) -> real time


## Screenshots (for visual changes)
Numbered by [ticket requirements](https://github.com/newjersey/doula-pm/issues/267)

1. Is probably somewhere to find. Maybe if I'm logged in

2. and 3.
<img width="737" height="455" alt="image" src="https://github.com/user-attachments/assets/13496e88-50cb-4414-ba4a-7e8766d447ab" />

4.
<img width="329" height="400" alt="image" src="https://github.com/user-attachments/assets/35971c20-4da6-445a-8cbe-1a2e48cfee16" />
<img width="331" height="293" alt="image" src="https://github.com/user-attachments/assets/764c2efc-87d1-489d-b138-c5d446e1b316" />


5.
<img width="341" height="329" alt="image" src="https://github.com/user-attachments/assets/c3cece42-5314-469c-8f41-a193f128ca25" />
<img width="321" height="328" alt="image" src="https://github.com/user-attachments/assets/5b7ed760-b9b5-441e-a0c8-30af8c02b11c" />
