### PR TITLE
[newjersey/doula-pm#284] Add additional training orgs

### DIFF
--- a/src/app/form/_utils/inputFields/enums.ts
+++ b/src/app/form/_utils/inputFields/enums.ts
@@ -53,10 +53,17 @@ export enum AddressState {
 }
 
 export enum StateApprovedTraining {
-  "CHS" = "Children's Home Society of NJ (Trenton)",
-  "CF" = "Children's Futures (Trenton)",
-  "STS" = "Sister to Sister Community Doulas of Essex County (Newark)",
+  "CHSNJ" = "Children's Home Society of NJ (Trenton)",
+  "childrensFutures" = "Children's Futures (Trenton)",
+  "CDOSJ" = "Community Doulas of South Jersey (Camden)",
+  "sisterToSister" = "Sister to Sister Community Doulas of Essex County (Newark)",
   "NJDLC" = "New Jersey Doula Learning Collaborative (NJDLC)",
   "PMCH" = "The Partnership for Maternal and Child Health of Northern New Jersey (Paterson, Newark)",
+  "NJMIHIA" = "NJMIHIA (NJ Maternal and Infant Health Innovation Authority)",
+  "ancientSong" = "Ancient Song",
+  "healthConnectOne" = "HealthConnectOne",
+  "uzaziVillage" = "Uzazi Village",
+  "CAPPA" = "CAPPA (Childbirth and Postpartum Professional Association)",
+  "DONA" = "DONA International",
   "NONE" = "None of these",
 }


### PR DESCRIPTION
## Link to issue

This commit resolves #[284](https://github.com/newjersey/doula-pm/issues/284).

## What was done?
Add additional training orgs

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/form/training/1

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

<img width="789" height="343" alt="image" src="https://github.com/user-attachments/assets/c26f609e-43a5-49ab-9182-714c0431919f" />


</details>


<details>
<summary>After</summary>
<img width="737" height="500" alt="image" src="https://github.com/user-attachments/assets/f10bc71b-f5d4-445f-b860-3e0d33b33ab0" />



</details>