### PR TITLE
[newjersey/doula-pm#273] Confirm before leaving form

### DIFF
--- a/src/app/form/(formSteps)/components/FormProgressButtons.test.tsx
+++ b/src/app/form/(formSteps)/components/FormProgressButtons.test.tsx
@@ -4,8 +4,6 @@ import * as nextThirdPartiesGoogle from "@next/third-parties/google";
 import { within } from "@testing-library/dom";
 import { screen } from "@testing-library/react";
 
-const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
-
 const getFormProgressButtonsList = () => {
   const allLists = screen.getAllByRole("list");
   const formProgressButtonsList = allLists.find((list) => {
@@ -66,11 +64,13 @@ describe("<FormProgressButtons />", () => {
       jest.clearAllMocks();
     });
     it("when Next is clicked", async () => {
+      const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
       renderWithProviders(<FormProgressButtons />, "/form/personal-details/2");
       await screen.getByRole("button", { name: "Next" }).click();
       expect(mockSendGAEvent).toHaveBeenCalledWith("event", "progressNext");
     });
     it("when Previous is clicked", async () => {
+      const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
       renderWithProviders(<FormProgressButtons />, "/form/personal-details/2");
       await screen.getByRole("link", { name: "Previous" }).click();
       expect(mockSendGAEvent).toHaveBeenCalledWith("event", "progressPrevious");

--- a/src/app/form/(formSteps)/finish/FinishSection.test.tsx
+++ b/src/app/form/(formSteps)/finish/FinishSection.test.tsx
@@ -13,10 +13,6 @@ jest.mock("@form/_utils/fillPdf/form", () => ({
   }),
 }));
 
-const mockCreateObjectURL = jest.fn();
-(global.URL.createObjectURL as jest.Mock) = mockCreateObjectURL;
-const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
-
 const renderFunction = (dataStore: DataStore) =>
   renderWithProviders(<FinishSection />, "/form/finish/1", dataStore);
 
@@ -26,8 +22,11 @@ describe("<FinishSection />", () => {
   });
 
   it("builds form, renders download link, and previous buttons", async () => {
+    const mockCreateObjectURL = jest.fn().mockReturnValue("mock-blob-url");
+    (global.URL.createObjectURL as jest.Mock) = mockCreateObjectURL;
+    const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
+
     const dataStore = generateDataStoreWithRequiredFields();
-    mockCreateObjectURL.mockReturnValue("mock-blob-url");
     renderFunction(dataStore);
 
     expect(screen.getByRole("link", { name: "Previous" })).toBeInTheDocument();

--- a/src/app/form/(formSteps)/welcome/WelcomeSection.test.tsx
+++ b/src/app/form/(formSteps)/welcome/WelcomeSection.test.tsx
@@ -3,14 +3,13 @@ import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProvi
 import * as nextThirdPartiesGoogle from "@next/third-parties/google";
 import { screen } from "@testing-library/react";
 
-const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
-
 describe("<WelcomeSection />", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it("sends a GA event when Start Now is clicked", async () => {
+    const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
     renderWithProviders(<WelcomeSection />, "/form/welcome");
     await screen.getByRole("link", { name: "Start now" }).click();
     expect(mockSendGAEvent).toHaveBeenCalledWith("event", "progressStart");

--- a/src/app/form/_utils/DataStoreProvider.test.tsx
+++ b/src/app/form/_utils/DataStoreProvider.test.tsx
@@ -1,5 +1,6 @@
 import { getDefaultBoolean } from "@/app/form/_utils/dataStore";
 import { DataStoreProvider, useDataStore } from "@/app/form/_utils/DataStoreProvider";
+import * as nextThirdPartiesGoogle from "@next/third-parties/google";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -31,5 +32,43 @@ describe("<DataStoreProvider /> and useDataStore", () => {
     screen.getByRole("heading", { name: "The value of isSoleProprietor is ." });
     await user.click(screen.getByRole("button", { name: "Set to true" }));
     screen.getByRole("heading", { name: "The value of isSoleProprietor is true." });
+  });
+
+  it("asks the user for confirmation before leaving the page if the data store contains data", async () => {
+    const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
+
+    const Child = () => {
+      const { updateDataStore } = useDataStore();
+      return (
+        <button
+          onClick={() => {
+            updateDataStore({ isSoleProprietor: "true" });
+          }}
+        >
+          Add data to store
+        </button>
+      );
+    };
+    const user = userEvent.setup();
+    render(
+      <DataStoreProvider>
+        <Child />
+      </DataStoreProvider>,
+    );
+
+    const beforeUnloadEvent = new Event("beforeunload", { cancelable: true });
+    const preventDefaultSpy = jest.spyOn(beforeUnloadEvent, "preventDefault");
+
+    window.dispatchEvent(beforeUnloadEvent);
+
+    expect(preventDefaultSpy).not.toHaveBeenCalled();
+    expect(beforeUnloadEvent.defaultPrevented).toBe(false);
+    expect(mockSendGAEvent).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Add data to store" }));
+    window.dispatchEvent(beforeUnloadEvent);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(beforeUnloadEvent.defaultPrevented).toBe(true);
+    expect(mockSendGAEvent).toHaveBeenCalledWith("event", "leavePageConfirmationShown");
   });
 });

--- a/src/app/form/_utils/DataStoreProvider.tsx
+++ b/src/app/form/_utils/DataStoreProvider.tsx
@@ -1,5 +1,6 @@
 import type { DataStore } from "@/app/form/_utils/dataStore";
-import { createContext, useContext, useState } from "react";
+import { sendGAEvent } from "@next/third-parties/google";
+import { createContext, useContext, useEffect, useState } from "react";
 
 export const DataStoreContext = createContext<DataStore>({});
 export const UpdateDataStoreContext = createContext<(dataUpdates: DataStore) => void>(() => {});
@@ -9,6 +10,22 @@ export const DataStoreProvider = ({ children }: { children: React.ReactNode }) =
   const updateDataStore = (dataUpdates: { [key: string]: string }) => {
     setDataStore({ ...dataStore, ...dataUpdates });
   };
+
+  const hasData = Object.keys(dataStore).length > 0;
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (hasData) {
+        event.preventDefault();
+        event.returnValue = true; // Legacy browser support, e.g. Chrome/Edge < 119
+        sendGAEvent("event", "leavePageConfirmationShown");
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [hasData]);
 
   return (
     <DataStoreContext value={dataStore}>

--- a/src/app/form/components/DoulaForm.test.tsx
+++ b/src/app/form/components/DoulaForm.test.tsx
@@ -148,10 +148,8 @@ const doulaTestFormFields: TestField[] = createTestFields([
   },
 ]);
 
-const mockNavigate = jest.fn();
-const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
-
 describe("submission behavior", () => {
+  const mockNavigate = jest.fn();
   beforeEach(() => {
     jest.spyOn(router, "useNavigate").mockImplementation(() => mockNavigate);
   });
@@ -177,6 +175,7 @@ describe("submission behavior", () => {
   });
 
   it("does not save fields to the data store and does not route on error", async () => {
+    const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
     const { mockUpdateDataStore } = renderWithProviders(
       <DoulaFormTestPage mayHaveThreeOrMoreErrors={true} />,
       "/form/personal-details/2",
@@ -204,6 +203,7 @@ describe("error summary", () => {
   });
   describe("when mayHaveThreeOrMoreErrors is true", () => {
     it("shows an error summary if there are 3 or more errors", async () => {
+      const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
       const user = userEvent.setup();
       renderWithProviders(
         <DoulaFormTestPage mayHaveThreeOrMoreErrors={true} />,
@@ -242,6 +242,7 @@ describe("error summary", () => {
     });
 
     it("does not show an error summary if there are fewer than 3 errors, instead it focuses on the first error", async () => {
+      const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
       const user = userEvent.setup();
       renderWithProviders(
         <DoulaFormTestPage mayHaveThreeOrMoreErrors={true} />,


### PR DESCRIPTION
## Link to issue
https://github.com/newjersey/doula-pm/issues/273

## What was done?
- This updates the DataStoreProvider component so it warns users before they refresh, close the tab, or navigate to a different website on the same tab if they have form data saved.
    - The dialogue does not appear if they do not have form data saved
- It utilizes the `beforeunload` event, which is [NOT supported by Safari on iOS](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event#browser_compatibility). Safari on MacOS works fine. We have a [separate ticket](https://github.com/newjersey/doula-pm/issues/312) to figure this out on Safari on iOS.
- It includes code to fire a Google Analytics event showing that the message was triggered.

This commit also
- Refactors spies on `sendGAEvent` to be defined within relevant tests, instead of top-level in their test files, to more easily understand where the spies come from.


## Accessibility
- [x] I have made sure this works with a screenreader!
    - <img width="697" height="500" alt="image" src="https://github.com/user-attachments/assets/bde6e9f7-1363-4dfb-8868-bd134be12867" />
- [N/A] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Check out branch, run locally. On the homepage, try to refresh. The refresh should work
- Click Start Now, fill out the first form page, then click Next
- On any page, attempting to refresh the page, close the tab, or navigate to a different website using the same tab should trigger a dialogue confirming whether or not you want to leave.
 
## Screenshots (for visual changes)
- After


Chrome: see Accessibility section screenshot

Firefox:
<img width="1462" height="812" alt="image" src="https://github.com/user-attachments/assets/3cd6ada3-38a7-4bac-b5c5-25d4686658a1" />

Safari:
<img width="1070" height="642" alt="image" src="https://github.com/user-attachments/assets/53264c8d-df7e-402f-94e6-34c2ab5c04b4" />

