### PR TITLE
[newjersey/doula-pm#324] Rename to shorter variables for bankruptcy

### DIFF
--- a/src/app/form/(formSteps)/business-details/4/BusinessDetailsStep4.test.tsx
+++ b/src/app/form/(formSteps)/business-details/4/BusinessDetailsStep4.test.tsx
@@ -1,10 +1,10 @@
 import BusinessDetailsStep4 from "@/app/form/(formSteps)/business-details/4/BusinessDetailsStep4";
 import {
   firstRadioOptionTestFields,
-  nextYearBankruptcyDateFields,
-  noHasFiledForBankruptcyPast7Years,
-  noMightFileForBankruptcyNextYear,
-  past7YearsBankruptcyDateFields,
+  futureBankruptcyDateFields,
+  noHasFiledBankruptcy,
+  noMightFileBankruptcy,
+  pastBankruptcyDateFields,
   path1TestFields,
   path2TestFields,
 } from "@/app/form/(formSteps)/business-details/4/testFields";
@@ -35,7 +35,7 @@ describe("<BusinessDetailsStep4 />", () => {
     );
 
     it.each(
-      [...past7YearsBankruptcyDateFields, ...nextYearBankruptcyDateFields].filter(
+      [...pastBankruptcyDateFields, ...futureBankruptcyDateFields].filter(
         (field) => field.required === true,
       ),
     )(
@@ -46,24 +46,24 @@ describe("<BusinessDetailsStep4 />", () => {
     );
   });
 
-  it.each([...path1TestFields, ...past7YearsBankruptcyDateFields, ...nextYearBankruptcyDateFields])(
+  it.each([...path1TestFields, ...pastBankruptcyDateFields, ...futureBankruptcyDateFields])(
     "fills $dataStoreKey from the data store when page is loaded",
     async (field) => {
       await testFillFromDataStore(field, renderFunction, screen);
     },
   );
 
-  it.each(past7YearsBankruptcyDateFields)(
-    "conditionally renders $dataStoreKey based on hasFiledForBankruptcyPast7Years",
+  it.each(pastBankruptcyDateFields)(
+    "conditionally renders $dataStoreKey based on hasFiledBankruptcy",
     async (field) => {
-      await testConditionalRender(field, noHasFiledForBankruptcyPast7Years, renderFunction, screen);
+      await testConditionalRender(field, noHasFiledBankruptcy, renderFunction, screen);
     },
   );
 
-  it.each(nextYearBankruptcyDateFields)(
-    "conditionally renders $dataStoreKey based on mightFileForBankruptcyNextYear",
+  it.each(futureBankruptcyDateFields)(
+    "conditionally renders $dataStoreKey based on mightFileBankruptcy",
     async (field) => {
-      await testConditionalRender(field, noMightFileForBankruptcyNextYear, renderFunction, screen);
+      await testConditionalRender(field, noMightFileBankruptcy, renderFunction, screen);
     },
   );
 });

--- a/src/app/form/(formSteps)/business-details/4/BusinessDetailsStep4.tsx
+++ b/src/app/form/(formSteps)/business-details/4/BusinessDetailsStep4.tsx
@@ -11,14 +11,14 @@ import FormProgressButtons from "@form/(formSteps)/components/FormProgressButton
 import { useForm } from "react-hook-form";
 
 const orderedInputNames: Array<keyof BusinessDetails4Data> = [
-  "hasFiledForBankruptcyPast7Years",
-  "past7YearsBankruptcyMonth",
-  "past7YearsBankruptcyDay",
-  "past7YearsBankruptcyYear",
-  "mightFileForBankruptcyNextYear",
-  "nextYearBankruptcyMonth",
-  "nextYearBankruptcyDay",
-  "nextYearBankruptcyYear",
+  "hasFiledBankruptcy",
+  "pastBankruptcyMonth",
+  "pastBankruptcyDay",
+  "pastBankruptcyYear",
+  "mightFileBankruptcy",
+  "futureBankruptcyMonth",
+  "futureBankruptcyDay",
+  "futureBankruptcyYear",
 ];
 
 const mayHaveThreeOrMoreErrors = true;
@@ -32,25 +32,19 @@ const BusinessDetailsStep4 = () => {
     watch,
   } = useForm<BusinessDetails4Data>({
     defaultValues: {
-      hasFiledForBankruptcyPast7Years: getDefaultBoolean(
-        dataStore,
-        "hasFiledForBankruptcyPast7Years",
-      ),
-      past7YearsBankruptcyMonth: getDefaultValue(dataStore, "past7YearsBankruptcyMonth") ?? "",
-      past7YearsBankruptcyDay: getDefaultValue(dataStore, "past7YearsBankruptcyDay") ?? "",
-      past7YearsBankruptcyYear: getDefaultValue(dataStore, "past7YearsBankruptcyYear") ?? "",
-      mightFileForBankruptcyNextYear: getDefaultBoolean(
-        dataStore,
-        "mightFileForBankruptcyNextYear",
-      ),
-      nextYearBankruptcyMonth: getDefaultValue(dataStore, "nextYearBankruptcyMonth") ?? "",
-      nextYearBankruptcyDay: getDefaultValue(dataStore, "nextYearBankruptcyDay") ?? "",
-      nextYearBankruptcyYear: getDefaultValue(dataStore, "nextYearBankruptcyYear") ?? "",
+      hasFiledBankruptcy: getDefaultBoolean(dataStore, "hasFiledBankruptcy"),
+      pastBankruptcyMonth: getDefaultValue(dataStore, "pastBankruptcyMonth") ?? "",
+      pastBankruptcyDay: getDefaultValue(dataStore, "pastBankruptcyDay") ?? "",
+      pastBankruptcyYear: getDefaultValue(dataStore, "pastBankruptcyYear") ?? "",
+      mightFileBankruptcy: getDefaultBoolean(dataStore, "mightFileBankruptcy"),
+      futureBankruptcyMonth: getDefaultValue(dataStore, "futureBankruptcyMonth") ?? "",
+      futureBankruptcyDay: getDefaultValue(dataStore, "futureBankruptcyDay") ?? "",
+      futureBankruptcyYear: getDefaultValue(dataStore, "futureBankruptcyYear") ?? "",
     },
     shouldFocusError: !mayHaveThreeOrMoreErrors,
   });
-  const hasFiledForBankruptcyPast7Years = watch("hasFiledForBankruptcyPast7Years");
-  const mightFileForBankruptcyNextYear = watch("mightFileForBankruptcyNextYear");
+  const hasFiledBankruptcy = watch("hasFiledBankruptcy");
+  const mightFileBankruptcy = watch("mightFileBankruptcy");
 
   const currentYear: number = new Date().getFullYear();
 
@@ -68,21 +62,21 @@ const BusinessDetailsStep4 = () => {
             Mark Yes if these apply to your business, otherwise mark No.
           </h2>
           <DoulaYesNoRadio
-            name="hasFiledForBankruptcyPast7Years"
-            value={hasFiledForBankruptcyPast7Years}
+            name="hasFiledBankruptcy"
+            value={hasFiledBankruptcy}
             label="Have you filed for bankruptcy in the past 7 years?"
             required
             register={register}
             errors={errors}
           />
-          {hasFiledForBankruptcyPast7Years === "true" && (
+          {hasFiledBankruptcy === "true" && (
             <DoulaDateInput
-              name="past7YearsBankruptcy"
+              name="pastBankruptcy"
               label="When did you file for bankruptcy?"
               hint={`For example: January 1 ${currentYear - 2}`}
-              monthName="past7YearsBankruptcyMonth"
-              dayName="past7YearsBankruptcyDay"
-              yearName="past7YearsBankruptcyYear"
+              monthName="pastBankruptcyMonth"
+              dayName="pastBankruptcyDay"
+              yearName="pastBankruptcyYear"
               errorLabelPrefix="Past bankruptcy"
               errors={errors}
               register={register}
@@ -94,21 +88,21 @@ const BusinessDetailsStep4 = () => {
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">
           <DoulaYesNoRadio
-            name="mightFileForBankruptcyNextYear"
-            value={mightFileForBankruptcyNextYear}
+            name="mightFileBankruptcy"
+            value={mightFileBankruptcy}
             label="Is there a possibility that you will file for bankruptcy in the next year?"
             required
             register={register}
             errors={errors}
           />
-          {mightFileForBankruptcyNextYear === "true" && (
+          {mightFileBankruptcy === "true" && (
             <DoulaDateInput
-              name="nextYearBankruptcy"
+              name="futureBankruptcy"
               label="When will you file for bankruptcy?"
               hint={`For example: January 1 ${currentYear + 1}`}
-              monthName="nextYearBankruptcyMonth"
-              dayName="nextYearBankruptcyDay"
-              yearName="nextYearBankruptcyYear"
+              monthName="futureBankruptcyMonth"
+              dayName="futureBankruptcyDay"
+              yearName="futureBankruptcyYear"
               errorLabelPrefix="Future bankruptcy"
               errors={errors}
               register={register}

--- a/src/app/form/(formSteps)/business-details/4/testFields.ts
+++ b/src/app/form/(formSteps)/business-details/4/testFields.ts
@@ -6,117 +6,114 @@ import {
 
 const currentYear: number = new Date().getFullYear();
 
-export const noHasFiledForBankruptcyPast7Years: TestField = createTestField({
+export const noHasFiledBankruptcy: TestField = createTestField({
   name: "No",
-  dataStoreKey: "hasFiledForBankruptcyPast7Years",
+  dataStoreKey: "hasFiledBankruptcy",
   required: true,
   role: "radio",
   testValue: "false",
   withinGroupName: "Have you filed for bankruptcy in the past 7 years? Select one *",
 });
 
-const yesHasFiledForBankruptcyPast7Years: TestField = createTestField({
+const yesHasFiledBankruptcy: TestField = createTestField({
   name: "Yes",
-  dataStoreKey: "hasFiledForBankruptcyPast7Years",
+  dataStoreKey: "hasFiledBankruptcy",
   required: true,
   role: "radio",
   testValue: "true",
   withinGroupName: "Have you filed for bankruptcy in the past 7 years? Select one *",
 });
-export const past7YearsBankruptcyDateFields = createTestFields([
+export const pastBankruptcyDateFields = createTestFields([
   {
     name: "Month *",
-    dataStoreKey: "past7YearsBankruptcyMonth",
+    dataStoreKey: "pastBankruptcyMonth",
     required: true,
     testValue: "July",
     expectedValue: "7",
     role: "combobox",
     withinGroupName: `When did you file for bankruptcy? * For example: January 1 ${currentYear - 2}`,
-    prerequisiteField: yesHasFiledForBankruptcyPast7Years,
+    prerequisiteField: yesHasFiledBankruptcy,
     alternateRequiredFieldError: "Past bankruptcy month is required",
   },
   {
     name: "Day *",
-    dataStoreKey: "past7YearsBankruptcyDay",
+    dataStoreKey: "pastBankruptcyDay",
     required: true,
     testValue: "6",
     withinGroupName: `When did you file for bankruptcy? * For example: January 1 ${currentYear - 2}`,
-    prerequisiteField: yesHasFiledForBankruptcyPast7Years,
+    prerequisiteField: yesHasFiledBankruptcy,
     alternateRequiredFieldError: "Past bankruptcy day is required",
   },
   {
     name: "Year *",
-    dataStoreKey: "past7YearsBankruptcyYear",
+    dataStoreKey: "pastBankruptcyYear",
     required: true,
     testValue: "2024",
     withinGroupName: `When did you file for bankruptcy? * For example: January 1 ${currentYear - 2}`,
-    prerequisiteField: yesHasFiledForBankruptcyPast7Years,
+    prerequisiteField: yesHasFiledBankruptcy,
     alternateRequiredFieldError: "Past bankruptcy year is required",
   },
 ]);
 
-export const noMightFileForBankruptcyNextYear: TestField = createTestField({
+export const noMightFileBankruptcy: TestField = createTestField({
   name: "No",
-  dataStoreKey: "mightFileForBankruptcyNextYear",
+  dataStoreKey: "mightFileBankruptcy",
   required: true,
   role: "radio",
   testValue: "false",
   withinGroupName:
     "Is there a possibility that you will file for bankruptcy in the next year? Select one *",
 });
-const yesMightFileForBankruptcyNextYear: TestField = createTestField({
+const yesMightFileBankruptcy: TestField = createTestField({
   name: "Yes",
-  dataStoreKey: "mightFileForBankruptcyNextYear",
+  dataStoreKey: "mightFileBankruptcy",
   required: true,
   role: "radio",
   testValue: "true",
   withinGroupName:
     "Is there a possibility that you will file for bankruptcy in the next year? Select one *",
 });
-export const nextYearBankruptcyDateFields = createTestFields([
+export const futureBankruptcyDateFields = createTestFields([
   {
     name: "Month *",
-    dataStoreKey: "nextYearBankruptcyMonth",
+    dataStoreKey: "futureBankruptcyMonth",
     required: true,
     testValue: "July",
     expectedValue: "7",
     role: "combobox",
     withinGroupName: `When will you file for bankruptcy? * For example: January 1 ${currentYear + 1}`,
-    prerequisiteField: yesMightFileForBankruptcyNextYear,
+    prerequisiteField: yesMightFileBankruptcy,
     alternateRequiredFieldError: "Future bankruptcy month is required",
   },
   {
     name: "Day *",
-    dataStoreKey: "nextYearBankruptcyDay",
+    dataStoreKey: "futureBankruptcyDay",
     required: true,
     testValue: "6",
     withinGroupName: `When will you file for bankruptcy? * For example: January 1 ${currentYear + 1}`,
-    prerequisiteField: yesMightFileForBankruptcyNextYear,
+    prerequisiteField: yesMightFileBankruptcy,
     alternateRequiredFieldError: "Future bankruptcy day is required",
   },
   {
     name: "Year *",
-    dataStoreKey: "nextYearBankruptcyYear",
+    dataStoreKey: "futureBankruptcyYear",
     required: true,
     testValue: "2024",
     withinGroupName: `When will you file for bankruptcy? * For example: January 1 ${currentYear + 1}`,
-    prerequisiteField: yesMightFileForBankruptcyNextYear,
+    prerequisiteField: yesMightFileBankruptcy,
     alternateRequiredFieldError: "Future bankruptcy year is required",
   },
 ]);
 
-export const path1TestFields: Array<TestField> = [
-  noHasFiledForBankruptcyPast7Years,
-  noMightFileForBankruptcyNextYear,
-];
+export const path1TestFields: Array<TestField> = [noHasFiledBankruptcy, noMightFileBankruptcy];
 export const firstRadioOptionTestFields: Array<TestField> = [
-  yesHasFiledForBankruptcyPast7Years,
-  yesMightFileForBankruptcyNextYear,
+  yesHasFiledBankruptcy,
+  yesMightFileBankruptcy,
 ];
 
 export const path2TestFields: Array<TestField> = [
-  yesHasFiledForBankruptcyPast7Years,
-  ...past7YearsBankruptcyDateFields,
-  yesMightFileForBankruptcyNextYear,
-  ...nextYearBankruptcyDateFields,
+  yesHasFiledBankruptcy,
+  ...pastBankruptcyDateFields,
+  yesMightFileBankruptcy,
+  ...futureBankruptcyDateFields,
 ];

--- a/src/app/form/(formSteps)/business-details/BusinessDetailsData.ts
+++ b/src/app/form/(formSteps)/business-details/BusinessDetailsData.ts
@@ -29,15 +29,15 @@ export interface BusinessDetails3Data {
 }
 
 export interface BusinessDetails4Data {
-  hasFiledForBankruptcyPast7Years: "true" | "false" | "";
-  past7YearsBankruptcyMonth: string;
-  past7YearsBankruptcyDay: string;
-  past7YearsBankruptcyYear: string;
+  hasFiledBankruptcy: "true" | "false" | "";
+  pastBankruptcyMonth: string;
+  pastBankruptcyDay: string;
+  pastBankruptcyYear: string;
 
-  mightFileForBankruptcyNextYear: "true" | "false" | "";
-  nextYearBankruptcyMonth: string;
-  nextYearBankruptcyDay: string;
-  nextYearBankruptcyYear: string;
+  mightFileBankruptcy: "true" | "false" | "";
+  futureBankruptcyMonth: string;
+  futureBankruptcyDay: string;
+  futureBankruptcyYear: string;
 }
 
 export interface BusinessDetailsFormData {
@@ -47,10 +47,10 @@ export interface BusinessDetailsFormData {
   businessState: AddressState;
   businessZip: string;
   hasDisclosableEvent: boolean;
-  hasFiledForBankruptcyPast7Years: boolean;
-  past7YearsBankruptcyDate: Date | null;
-  mightFileForBankruptcyNextYear: boolean;
-  nextYearBankruptcyDate: Date | null;
+  hasFiledBankruptcy: boolean;
+  pastBankruptcyDate: Date | null;
+  mightFileBankruptcy: boolean;
+  futureBankruptcyDate: Date | null;
 }
 
 const getBusinessDetails1Data = (dataStore: DataStore) => {
@@ -105,34 +105,26 @@ const getBusinessDetails2And3Data = (dataStore: DataStore) => {
 };
 
 const getBusinessDetails4Data = (dataStore: DataStore) => {
-  const hasFiledForBankruptcyPast7Years = getBoolean(
-    dataStore,
-    "hasFiledForBankruptcyPast7Years",
-    true,
-  );
-  const past7YearsBankruptcyDate = hasFiledForBankruptcyPast7Years
+  const hasFiledBankruptcy = getBoolean(dataStore, "hasFiledBankruptcy", true);
+  const pastBankruptcyDate = hasFiledBankruptcy
     ? new Date(
-        `${getValue(dataStore, "past7YearsBankruptcyMonth", true)}/${getValue(dataStore, "past7YearsBankruptcyDay", true)}/${getValue(dataStore, "past7YearsBankruptcyYear", true)}`,
+        `${getValue(dataStore, "pastBankruptcyMonth", true)}/${getValue(dataStore, "pastBankruptcyDay", true)}/${getValue(dataStore, "pastBankruptcyYear", true)}`,
       )
     : null;
 
-  const mightFileForBankruptcyNextYear = getBoolean(
-    dataStore,
-    "mightFileForBankruptcyNextYear",
-    true,
-  );
+  const mightFileBankruptcy = getBoolean(dataStore, "mightFileBankruptcy", true);
 
-  const nextYearBankruptcyDate = mightFileForBankruptcyNextYear
+  const futureBankruptcyDate = mightFileBankruptcy
     ? new Date(
-        `${getValue(dataStore, "nextYearBankruptcyMonth", true)}/${getValue(dataStore, "nextYearBankruptcyDay", true)}/${getValue(dataStore, "nextYearBankruptcyYear", true)}`,
+        `${getValue(dataStore, "futureBankruptcyMonth", true)}/${getValue(dataStore, "futureBankruptcyDay", true)}/${getValue(dataStore, "futureBankruptcyYear", true)}`,
       )
     : null;
 
   return {
-    hasFiledForBankruptcyPast7Years,
-    past7YearsBankruptcyDate,
-    mightFileForBankruptcyNextYear,
-    nextYearBankruptcyDate,
+    hasFiledBankruptcy,
+    pastBankruptcyDate,
+    mightFileBankruptcy,
+    futureBankruptcyDate,
   };
 };
 

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page21.test.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page21.test.ts
@@ -41,28 +41,26 @@ describe("Page 21 - disclosure of ownership and control interest statement", () 
   });
 
   describe("Filed for bankruptcy in the past 7 years", () => {
-    it("throws an UnexpectedFormDataError when hasFiledForBankruptcyPast7Years is true but past7YearsBankruptcyDate is null", () => {
+    it("throws an UnexpectedFormDataError when hasFiledBankruptcy is true but pastBankruptcyDate is null", () => {
       const testFunction = () =>
         mapFfsIndividualFields(
           generateFormData({
-            hasFiledForBankruptcyPast7Years: true,
-            past7YearsBankruptcyDate: null,
+            hasFiledBankruptcy: true,
+            pastBankruptcyDate: null,
           }),
         );
       expect(testFunction).toThrow(UnexpectedFormDataError);
-      expect(testFunction).toThrow(
-        "hasFiledForBankruptcyPast7Years true, but past7YearsBankruptcyDate is null.",
-      );
+      expect(testFunction).toThrow("hasFiledBankruptcy true, but pastBankruptcyDate is null.");
     });
 
-    it("checks the No checkbox when formData.hasFiledForBankruptcyPast7Years is false", () => {
+    it("checks the No checkbox when formData.hasFiledBankruptcy is false", () => {
       const yesPdfKey = "fd452filedbankruptcypastsevenyearsyes";
       const noPdfKey = "fd452filedbankruptcypastsevenyearsno";
       const datePdfKey = "fd452filedbankruptcypastsevenyearsdate";
       expectNoDuplicateTest<PdfFfsIndividualPage21>(noPdfKey, testedPdfKeys);
       const pdfFields = mapFfsIndividualFields(
         generateFormData({
-          hasFiledForBankruptcyPast7Years: false,
+          hasFiledBankruptcy: false,
         }),
       );
       expect(pdfFields[noPdfKey]).toEqual(true);
@@ -70,7 +68,7 @@ describe("Page 21 - disclosure of ownership and control interest statement", () 
       expect(pdfFields[datePdfKey]).toEqual(undefined);
     });
 
-    it("checks the Yes checkbox and fills in the date when formData.hasFiledForBankruptcyPast7Years is true", () => {
+    it("checks the Yes checkbox and fills in the date when formData.hasFiledBankruptcy is true", () => {
       const yesPdfKey = "fd452filedbankruptcypastsevenyearsyes";
       const noPdfKey = "fd452filedbankruptcypastsevenyearsno";
       const datePdfKey = "fd452filedbankruptcypastsevenyearsdate";
@@ -78,8 +76,8 @@ describe("Page 21 - disclosure of ownership and control interest statement", () 
       expectNoDuplicateTest<PdfFfsIndividualPage21>(datePdfKey, testedPdfKeys);
       const pdfFields = mapFfsIndividualFields(
         generateFormData({
-          hasFiledForBankruptcyPast7Years: true,
-          past7YearsBankruptcyDate: new Date("1/2/2024"),
+          hasFiledBankruptcy: true,
+          pastBankruptcyDate: new Date("1/2/2024"),
         }),
       );
       expect(pdfFields[yesPdfKey]).toEqual(true);
@@ -89,28 +87,26 @@ describe("Page 21 - disclosure of ownership and control interest statement", () 
   });
 
   describe("Possibility of filing for bankruptcy in the next year", () => {
-    it("throws an UnexpectedFormDataError when mightFileForBankruptcyNextYear is true but nextYearBankruptcyDate is null", () => {
+    it("throws an UnexpectedFormDataError when mightFileBankruptcy is true but futureBankruptcyDate is null", () => {
       const testFunction = () =>
         mapFfsIndividualFields(
           generateFormData({
-            mightFileForBankruptcyNextYear: true,
-            nextYearBankruptcyDate: null,
+            mightFileBankruptcy: true,
+            futureBankruptcyDate: null,
           }),
         );
       expect(testFunction).toThrow(UnexpectedFormDataError);
-      expect(testFunction).toThrow(
-        "mightFileForBankruptcyNextYear true, but nextYearBankruptcyDate is null.",
-      );
+      expect(testFunction).toThrow("mightFileBankruptcy true, but futureBankruptcyDate is null.");
     });
 
-    it("checks the No checkbox when formData.mightFileForBankruptcyNextYear is false", () => {
+    it("checks the No checkbox when formData.mightFileBankruptcy is false", () => {
       const yesPdfKey = "fd452filedbankruptcywithinyearyes";
       const noPdfKey = "fd452filedbankruptcywithinyearno";
       const datePdfKey = "fd452filedbankruptcywithinyeardate";
       expectNoDuplicateTest<PdfFfsIndividualPage21>(noPdfKey, testedPdfKeys);
       const pdfFields = mapFfsIndividualFields(
         generateFormData({
-          mightFileForBankruptcyNextYear: false,
+          mightFileBankruptcy: false,
         }),
       );
       expect(pdfFields[noPdfKey]).toEqual(true);
@@ -118,7 +114,7 @@ describe("Page 21 - disclosure of ownership and control interest statement", () 
       expect(pdfFields[datePdfKey]).toEqual(undefined);
     });
 
-    it("checks the Yes checkbox and fills in the date when formData.mightFileForBankruptcyNextYear is true", () => {
+    it("checks the Yes checkbox and fills in the date when formData.mightFileBankruptcy is true", () => {
       const yesPdfKey = "fd452filedbankruptcywithinyearyes";
       const noPdfKey = "fd452filedbankruptcywithinyearno";
       const datePdfKey = "fd452filedbankruptcywithinyeardate";
@@ -126,8 +122,8 @@ describe("Page 21 - disclosure of ownership and control interest statement", () 
       expectNoDuplicateTest<PdfFfsIndividualPage21>(datePdfKey, testedPdfKeys);
       const pdfFields = mapFfsIndividualFields(
         generateFormData({
-          mightFileForBankruptcyNextYear: true,
-          nextYearBankruptcyDate: new Date("1/2/2026"),
+          mightFileBankruptcy: true,
+          futureBankruptcyDate: new Date("1/2/2026"),
         }),
       );
       expect(pdfFields[yesPdfKey]).toEqual(true);

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page21.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page21.ts
@@ -38,16 +38,16 @@ export interface PdfFfsIndividualPage21 {
   fd452filedbankruptcywithinyeardate: string;
 }
 
-const getPast7YearsBankruptcyFields = (formData: FormData) => {
-  if (formData.hasFiledForBankruptcyPast7Years === true) {
-    if (formData.past7YearsBankruptcyDate === null) {
+const getPastBankruptcyFields = (formData: FormData) => {
+  if (formData.hasFiledBankruptcy === true) {
+    if (formData.pastBankruptcyDate === null) {
       throw new UnexpectedFormDataError(
-        `hasFiledForBankruptcyPast7Years true, but past7YearsBankruptcyDate is ${formData.past7YearsBankruptcyDate}.`,
+        `hasFiledBankruptcy true, but pastBankruptcyDate is ${formData.pastBankruptcyDate}.`,
       );
     }
     return {
       fd452filedbankruptcypastsevenyearsyes: true,
-      fd452filedbankruptcypastsevenyearsdate: formatDate(formData.past7YearsBankruptcyDate),
+      fd452filedbankruptcypastsevenyearsdate: formatDate(formData.pastBankruptcyDate),
     };
   }
   return {
@@ -55,16 +55,16 @@ const getPast7YearsBankruptcyFields = (formData: FormData) => {
   };
 };
 
-const getNextYearBankruptcyFields = (formData: FormData) => {
-  if (formData.mightFileForBankruptcyNextYear === true) {
-    if (formData.nextYearBankruptcyDate === null) {
+const getFutureBankruptcyFields = (formData: FormData) => {
+  if (formData.mightFileBankruptcy === true) {
+    if (formData.futureBankruptcyDate === null) {
       throw new UnexpectedFormDataError(
-        `mightFileForBankruptcyNextYear true, but nextYearBankruptcyDate is ${formData.nextYearBankruptcyDate}.`,
+        `mightFileBankruptcy true, but futureBankruptcyDate is ${formData.futureBankruptcyDate}.`,
       );
     }
     return {
       fd452filedbankruptcywithinyearyes: true,
-      fd452filedbankruptcywithinyeardate: formatDate(formData.nextYearBankruptcyDate),
+      fd452filedbankruptcywithinyeardate: formatDate(formData.futureBankruptcyDate),
     };
   }
   return {
@@ -83,7 +83,7 @@ export const getPage21Fields = (formData: FormData): Partial<PdfFfsIndividualPag
     fd452ownershiphealthcareproviderno: true,
     fd452ownershipchangeno: true,
     fd452ownershipchangewithinyearno: true,
-    ...getPast7YearsBankruptcyFields(formData),
-    ...getNextYearBankruptcyFields(formData),
+    ...getPastBankruptcyFields(formData),
+    ...getFutureBankruptcyFields(formData),
   };
 };

--- a/src/app/form/_utils/fillPdf/testUtils/formData.ts
+++ b/src/app/form/_utils/fillPdf/testUtils/formData.ts
@@ -84,10 +84,10 @@ const testBusinessDetailsFormData: BusinessDetailsFormData = {
   businessState: AddressState.NJ,
   businessZip: "08000",
   hasDisclosableEvent: false,
-  hasFiledForBankruptcyPast7Years: false,
-  past7YearsBankruptcyDate: null,
-  mightFileForBankruptcyNextYear: false,
-  nextYearBankruptcyDate: null,
+  hasFiledBankruptcy: false,
+  pastBankruptcyDate: null,
+  mightFileBankruptcy: false,
+  futureBankruptcyDate: null,
 };
 
 const testFormData: FormData = {


### PR DESCRIPTION
## Link to issue

This commit resolves #[324](https://github.com/newjersey/doula-pm/issues/324).

## What was done?

Make variable names shorter.