### PR TITLE
Group nextjs packages into one renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,10 @@
       "groupName": "react"
     },
     {
+      "matchPackageNames": ["next", "@next/third-parties", "eslint-config-next"],
+      "groupName": "nextjs"
+    },
+    {
       "matchPackagePrefixes": ["@testing-library"],
       "groupName": "testing-library"
     },


### PR DESCRIPTION
## Link to issue

None

## What was done?

Group nextjs packages into one renovate group, so that they produce a single PR. 

This was inspired from these two separate renovate prs:
- https://github.com/newjersey/doula-medicaid/pull/240
- https://github.com/newjersey/doula-medicaid/pull/239
