### PR TITLE
[newjersey/doula-pm#352] Set application root URL as `/humanservices/dmahs/info/doulahelp` URL

### DIFF
--- a/.github/workflows/end_to_end_test.yml
+++ b/.github/workflows/end_to_end_test.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Build the application
         run: npm run build
       - name: Start the application
-        run: npm start & npx wait-on http://localhost:3000
+        run: npm start & npx wait-on http://localhost:3000/humanservices/dmahs/info/doulahelp
       - name: Run cypress tests
         run: npm run cypress:run

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,7 +1,8 @@
+import { BASE_PATH } from "@/app/basePath";
 import { defineConfig } from "cypress";
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: "http://localhost:3000",
+    baseUrl: `http://localhost:3000${BASE_PATH}`,
   },
 });

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,8 @@
+import { BASE_PATH } from "@/app/basePath";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  basePath: BASE_PATH,
   output: "standalone",
   webpack: (config) => {
     config.resolve.alias.canvas = false;

--- a/src/app/basePath.ts
+++ b/src/app/basePath.ts
@@ -1,0 +1,1 @@
+export const BASE_PATH = "/humanservices/dmahs/info/doulahelp";

--- a/src/app/form/ClientRoutes.tsx
+++ b/src/app/form/ClientRoutes.tsx
@@ -1,3 +1,4 @@
+import { BASE_PATH } from "@/app/basePath";
 import BusinessDetailsStep1 from "@/app/form/(formSteps)/business-details/1/BusinessDetailsStep1";
 import BusinessDetailsStep2 from "@/app/form/(formSteps)/business-details/2/BusinessDetailsStep2";
 import BusinessDetailsStep3 from "@/app/form/(formSteps)/business-details/3/BusinessDetailsStep3";
@@ -49,5 +50,5 @@ export const routes = (
 );
 
 export default function ClientRoutes() {
-  return <BrowserRouter>{routes}</BrowserRouter>;
+  return <BrowserRouter basename={BASE_PATH}>{routes}</BrowserRouter>;
 }

--- a/src/app/form/_utils/fillPdf/form.ts
+++ b/src/app/form/_utils/fillPdf/form.ts
@@ -1,3 +1,4 @@
+import { BASE_PATH } from "@/app/basePath";
 import {
   getBusinessDetailsFormData,
   type BusinessDetailsFormData,
@@ -63,7 +64,7 @@ export const fillForm = async (
   pdfPath: string,
   filename: string,
 ): Promise<FilledPDFData> => {
-  const unfilledPdfFile = await fetch(pdfPath);
+  const unfilledPdfFile = await fetch(`${BASE_PATH}${pdfPath}`);
   const unfilledPdfBytes = await unfilledPdfFile.arrayBuffer();
   const pdfDoc = await PDFDocument.load(unfilledPdfBytes);
   const form = pdfDoc.getForm();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { APPLICATION_NAME } from "@/app/_utils/title";
+import { BASE_PATH } from "@/app/basePath";
 import { HorizontalDivider } from "@/app/components/HorizontalDivider";
 import WipBanner from "@/app/form/(formSteps)/welcome/WipBanner";
 import "@/app/globals.css";
@@ -61,7 +62,7 @@ export default function RootLayout({
                             focusable="false"
                             role="img"
                           >
-                            <use href={"/svg/sprite.svg#mail"}></use>
+                            <use href={`${BASE_PATH}/svg/sprite.svg#mail`}></use>
                           </svg>
                           <span className="usa-sr-only">opens in a new tab.</span>
                           Get Updates
@@ -87,7 +88,14 @@ export default function RootLayout({
           secondary={
             <Logo
               size="slim"
-              image={<Image src="/svg/DHS_logo.svg" width={210} height={107} alt="DHS logo" />}
+              image={
+                <Image
+                  src={`${BASE_PATH}/svg/DHS_logo.svg`}
+                  width={210}
+                  height={107}
+                  alt="DHS logo"
+                />
+              }
               heading={
                 <div className="grid-row flex-align-center">
                   <div className="tablet:grid-col-auto tablet:border-right tablet:margin-right-2 tablet:padding-right-2">
@@ -98,7 +106,7 @@ export default function RootLayout({
                         focusable="false"
                         role="img"
                       >
-                        <use href={"/svg/sprite.svg#mail"}></use>
+                        <use href={`${BASE_PATH}/svg/sprite.svg#mail`}></use>
                       </svg>
                       mahs.doulaguide@dhs.nj.gov
                     </a>{" "}


### PR DESCRIPTION
## Link to issue

This commit resolves #[352](https://github.com/newjersey/doula-pm/issues/352).

## What was done?
Previously, the application would be accessed by going to http://localhost:3000/. However, we want the production application to be the URL path https://www.nj.gov/humanservices/dmahs/info/doulahelp. Placing the application at that path as it previously existed had caused a 404 error.

This commit updates:
- The NextJS application
- React Router inside of it
- hardcoded paths to static assets
- Cypress test URLs

To expect the application root to be at the path /humanservices/dmahs/info/doulahelp.

I had verified this works on production by cherrypicking this commit to the production branch, pushing it to trigger the deploy, clicking through the full flow to verify that I am able to download a pdf. Then, I quickly reverted production. We currently don't have a staging environment, but that is next on the list.

I think the excess github actions in this PR were not triggered by the PR, just that the exact same commit it was also deployed to production?

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/humanservices/dmahs/info/doulahelp, and open devtools
- Click through the form. The website should work, in there should be no errors either in the console, or server-side in the running process

## Screenshots (for visual changes)

<details>
<summary>Before</summary>
On production:

<img width="1267" height="957" alt="748880 production 404" src="https://github.com/user-attachments/assets/41595ff7-6f92-46b1-91aa-53544b3d3129" />


</details>


<details>
<summary>After</summary>

<img width="1298" height="1002" alt="image" src="https://github.com/user-attachments/assets/5a06a9b1-d52a-44d6-95e3-87baf74a5d9c" />


</details>