### PR TITLE
[newjersey/doula-pm#301] Add PO box content

### DIFF
--- a/src/app/form/(formSteps)/business-details/1/BusinessDetailsStep1.tsx
+++ b/src/app/form/(formSteps)/business-details/1/BusinessDetailsStep1.tsx
@@ -113,7 +113,25 @@ const BusinessDetailsStep1 = () => {
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">
           <h2 className="font-heading-md">Business address</h2>
-          <p className="usa-hint">Many doulas use their home address as their business address.</p>
+          <div className="usa-hint">
+            <p>
+              Medicaid wants to help clients find your services easily.{" "}
+              <span className="text-bold">
+                Many doulas use their home address as their business address.
+              </span>
+            </p>
+            <p>
+              If you use a PO box or a Private Mail Box, ensure the address matches the area where
+              you work, and excludes the words “PO Box”. For example:
+            </p>
+            <div className="margin-top-0">
+              <div>123 Main St</div>
+              <div>
+                <span className="text-bold">#456</span>
+              </div>
+              <div>Trenton, NJ 08601</div>
+            </div>
+          </div>
           <DoulaRadio
             name="businessAddressSameAsOtherAddress"
             value={businessAddressSameAsOtherAddress}


### PR DESCRIPTION
## Link to issue

This commit resolves #[301](https://github.com/newjersey/doula-pm/issues/301).

## What was done?
This commit adds content per [this figma](https://www.figma.com/design/2R3VxYvZQYsaIxBcWoA1kL/Doula-Prototypes?node-id=4658-7553&t=JWEUQQsgWiiwPg6L-4) about PO boxes to the business address question.

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/form/personal-details/2. Fill these next two pages, until getting to http://localhost:3000/form/business-details/1
- Look at the content

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

<img width="1012" height="621" alt="image" src="https://github.com/user-attachments/assets/6873838e-363c-40cc-a1da-b0d3ae21c050" />


</details>


<details>
<summary>After</summary>

<img width="1039" height="778" alt="image" src="https://github.com/user-attachments/assets/5d388a00-7548-43cb-8319-691035642aa5" />


</details>