### PR TITLE
[newjersey/doula-pm#329] Fix address bug

### DIFF
--- a/src/app/form/(formSteps)/business-details/1/_utils/formatAddressLabel.tsx
+++ b/src/app/form/(formSteps)/business-details/1/_utils/formatAddressLabel.tsx
@@ -1,4 +1,4 @@
-import { formatAddressLine3 } from "@/app/form/_utils/formatters";
+import { formatCityStateZipAddressSingleField } from "@/app/form/_utils/formatters";
 import type { AddressState } from "@/app/form/_utils/inputFields/addressState";
 
 export const formatAddressLabel = (
@@ -12,7 +12,10 @@ export const formatAddressLabel = (
   if (streetAddress2 !== null) {
     addressParts.push({ key: "addressLine2", value: streetAddress2 });
   }
-  addressParts.push({ key: "addressLine3", value: formatAddressLine3(city, state, zip) });
+  addressParts.push({
+    key: "addressLine3",
+    value: formatCityStateZipAddressSingleField(city, state, zip),
+  });
 
   return (
     <div className="usa-hint">

--- a/src/app/form/(formSteps)/personal-details/2/testFields.ts
+++ b/src/app/form/(formSteps)/personal-details/2/testFields.ts
@@ -113,7 +113,7 @@ export const billingAddressFields = [
       name: "Street address line 2",
       dataStoreKey: "billingStreetAddress2",
       required: false,
-      testValue: "Test address 2",
+      testValue: "", // Test this address field not having a line 2
       withinGroupName: billingAddressQuestion,
       prerequisiteField: noSameBillingMailingAddress,
     },

--- a/src/app/form/(formSteps)/training/1/testFields.ts
+++ b/src/app/form/(formSteps)/training/1/testFields.ts
@@ -68,7 +68,7 @@ export const trainingAddressFields: TestField[] = createTestFields([
     name: "Street address line 2",
     required: false,
     dataStoreKey: "trainingStreetAddress2",
-    testValue: "Test address 2",
+    testValue: "", // Test this address field not having a line 2
     withinGroupName: trainingAddressGroupName,
     prerequisiteField: yesDoulaTrainingInPerson,
   },

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page13.test.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page13.test.ts
@@ -57,6 +57,7 @@ describe("Page 13 - request for paper updates", () => {
         description: "no streetAddress2",
         formData: {
           streetAddress1: "456 Test St",
+          streetAddress2: "",
           city: "Newark",
           state: AddressState.NJ,
           zip: "22222",

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page13.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page13.ts
@@ -1,5 +1,4 @@
-import { formatName } from "@/app/form/_utils/fillPdf/formatters";
-import { formatAddressLine3 } from "@/app/form/_utils/formatters";
+import { formatFullAddressThreeFields, formatName } from "@/app/form/_utils/fillPdf/formatters";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
 // Page 13 - request for paper updates
@@ -17,13 +16,19 @@ export interface PdfFfsIndividualPage13 {
 }
 
 export const getPage13Fields = (formData: FormData): Partial<PdfFfsIndividualPage13> => {
-  const addressLine3 = formatAddressLine3(formData.city, formData.state, formData.zip);
+  const address = formatFullAddressThreeFields(
+    formData.streetAddress1,
+    formData.streetAddress2,
+    formData.city,
+    formData.state,
+    formData.zip,
+  );
   return {
     "fd455aREQPAPER_Provider Name": formatName(formData),
     "fd455aREQPAPER_Provider Number": formData.npiNumber ?? "",
     "fd455aREQPAPER_Telephone Number": formData.phoneNumber ?? "",
-    "fd455aREQPAPER_Mail To Address 1": formData.streetAddress1 ?? "",
-    "fd455aREQPAPER_Mail To Address 2": formData.streetAddress2 ?? addressLine3,
-    "fd455aREQPAPER_Mail To Address 3": formData.streetAddress2 ? addressLine3 : "",
+    "fd455aREQPAPER_Mail To Address 1": address.line1,
+    "fd455aREQPAPER_Mail To Address 2": address.line2,
+    "fd455aREQPAPER_Mail To Address 3": address.line3,
   };
 };

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page17.test.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page17.test.ts
@@ -69,6 +69,7 @@ describe("Page 17 - disclosure of ownership and control interest statement", () 
           description: "no streetAddress2",
           formData: {
             businessStreetAddress1: "456 Test St",
+            businessStreetAddress2: "",
             businessCity: "Newark",
             businessState: AddressState.NJ,
             businessZip: "22222",

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page17.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page17.ts
@@ -1,6 +1,5 @@
 import { UnexpectedFormDataError } from "@/app/form/_utils/fillPdf/ffsIndividual/errors";
-import { formatName } from "@/app/form/_utils/fillPdf/formatters";
-import { formatAddressLine3 } from "@/app/form/_utils/formatters";
+import { formatFullAddressThreeFields, formatName } from "@/app/form/_utils/fillPdf/formatters";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
 // Page 17 - disclosure of ownership and control interest statement
@@ -29,7 +28,9 @@ export interface PdfFfsIndividualPage17 {
 
 export const getPage17Fields = (formData: FormData): Partial<PdfFfsIndividualPage17> => {
   if (formData.isSupportedSoleProprietor === true) {
-    const addressLine3 = formatAddressLine3(
+    const businessAddress = formatFullAddressThreeFields(
+      formData.businessStreetAddress1,
+      formData.businessStreetAddress2,
       formData.businessCity,
       formData.businessState,
       formData.businessZip,
@@ -42,9 +43,9 @@ export const getPage17Fields = (formData: FormData): Partial<PdfFfsIndividualPag
       fd452einorothertaxidnumber: formData.socialSecurityNumber,
       fd452ownershipoffivepercentormoreno: true,
       fd452convictedofcrimeno: true,
-      fd452businessstreetline1: formData.businessStreetAddress1,
-      fd452businessstreetline2: formData.businessStreetAddress2 ?? addressLine3,
-      fd452businessstreetline3: formData.businessStreetAddress2 ? addressLine3 : "",
+      fd452businessstreetline1: businessAddress.line1,
+      fd452businessstreetline2: businessAddress.line2,
+      fd452businessstreetline3: businessAddress.line3,
     };
   }
   throw new UnexpectedFormDataError(

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page18.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page18.ts
@@ -1,7 +1,7 @@
 import { UnexpectedFormDataError } from "@/app/form/_utils/fillPdf/ffsIndividual/errors";
 import {
   formatDate,
-  formatMultilineAddress,
+  formatFullAddressSingleField,
   formatName,
 } from "@/app/form/_utils/fillPdf/formatters";
 import { type FormData } from "@form/_utils/fillPdf/form";
@@ -46,7 +46,7 @@ export const getPage18Fields = (formData: FormData): Partial<PdfFfsIndividualPag
       fd452ownershipinterestDateofBirthline1: formatDate(formData.dateOfBirth),
       fd452ownershipinterestcontrolpercentline1: "100",
       fd452ownershipinterestssnortaxidline1: formData.socialSecurityNumber,
-      fd452ownershipinterestaddressline1: formatMultilineAddress(
+      fd452ownershipinterestaddressline1: formatFullAddressSingleField(
         formData.businessStreetAddress1,
         formData.businessStreetAddress2,
         formData.businessCity,

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page19.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page19.ts
@@ -1,7 +1,7 @@
 import { UnexpectedFormDataError } from "@/app/form/_utils/fillPdf/ffsIndividual/errors";
 import {
   formatDate,
-  formatMultilineAddress,
+  formatFullAddressSingleField,
   formatName,
 } from "@/app/form/_utils/fillPdf/formatters";
 import { type FormData } from "@form/_utils/fillPdf/form";
@@ -47,7 +47,7 @@ export const getPage19Fields = (formData: FormData): Partial<PdfFfsIndividualPag
       fd452managingagentsdateofbirthine1: formatDate(formData.dateOfBirth),
       fd452managingagentsssnline1: formData.socialSecurityNumber,
       fd452managingagentsnametitleline1: `${formatName(formData)}, doula`,
-      fd452managingagentsaddressline1: formatMultilineAddress(
+      fd452managingagentsaddressline1: formatFullAddressSingleField(
         formData.businessStreetAddress1,
         formData.businessStreetAddress2,
         formData.businessCity,

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page26.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page26.ts
@@ -3,7 +3,7 @@ import {
   formatName,
   formatNumericStringAsIndividualFields,
 } from "@/app/form/_utils/fillPdf/formatters";
-import { formatAddressLine3 } from "@/app/form/_utils/formatters";
+import { formatCityStateZipAddressSingleField } from "@/app/form/_utils/formatters";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
 // Page 26 - W-9 Request for Taxpayer Identification Number and Certification
@@ -89,7 +89,7 @@ export const getPage26Fields = (formData: FormData): Partial<PdfFfsIndividualPag
       "W9_Name See Specific Instructions on page 2": formatName(formData),
       "W9_IndividualSole proprietor": true,
       "W9_Address number street and apt or suite no": `${formData.businessStreetAddress1}${formData.businessStreetAddress2 ? ` ${formData.businessStreetAddress2}` : ""}`,
-      "W9_City state and ZIP code": formatAddressLine3(
+      "W9_City state and ZIP code": formatCityStateZipAddressSingleField(
         formData.businessCity,
         formData.businessState,
         formData.businessZip,

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page6.test.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page6.test.ts
@@ -50,6 +50,7 @@ describe("Page 6 - authorization agreement for automated deposits of state payme
         description: "no streetAddress2",
         formData: {
           billingStreetAddress1: "456 Test St",
+          billingStreetAddress2: "",
           billingCity: "Newark",
           billingState: AddressState.NJ,
           billingZip: "22222",

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page6.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page6.ts
@@ -1,4 +1,4 @@
-import { formatAddressLine3 } from "@/app/form/_utils/formatters";
+import { formatFullAddressThreeFields } from "@/app/form/_utils/fillPdf/formatters";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
 // Page 6 - authorization agreement for automated deposits of state payments
@@ -27,7 +27,9 @@ export interface PdfFfsIndividualPage6 {
 }
 
 export const getPage6Fields = (formData: FormData): Partial<PdfFfsIndividualPage6> => {
-  const addressLine3 = formatAddressLine3(
+  const billingAddressLines = formatFullAddressThreeFields(
+    formData.billingStreetAddress1,
+    formData.billingStreetAddress2,
     formData.billingCity,
     formData.billingState,
     formData.billingZip,
@@ -35,8 +37,8 @@ export const getPage6Fields = (formData: FormData): Partial<PdfFfsIndividualPage
   return {
     fd443telephoneno: formData.phoneNumber ?? "",
     fd443npino: formData.npiNumber ?? "",
-    fd443paytoaddressline1: formData.billingStreetAddress1 ?? "",
-    fd443paytoaddressline2: formData.billingStreetAddress2 ?? addressLine3,
-    fd443paytoaddressline3: formData.billingStreetAddress2 ? addressLine3 : "",
+    fd443paytoaddressline1: billingAddressLines.line1,
+    fd443paytoaddressline2: billingAddressLines.line2,
+    fd443paytoaddressline3: billingAddressLines.line3,
   };
 };

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page8.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page8.ts
@@ -1,4 +1,9 @@
-import { formatDate, formatNaIfBlank, formatName } from "@/app/form/_utils/fillPdf/formatters";
+import {
+  formatDate,
+  formatNaIfBlank,
+  formatName,
+  formatStreetAddressSingleField,
+} from "@/app/form/_utils/fillPdf/formatters";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
 // Page 8 - individual doula provider application section I provider identification
@@ -38,7 +43,10 @@ export const getPage8Fields = (formData: FormData): Partial<PdfFfsIndividualPage
     fd425telephoneno: formData.phoneNumber ?? "",
     fd425emailaddress: formData.email ?? "",
 
-    fd425mailtoaddressstreet: `${formData.streetAddress1}${formData.streetAddress2 ? ` ${formData.streetAddress2}` : ""}`,
+    fd425mailtoaddressstreet: formatStreetAddressSingleField(
+      formData.streetAddress1,
+      formData.streetAddress2,
+    ),
     fd425mailtoaddressstate: formData.state ?? "",
     fd425mailtoaddresscity: formData.city ?? "",
     fd425mailtoaddresszip: formData.zip ?? "",

--- a/src/app/form/_utils/fillPdf/formatters.test.ts
+++ b/src/app/form/_utils/fillPdf/formatters.test.ts
@@ -1,7 +1,9 @@
 import {
-  formatMultilineAddress,
+  formatFullAddressSingleField,
+  formatFullAddressThreeFields,
   formatNaIfBlank,
   formatNumericStringAsIndividualFields,
+  formatStreetAddressSingleField,
 } from "@/app/form/_utils/fillPdf/formatters";
 import { AddressState } from "@/app/form/_utils/inputFields/addressState";
 
@@ -48,17 +50,49 @@ describe("formatNumericStringAsIndividualFields", () => {
   });
 });
 
-describe("formatMultilineAddress", () => {
+describe("formatStreetAddressSingleField", () => {
   it("includes street address 2 if present", () => {
-    expect(formatMultilineAddress("Street 1", "Apt 2", "Newark", AddressState.NJ, "99999"))
+    expect(formatStreetAddressSingleField("Street 1", "Apt 2")).toEqual("Street 1 Apt 2");
+  });
+
+  it("excludes street address 2 if absent", () => {
+    expect(formatStreetAddressSingleField("Street 1", null)).toEqual("Street 1");
+  });
+});
+
+describe("formatFullAddressSingleField", () => {
+  it("includes street address 2 if present", () => {
+    expect(formatFullAddressSingleField("Street 1", "Apt 2", "Newark", AddressState.NJ, "99999"))
       .toEqual(`Street 1
 Apt 2
 Newark, NJ 99999`);
   });
 
-  it("excludes street address 2 if present", () => {
-    expect(formatMultilineAddress("Street 1", null, "Newark", AddressState.NJ, "99999"))
+  it("excludes street address 2 if absent", () => {
+    expect(formatFullAddressSingleField("Street 1", null, "Newark", AddressState.NJ, "99999"))
       .toEqual(`Street 1
 Newark, NJ 99999`);
+  });
+});
+
+describe("formatFullAddressThreeFields", () => {
+  it("includes street address 2 if present", () => {
+    expect(
+      formatFullAddressThreeFields("Street 1", "Apt 2", "Newark", AddressState.NJ, "99999"),
+    ).toEqual({
+      line1: "Street 1",
+      line2: "Apt 2",
+      line3: "Newark, NJ 99999",
+    });
+  });
+
+  it("excludes street address 2 if absent", () => {
+    expect(
+      formatFullAddressThreeFields("Street 1", null, "Newark", AddressState.NJ, "99999"),
+    ).toEqual({
+      line1: "Street 1",
+      line2: "Newark, NJ 99999",
+      line3: "",
+    });
   });
 });

--- a/src/app/form/_utils/fillPdf/formatters.ts
+++ b/src/app/form/_utils/fillPdf/formatters.ts
@@ -1,4 +1,4 @@
-import { formatAddressLine3 } from "@/app/form/_utils/formatters";
+import { formatCityStateZipAddressSingleField } from "@/app/form/_utils/formatters";
 import type { AddressState } from "@/app/form/_utils/inputFields/addressState";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
@@ -40,16 +40,39 @@ export const formatDate = (date: Date): string => {
   });
 };
 
-export const formatMultilineAddress = (
+export const formatStreetAddressSingleField = (
+  streetAddress1: string,
+  streetAddress2: string | null,
+): string => {
+  return `${streetAddress1}${streetAddress2 ? ` ${streetAddress2}` : ""}`;
+};
+
+export const formatFullAddressSingleField = (
   streetAddress1: string,
   streetAddress2: string | null,
   city: string,
   state: AddressState,
   zip: string,
 ): string => {
-  return `${streetAddress1}${streetAddress2 ? `\n${streetAddress2}` : ""}\n${formatAddressLine3(
+  return `${streetAddress1}${streetAddress2 ? `\n${streetAddress2}` : ""}\n${formatCityStateZipAddressSingleField(
     city,
     state,
     zip,
   )}`;
+};
+
+export const formatFullAddressThreeFields = (
+  streetAddress1: string,
+  streetAddress2: string | null,
+  city: string,
+  state: AddressState,
+  zip: string,
+): { line1: string; line2: string; line3: string } => {
+  const addressLine3 = formatCityStateZipAddressSingleField(city, state, zip);
+  const hasStreetAddress2 = streetAddress2 && streetAddress2 !== "";
+  return {
+    line1: streetAddress1,
+    line2: hasStreetAddress2 === true ? streetAddress2 : addressLine3,
+    line3: hasStreetAddress2 === true ? addressLine3 : "",
+  };
 };

--- a/src/app/form/_utils/formatters.test.ts
+++ b/src/app/form/_utils/formatters.test.ts
@@ -1,0 +1,8 @@
+import { formatCityStateZipAddressSingleField } from "@/app/form/_utils/formatters";
+import { AddressState } from "@/app/form/_utils/inputFields/addressState";
+
+it("formatCityStateZipAddressSingleField", () => {
+  expect(formatCityStateZipAddressSingleField("Trenton", AddressState.NJ, "11111")).toEqual(
+    "Trenton, NJ 11111",
+  );
+});

--- a/src/app/form/_utils/formatters.ts
+++ b/src/app/form/_utils/formatters.ts
@@ -1,5 +1,9 @@
 import type { AddressState } from "@/app/form/_utils/inputFields/addressState";
 
-export const formatAddressLine3 = (city: string, state: AddressState, zip: string): string => {
+export const formatCityStateZipAddressSingleField = (
+  city: string,
+  state: AddressState,
+  zip: string,
+): string => {
   return `${city}, ${state} ${zip}`;
 };

--- a/src/app/form/_utils/testUtils/fillInputs.ts
+++ b/src/app/form/_utils/testUtils/fillInputs.ts
@@ -42,7 +42,9 @@ export const fillField = async (screen: Screen, user: UserEvent, fieldToFill: Fi
   const inputField = await getInputField(screen, fieldToFill);
   switch (fieldToFill.role) {
     case "textbox":
-      await user.type(inputField, fieldToFill.testValue);
+      if (fieldToFill.testValue !== "") {
+        await user.type(inputField, fieldToFill.testValue);
+      }
       break;
     case undefined:
       await user.type(inputField, fieldToFill.testValue);


### PR DESCRIPTION
## Link to issue

This commit resolves #[329](https://github.com/newjersey/doula-pm/issues/329).

## What was done?
This commit fixes a bug where if address line 2 is not filled, then the city, state, and zip is also not filled.

It was caused because the code expected addressLine2 to be undefined if not filled. However, it is actually an empty string when not filled.

This commit also renames our address-formatting functions for clarity

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/, and go through the form. For all addresses, don't fill in address line 2
- At the end of the form, download the pdf
- On the following pages and sections, the city, state, and zip should be populated
   - Pay to address on page 6 - Authorization Agreement for Automated Deposits of State Payments
   - Mail to address on page 13 - Request for Paper Updates
   - Business address on page 17 - Disclosure of Ownership and Control Interest Statement

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

<img width="761" height="88" alt="Image" src="https://github.com/user-attachments/assets/d8a82655-6ec2-42bd-8115-84eb63c39b1c" />
<img width="529" height="137" alt="Image" src="https://github.com/user-attachments/assets/d52edef3-2e7a-4c3d-aa3a-d9a0cb05ba1c" />
<img width="418" height="99" alt="Image" src="https://github.com/user-attachments/assets/c057377c-468c-4323-9130-96dba75881ad" />


</details>


<details>
<summary>After</summary>

<img width="312" height="134" alt="image" src="https://github.com/user-attachments/assets/f85d7f86-6078-4c8e-b255-f98191899694" />
<img width="533" height="145" alt="image" src="https://github.com/user-attachments/assets/4c118830-157c-40b5-928b-a971f4e83e14" />

<img width="531" height="171" alt="image" src="https://github.com/user-attachments/assets/31253fc5-7507-4857-9171-9e24a419e873" />



</details>