### PR TITLE
[newjersey/doula-pm#351] Stable VPC-internal application load balancer DNS

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -6,6 +6,8 @@ import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as ecsPatterns from "aws-cdk-lib/aws-ecs-patterns";
 import { Protocol } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as iam from "aws-cdk-lib/aws-iam";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as targets from "aws-cdk-lib/aws-route53-targets";
 
 const VPC_NAME = "DHS-DMAHS-DoulaApp-*";
 const ECR_REPOSITORY_NAME = "doula-app";
@@ -180,6 +182,21 @@ export class CdkStack extends cdk.Stack {
       }),
     );
 
+    const hostedZone = new route53.PrivateHostedZone(this, "DoulaPrivateZone", {
+      vpc,
+      zoneName: "doula-vpc.dhs.nj.gov",
+    });
+
+    const aRecord = new route53.ARecord(this, "DoulaAlbARecord", {
+      zone: hostedZone,
+      recordName: "app",
+      target: route53.RecordTarget.fromAlias(
+        new targets.LoadBalancerTarget(fargateService.loadBalancer, {
+          evaluateTargetHealth: true,
+        }),
+      ),
+    });
+
     // Create GitHub Actions IAM role for OIDC federation
     const githubActionsRole = new iam.Role(this, "GitHubActionsRole", {
       roleName: "GitHubAction-PushEcrUpdateEcs",
@@ -211,19 +228,19 @@ export class CdkStack extends cdk.Stack {
 
     // CloudFormation Outputs
     new cdk.CfnOutput(this, "LoadBalancerUrl", {
-      value: `http${isHttps ? "s" : ""}://${fargateService.loadBalancer.loadBalancerDnsName}`,
+      value: `http${isHttps ? "s" : ""}://${aRecord.domainName}`,
       description: "URL of the Internal Application Load Balancer (accessible from within VPC)",
       exportName: "DoulaAssistantLoadBalancerUrl",
     });
 
     new cdk.CfnOutput(this, "HealthCheckUrl", {
-      value: `http${isHttps ? "s" : ""}://${fargateService.loadBalancer.loadBalancerDnsName}/humanservices/dmahs/info/doulahelp/api/health`,
+      value: `http${isHttps ? "s" : ""}://${aRecord.domainName}/humanservices/dmahs/info/doulahelp/api/health`,
       description: "URL for the health check endpoint (accessible from within VPC)",
       exportName: "DoulaAssistantHealthCheckUrl",
     });
 
     new cdk.CfnOutput(this, "LoadBalancerDnsName", {
-      value: fargateService.loadBalancer.loadBalancerDnsName,
+      value: aRecord.domainName,
       description: "Load Balancer DNS name for DNS configuration",
       exportName: "DoulaAssistantLoadBalancerDnsName",
     });

--- a/scripts/generate_csr.py
+++ b/scripts/generate_csr.py
@@ -38,7 +38,7 @@ def generate_certificate_signing_request(
     )
 
     if subject_alternative_names:
-        builder.add_extension(
+        builder = builder.add_extension(
             x509.SubjectAlternativeName(
                 [x509.DNSName(san) for san in subject_alternative_names]
             ),

--- a/scripts/generate_self_signed_cert.py
+++ b/scripts/generate_self_signed_cert.py
@@ -48,7 +48,7 @@ def generate_self_signed_certificate(
 
     if subject_alternative_names:
         print("subject_alternative_names", subject_alternative_names)
-        builder.add_extension(
+        builder = builder.add_extension(
             x509.SubjectAlternativeName(
                 [x509.DNSName(san) for san in subject_alternative_names]
             ),
@@ -105,7 +105,7 @@ def main():
 
     args = parser.parse_args()
 
-    if not (args.san or args.common_name):
+    if not (args.subject_alternative_names or args.common_name):
         raise ValueError("common name or SAN is required")
 
     key = rsa.generate_private_key(


### PR DESCRIPTION
## Link to issue

This commit contributes to #[351](https://github.com/newjersey/doula-pm/issues/351).

## What was done?
Previously, the application load balancer spun up by cloud formation had a random number that changed on every cdk deploy. E.g., `internal-doula-assistant-alb-1234567890.us-east-1.elb.amazonaws.com`, where `1234567890` it is a random number. This meant that an outside source targeting this load balancer needed to hardcode that random number.

This commit creates a private hosted zone within the VPC, and an alias record that enables the application load balancer to also be available at `app.doula-vpc.dhs.nj.gov`. The application is now accessible from within the VPC at both `https://app.doula-vpc.dhs.nj.gov/humanservices/dmahs/info/doulahelp/api/health`, and `https://internal-doula-assistant-alb-1234567890.us-east-1.elb.amazonaws.com/humanservices/dmahs/info/doulahelp/api/health` (assuming the random number).

This commit also fixes a breaking bug in the script to generate a self-signed certificate and certificate signing request.

## How should a reviewer test?

- There isn't really a way to test the full cdk stack without poking around an AWS account
- For the certificate, before the bugfix, the domain name did not show up when imported in two AWS certificate manager. After the bugfix, it does 
<img width="551" height="129" alt="image" src="https://github.com/user-attachments/assets/4dd54c8a-8e13-435b-9a46-a5d172f449ab" />
