### PR TITLE
[newjersey/doula-pm#310] Update renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "timezone": "US/Eastern",
   "minimumReleaseAge": "3 days",
   "extends": ["config:recommended", ":maintainLockFilesWeekly"],
-  "automergeSchedule": ["* * * * 0,6", "* 0-6 * * 1"],
+  "schedule": ["* 17-23,0-8 * * *", "* * * * 0,6"],
+  "automergeSchedule": ["* 9-13 * * 1-5"],
   "ignorePaths": ["**/scripts/**"],
   "labels": ["renovate"],
   "packageRules": [


### PR DESCRIPTION
## Link to issue

This commit resolves #[310](https://github.com/newjersey/doula-pm/issues/310).

## What was done?
This commit updates renovate to:
- Only create new PRs outside work hours, to not clog up our github builds
- Only merge PRs in the morning during work hours, so that we can respond to any outages that it causes

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).
