### PR TITLE
[newjersey/doula-pm#344] Fix timezone for automated demo merge to main

### DIFF
--- a/.github/workflows/merge_main_into_demo.yml
+++ b/.github/workflows/merge_main_into_demo.yml
@@ -3,7 +3,7 @@ name: merge-main-into-demo
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 9 * * 1" # Every Monday at 9am
+    - cron: "0 14 * * 1" # Every Monday at 9am EST/10am EDT. Github actions run on UTC and as of writing [lacks timezone config](https://github.com/orgs/community/discussions/13454).
 
 permissions:
   contents: write


### PR DESCRIPTION
## Link to issue

This commit resolves #[344](https://github.com/newjersey/doula-pm/issues/344).

## What was done?
The cron expression in github actions needs to be expressed in UTC. As of writing, Github actions [lacks timezone config](https://github.com/orgs/community/discussions/13454).

