### PR TITLE
[newjersey/doula-pm#375] Component cleanup

### DIFF
--- a/src/app/form/(formSteps)/components/DoulaAddress.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddress.tsx
@@ -39,7 +39,7 @@ export const DoulaAddress = <T extends FieldValues>(props: DoulaAddressProps<T>)
             required
             errors={props.errors}
             register={props.register}
-            registerOptions={{
+            additionalRegisterOptions={{
               required: `${formatInputErrorLabel(props.orderedInputNameToLabel[props.addressKeys.streetAddress1], props.errorLabelPrefix)} is required`,
             }}
           />
@@ -66,7 +66,7 @@ export const DoulaAddress = <T extends FieldValues>(props: DoulaAddressProps<T>)
             required
             errors={props.errors}
             register={props.register}
-            registerOptions={{
+            additionalRegisterOptions={{
               required: `${formatInputErrorLabel(props.orderedInputNameToLabel[props.addressKeys.city], props.errorLabelPrefix)} is required`,
             }}
           />
@@ -107,7 +107,7 @@ export const DoulaAddress = <T extends FieldValues>(props: DoulaAddressProps<T>)
             required
             errors={props.errors}
             register={props.register}
-            registerOptions={{
+            additionalRegisterOptions={{
               required: `${formatInputErrorLabel(props.orderedInputNameToLabel[props.addressKeys.zip], props.errorLabelPrefix, true)} is required`,
               minLength: {
                 value: 5,

--- a/src/app/form/(formSteps)/components/DoulaDateInput.tsx
+++ b/src/app/form/(formSteps)/components/DoulaDateInput.tsx
@@ -81,7 +81,7 @@ export const DoulaDateInput = <T extends FieldValues>(props: DoulaDateInputProps
             hideErrorMessage
             errors={props.errors}
             register={props.register}
-            registerOptions={{
+            additionalRegisterOptions={{
               required: `${formatInputErrorLabel("Day", props.errorLabelPrefix)} is required`,
               valueAsNumber: true,
               min: {
@@ -116,7 +116,7 @@ export const DoulaDateInput = <T extends FieldValues>(props: DoulaDateInputProps
             hideErrorMessage
             errors={props.errors}
             register={props.register}
-            registerOptions={{
+            additionalRegisterOptions={{
               required: `${formatInputErrorLabel("Year", props.errorLabelPrefix)} is required`,
               valueAsNumber: true,
               validate: (value) => {

--- a/src/app/form/(formSteps)/components/DoulaRadio.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaRadio.test.tsx
@@ -210,7 +210,7 @@ describe("DoulaRadio", () => {
           },
         }}
         register={jest.fn()}
-        customErrorMessages={[
+        jsxErrorMessage={[
           {
             type: "required",
             message: (

--- a/src/app/form/(formSteps)/components/DoulaRadio.tsx
+++ b/src/app/form/(formSteps)/components/DoulaRadio.tsx
@@ -19,7 +19,7 @@ export interface DoulaRadioOption<T extends FieldValues> {
   additionalRegisterOptions?: RegisterOptions<T>;
 }
 
-type wrappedAttributes = "type" | "name" | "required";
+type wrappedAttributes = "name" | "required";
 type internallySetAttributes = "id" | "aria-invalid";
 
 export interface DoulaRadioProps<T extends FieldValues>
@@ -31,7 +31,7 @@ export interface DoulaRadioProps<T extends FieldValues>
   options: Array<DoulaRadioOption<T>>;
   errors?: FieldErrors<T>;
   register: UseFormRegister<T>;
-  customErrorMessages?: Array<CustomErrorMessage>;
+  jsxErrorMessage?: Array<CustomErrorMessage>;
 }
 
 const getLegend = (label: React.ReactNode, isRequired: boolean | undefined) => {
@@ -58,7 +58,7 @@ const DoulaRadio = <T extends FieldValues>(props: DoulaRadioProps<T>) => {
     options,
     errors,
     register,
-    customErrorMessages,
+    jsxErrorMessage,
     ...otherProps
   } = props;
 
@@ -70,7 +70,7 @@ const DoulaRadio = <T extends FieldValues>(props: DoulaRadioProps<T>) => {
   }
 
   if (hasError) {
-    internallySetProps["aria-invalid"] = errors[name] ? ("true" as const) : ("false" as const);
+    internallySetProps["aria-invalid"] = "true" as const;
   }
 
   const defaultRegisterOptions = required === true ? { required: "This question is required" } : {};
@@ -97,9 +97,7 @@ const DoulaRadio = <T extends FieldValues>(props: DoulaRadioProps<T>) => {
           />
         );
       })}
-      {hasError && (
-        <ErrorMessage name={name} errors={errors} customErrorMessages={customErrorMessages} />
-      )}
+      {hasError && <ErrorMessage name={name} errors={errors} jsxErrorMessage={jsxErrorMessage} />}
     </Fieldset>
   );
 };

--- a/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
@@ -10,7 +10,7 @@ describe("DoulaTextInput", () => {
     const mockRegister = jest.fn();
     render(<DoulaTextInput name="testInput" label="Test label" register={mockRegister} />);
 
-    expect(mockRegister).toHaveBeenCalledWith("testInput", undefined);
+    expect(mockRegister).toHaveBeenCalledWith("testInput", {});
     const input = screen.getByRole("textbox", { name: "Test label" });
     expect(input).toBeInTheDocument();
     expect(input).not.toHaveAttribute("aria-invalid");
@@ -53,20 +53,9 @@ describe("DoulaTextInput", () => {
 
   it("sets appropriate attributes when the input is required", () => {
     const mockRegister = jest.fn();
-    const registerOptions = {
-      required: "This field is required",
-    };
-    render(
-      <DoulaTextInput
-        name="testInput"
-        label="Test label"
-        required
-        register={mockRegister}
-        registerOptions={registerOptions}
-      />,
-    );
+    render(<DoulaTextInput name="testInput" label="Test label" required register={mockRegister} />);
 
-    expect(mockRegister).toHaveBeenCalledWith("testInput", registerOptions);
+    expect(mockRegister).toHaveBeenCalledWith("testInput", { required: "Test label is required" });
     const input = screen.getByRole("textbox", { name: "Test label *" });
     expect(input).toHaveAttribute("required");
     expect(input).not.toHaveAttribute("aria-invalid");
@@ -119,21 +108,21 @@ describe("DoulaTextInput", () => {
         errors={{
           testInput: {
             type: "required",
-            message: "This field is required",
+            message: "This field has a custom required error message",
           },
         }}
         register={jest.fn()}
-        registerOptions={{
-          required: "This field is required",
+        additionalRegisterOptions={{
+          required: "This field has a custom required error message",
         }}
       />,
     );
     const input = screen.getByRole("textbox", { name: "Test label *" });
-    expect(input).toHaveAccessibleDescription("This field is required");
+    expect(input).toHaveAccessibleDescription("This field has a custom required error message");
     expect(input).toHaveAttribute("aria-invalid", "true");
   });
 
-  it("shows a custom error message if provided", async () => {
+  it("shows a jsx error message if provided", async () => {
     render(
       <DoulaTextInput
         name="testInput"
@@ -142,14 +131,14 @@ describe("DoulaTextInput", () => {
         errors={{
           testInput: {
             type: "required",
-            message: "This field is required",
+            message: "This field has a custom required error message",
           },
         }}
         register={jest.fn()}
-        registerOptions={{
-          required: "This field is required",
+        additionalRegisterOptions={{
+          required: "This field has a custom required error message",
         }}
-        customErrorMessages={[
+        jsxErrorMessage={[
           {
             type: "required",
             message: (
@@ -198,12 +187,12 @@ describe("DoulaTextInput", () => {
           errors={{
             testInput: {
               type: "required",
-              message: "This field is required",
+              message: "This field has a custom required error message",
             },
           }}
           register={jest.fn()}
-          registerOptions={{
-            required: "This field is required",
+          additionalRegisterOptions={{
+            required: "This field has a custom required error message",
           }}
         />
         <span id="anotherDescriptonID">Additional description</span>
@@ -211,7 +200,7 @@ describe("DoulaTextInput", () => {
     );
     const input = screen.getByRole("textbox", { name: "Test label *" });
     expect(input).toHaveAccessibleDescription(
-      "This field is required Test hint Additional description",
+      "This field has a custom required error message Test hint Additional description",
     );
     expect(input).toHaveAttribute("aria-invalid", "true");
   });

--- a/src/app/form/(formSteps)/components/DoulaTextInput.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.tsx
@@ -10,7 +10,6 @@ import {
   Label,
   TextInput,
   type TextInputProps,
-  type ValidationStatus,
 } from "@trussworks/react-uswds";
 import type {
   ChangeHandler,
@@ -38,8 +37,8 @@ interface DoulaTextInputProps<T extends FieldValues>
   hideErrorMessage?: boolean;
   errors?: FieldErrors<T>;
   register: UseFormRegister<T>;
-  registerOptions?: RegisterOptions<T>;
-  customErrorMessages?: Array<CustomErrorMessage>;
+  additionalRegisterOptions?: RegisterOptions<T>;
+  jsxErrorMessage?: Array<CustomErrorMessage>;
 }
 
 const wrapRegisterProps = <T extends FieldValues>(
@@ -74,8 +73,8 @@ const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) =>
     errors,
     hideErrorMessage,
     register,
-    registerOptions,
-    customErrorMessages,
+    additionalRegisterOptions,
+    jsxErrorMessage,
     ...otherProps
   } = props;
 
@@ -88,10 +87,13 @@ const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) =>
   }
 
   if (hasError) {
-    const validationStatusError: ValidationStatus = "error";
-    internallySetProps.validationStatus = errors[name] ? validationStatusError : undefined;
-    internallySetProps["aria-invalid"] = errors[name] ? ("true" as const) : ("false" as const);
+    internallySetProps.validationStatus = "error";
+    internallySetProps["aria-invalid"] = "true" as const;
   }
+
+  // To override this, pass in additionalRegisterOptions
+  const defaultRegisterOptions = required === true ? { required: `${label} is required` } : {};
+
   let input = (
     <TextInput
       id={name}
@@ -99,7 +101,10 @@ const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) =>
       required={required}
       {...internallySetProps}
       {...otherProps}
-      {...wrapRegisterProps(register(name, registerOptions), numericOnly)}
+      {...wrapRegisterProps(
+        register(name, { ...defaultRegisterOptions, ...additionalRegisterOptions }),
+        numericOnly,
+      )}
     />
   );
 
@@ -120,7 +125,7 @@ const DoulaTextInput = <T extends FieldValues>(props: DoulaTextInputProps<T>) =>
       {hint !== undefined && <Hint name={name} hint={hint} />}
       {input}
       {hasError && hideErrorMessage !== true && (
-        <ErrorMessage name={name} errors={errors} customErrorMessages={customErrorMessages} />
+        <ErrorMessage name={name} errors={errors} jsxErrorMessage={jsxErrorMessage} />
       )}
     </>
   );

--- a/src/app/form/(formSteps)/components/DoulaTextInputMask.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInputMask.test.tsx
@@ -15,7 +15,7 @@ describe("DoulaTextInputMask", () => {
       />,
     );
 
-    expect(mockRegister).toHaveBeenCalledWith("testInput", undefined);
+    expect(mockRegister).toHaveBeenCalledWith("testInput", {});
     const input = screen.getByRole("textbox", { name: "Test label" });
     expect(input).toBeInTheDocument();
     expect(input).not.toHaveAttribute("aria-invalid");
@@ -24,9 +24,6 @@ describe("DoulaTextInputMask", () => {
 
   it("sets appropriate attributes when the input is required", () => {
     const mockRegister = jest.fn();
-    const registerOptions = {
-      required: "This field is required",
-    };
     render(
       <DoulaTextInputMask
         name="testInput"
@@ -36,10 +33,9 @@ describe("DoulaTextInputMask", () => {
         pattern="\d{3}-\d{3}-\d{4}"
         required
         register={mockRegister}
-        registerOptions={registerOptions}
       />,
     );
-    expect(mockRegister).toHaveBeenCalledWith("testInput", registerOptions);
+    expect(mockRegister).toHaveBeenCalledWith("testInput", { required: "Test label is required" });
     const input = screen.getByRole("textbox", { name: "Test label *" });
     expect(input).toHaveAttribute("required");
     expect(input).not.toHaveAttribute("aria-invalid");
@@ -93,21 +89,21 @@ describe("DoulaTextInputMask", () => {
         errors={{
           testInput: {
             type: "required",
-            message: "This field is required",
+            message: "This field has a custom required error message",
           },
         }}
         register={jest.fn()}
-        registerOptions={{
-          required: "This field is required",
+        additionalRegisterOptions={{
+          required: "This field has a custom required error message",
         }}
       />,
     );
     const input = screen.getByRole("textbox", { name: "Test label *" });
-    expect(input).toHaveAccessibleDescription("This field is required");
+    expect(input).toHaveAccessibleDescription("This field has a custom required error message");
     expect(input).toHaveAttribute("aria-invalid", "true");
   });
 
-  it("shows a custom error message if provided", async () => {
+  it("shows a jsx error message if provided", async () => {
     render(
       <DoulaTextInputMask
         name="testInput"
@@ -119,14 +115,14 @@ describe("DoulaTextInputMask", () => {
         errors={{
           testInput: {
             type: "required",
-            message: "This field is required",
+            message: "This field has a custom required error message",
           },
         }}
         register={jest.fn()}
-        registerOptions={{
-          required: "This field is required",
+        additionalRegisterOptions={{
+          required: "This field has a custom required error message",
         }}
-        customErrorMessages={[
+        jsxErrorMessage={[
           {
             type: "required",
             message: (
@@ -172,34 +168,6 @@ describe("DoulaTextInputMask", () => {
         <DoulaTextInputMask
           name="testInput"
           label="Test label"
-          inputMode="numeric"
-          mask="___-___-____"
-          pattern="\d{3}-\d{3}-\d{4}"
-          required
-          errors={{
-            testInput: {
-              type: "required",
-              message: "This field is required",
-            },
-          }}
-          register={jest.fn()}
-          registerOptions={{
-            required: "This field is required",
-          }}
-        />
-      </>,
-    );
-    const input = screen.getByRole("textbox", { name: "Test label *" });
-    expect(input).toHaveAccessibleDescription("This field is required");
-    expect(input).toHaveAttribute("aria-invalid", "true");
-  });
-
-  it("describes the input with the hint, the error message, and the aria-describedby when all are present", () => {
-    render(
-      <>
-        <DoulaTextInputMask
-          name="testInput"
-          label="Test label"
           hint="Test hint"
           aria-describedby="anotherDescriptonID"
           inputMode="numeric"
@@ -209,12 +177,12 @@ describe("DoulaTextInputMask", () => {
           errors={{
             testInput: {
               type: "required",
-              message: "This field is required",
+              message: "This field has a custom required error message",
             },
           }}
           register={jest.fn()}
-          registerOptions={{
-            required: "This field is required",
+          additionalRegisterOptions={{
+            required: "This field has a custom required error message",
           }}
         />
         <span id="anotherDescriptonID">Additional description</span>
@@ -222,7 +190,7 @@ describe("DoulaTextInputMask", () => {
     );
     const input = screen.getByRole("textbox", { name: "Test label *" });
     expect(input).toHaveAccessibleDescription(
-      "This field is required Test hint Additional description",
+      "This field has a custom required error message Test hint Additional description",
     );
   });
 });

--- a/src/app/form/(formSteps)/components/DoulaTextInputMask.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInputMask.tsx
@@ -4,12 +4,7 @@ import {
 } from "@/app/form/(formSteps)/components/ErrorMessage";
 import { Hint } from "@/app/form/(formSteps)/components/Hint";
 import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
-import {
-  Label,
-  TextInputMask,
-  type TextInputMaskProps,
-  type ValidationStatus,
-} from "@trussworks/react-uswds";
+import { Label, TextInputMask, type TextInputMaskProps } from "@trussworks/react-uswds";
 import type {
   FieldErrors,
   FieldPath,
@@ -30,8 +25,8 @@ interface DoulaTextInputMaskProps<T extends FieldValues>
   required?: boolean;
   errors?: FieldErrors<T>;
   register: UseFormRegister<T>;
-  registerOptions?: RegisterOptions<T>;
-  customErrorMessages?: Array<CustomErrorMessage>;
+  additionalRegisterOptions?: RegisterOptions<T>;
+  jsxErrorMessage?: Array<CustomErrorMessage>;
 }
 
 const DoulaTextInputMask = <T extends FieldValues>(props: DoulaTextInputMaskProps<T>) => {
@@ -44,8 +39,8 @@ const DoulaTextInputMask = <T extends FieldValues>(props: DoulaTextInputMaskProp
     required,
     errors,
     register,
-    registerOptions,
-    customErrorMessages,
+    additionalRegisterOptions,
+    jsxErrorMessage,
     ...otherProps
   } = props;
   const hasError = errors !== undefined && errors[name] !== undefined;
@@ -57,10 +52,12 @@ const DoulaTextInputMask = <T extends FieldValues>(props: DoulaTextInputMaskProp
   }
 
   if (hasError) {
-    const validationStatusError: ValidationStatus = "error";
-    internallySetProps.validationStatus = errors[name] ? validationStatusError : undefined;
-    internallySetProps["aria-invalid"] = errors[name] ? ("true" as const) : ("false" as const);
+    internallySetProps.validationStatus = "error";
+    internallySetProps["aria-invalid"] = "true" as const;
   }
+
+  // To override this, pass in additionalRegisterOptions
+  const defaultRegisterOptions = required === true ? { required: `${label} is required` } : {};
 
   return (
     <>
@@ -74,11 +71,9 @@ const DoulaTextInputMask = <T extends FieldValues>(props: DoulaTextInputMaskProp
         required={required}
         {...internallySetProps}
         {...otherProps}
-        {...register(name, registerOptions)}
+        {...register(name, { ...defaultRegisterOptions, ...additionalRegisterOptions })}
       />
-      {hasError && (
-        <ErrorMessage name={name} errors={errors} customErrorMessages={customErrorMessages} />
-      )}
+      {hasError && <ErrorMessage name={name} errors={errors} jsxErrorMessage={jsxErrorMessage} />}
     </>
   );
 };

--- a/src/app/form/(formSteps)/components/DoulaYesNoRadio.tsx
+++ b/src/app/form/(formSteps)/components/DoulaYesNoRadio.tsx
@@ -20,7 +20,7 @@ const DoulaYesNoRadio = <T extends FieldValues>(props: DoulaYesNoRadioProps<T>) 
     value: "false",
   };
 
-  let customErrorMessages;
+  let jsxErrorMessage;
   let options = [optionYes, optionNo];
   if (invalidOption !== undefined) {
     const validValue = invalidOption.label === "Yes" ? "false" : "true";
@@ -32,7 +32,7 @@ const DoulaYesNoRadio = <T extends FieldValues>(props: DoulaYesNoRadioProps<T>) 
         },
       };
     });
-    customErrorMessages = [
+    jsxErrorMessage = [
       {
         type: "validate",
         message: invalidOption.message,
@@ -40,7 +40,7 @@ const DoulaYesNoRadio = <T extends FieldValues>(props: DoulaYesNoRadioProps<T>) 
     ];
   }
 
-  return <DoulaRadio options={options} customErrorMessages={customErrorMessages} {...otherProps} />;
+  return <DoulaRadio options={options} jsxErrorMessage={jsxErrorMessage} {...otherProps} />;
 };
 
 export default DoulaYesNoRadio;

--- a/src/app/form/(formSteps)/components/ErrorMessage.test.tsx
+++ b/src/app/form/(formSteps)/components/ErrorMessage.test.tsx
@@ -25,7 +25,7 @@ describe("ErrorMessage", () => {
         type: "required",
       },
     };
-    const customErrorMessages = [
+    const jsxErrorMessage = [
       {
         type: "required",
         message: (
@@ -36,11 +36,7 @@ describe("ErrorMessage", () => {
       },
     ];
     const element = render(
-      <ErrorMessage
-        name="testErrorMessage"
-        errors={errors}
-        customErrorMessages={customErrorMessages}
-      />,
+      <ErrorMessage name="testErrorMessage" errors={errors} jsxErrorMessage={jsxErrorMessage} />,
     );
     expect(element.container.textContent).toEqual("Fancy error message");
   });
@@ -52,7 +48,7 @@ describe("ErrorMessage", () => {
         message: "This will get overwritten",
       },
     };
-    const customErrorMessages = [
+    const jsxErrorMessage = [
       {
         type: "required",
         message: (
@@ -63,11 +59,7 @@ describe("ErrorMessage", () => {
       },
     ];
     const element = render(
-      <ErrorMessage
-        name="testErrorMessage"
-        errors={errors}
-        customErrorMessages={customErrorMessages}
-      />,
+      <ErrorMessage name="testErrorMessage" errors={errors} jsxErrorMessage={jsxErrorMessage} />,
     );
     expect(element.container.textContent).toEqual("Fancy error message");
   });
@@ -79,18 +71,14 @@ describe("ErrorMessage", () => {
         message: "Must have 10 digits",
       },
     };
-    const customErrorMessages = [
+    const jsxErrorMessage = [
       {
         type: "required",
         message: <p>This is required</p>,
       },
     ];
     render(
-      <ErrorMessage
-        name="testErrorMessage"
-        errors={errors}
-        customErrorMessages={customErrorMessages}
-      />,
+      <ErrorMessage name="testErrorMessage" errors={errors} jsxErrorMessage={jsxErrorMessage} />,
     );
     expect(screen.getByText("Must have 10 digits")).toBeInTheDocument();
   });
@@ -101,7 +89,7 @@ describe("ErrorMessage", () => {
         type: "minLength",
       },
     };
-    const customErrorMessages = [
+    const jsxErrorMessage = [
       {
         type: "required",
         message: <p>This is required</p>,
@@ -109,11 +97,7 @@ describe("ErrorMessage", () => {
     ];
     expect(() =>
       render(
-        <ErrorMessage
-          name="testErrorMessage"
-          errors={errors}
-          customErrorMessages={customErrorMessages}
-        />,
+        <ErrorMessage name="testErrorMessage" errors={errors} jsxErrorMessage={jsxErrorMessage} />,
       ),
     ).toThrow("Unexpected error with no message");
   });

--- a/src/app/form/(formSteps)/components/ErrorMessage.tsx
+++ b/src/app/form/(formSteps)/components/ErrorMessage.tsx
@@ -15,15 +15,15 @@ export type CustomErrorMessage = {
 export interface ErrorMessageProps<T extends FieldValues> {
   name: FieldPath<T>;
   errors: FieldErrors<T>;
-  customErrorMessages?: Array<CustomErrorMessage>;
+  jsxErrorMessage?: Array<CustomErrorMessage>;
 }
 
 const getMessage = <T extends FieldValues>(
   error: NonNullable<FieldErrors<T>[FieldPath<T>]>,
-  customErrorMessages: Array<CustomErrorMessage> | undefined,
+  jsxErrorMessage: Array<CustomErrorMessage> | undefined,
 ) => {
-  if (customErrorMessages) {
-    for (const customErrorMessage of customErrorMessages) {
+  if (jsxErrorMessage) {
+    for (const customErrorMessage of jsxErrorMessage) {
       if (error.type === customErrorMessage.type) {
         return customErrorMessage.message;
       }
@@ -45,7 +45,7 @@ export const ErrorMessage = <T extends FieldValues>(props: ErrorMessageProps<T>)
     <>
       {error && (
         <span id={formatErrorMessageId(props.name)} className="usa-error-message">
-          {getMessage(error, props.customErrorMessages)}
+          {getMessage(error, props.jsxErrorMessage)}
         </span>
       )}
     </>

--- a/src/app/form/(formSteps)/insurance/1/InsuranceStep1.tsx
+++ b/src/app/form/(formSteps)/insurance/1/InsuranceStep1.tsx
@@ -118,8 +118,7 @@ const InsuranceStep1 = () => {
               register={register}
               errors={errors}
               inputMode="numeric"
-              registerOptions={{
-                required: `${inputNameToLabel["insuranceOccurenceAmount"]} is required`,
+              additionalRegisterOptions={{
                 min: {
                   value: 1000000,
                   message:
@@ -137,8 +136,7 @@ const InsuranceStep1 = () => {
               register={register}
               errors={errors}
               inputMode="numeric"
-              registerOptions={{
-                required: `${inputNameToLabel["insuranceAggregateAmount"]} is required`,
+              additionalRegisterOptions={{
                 min: {
                   value: 3000000,
                   message:

--- a/src/app/form/(formSteps)/insurance/2/InsuranceStep2.tsx
+++ b/src/app/form/(formSteps)/insurance/2/InsuranceStep2.tsx
@@ -64,9 +64,6 @@ const InsuranceStep2 = () => {
               required
               errors={errors}
               register={register}
-              registerOptions={{
-                required: `${orderedInputNameToLabel["insuranceCarrierName"]} is required`,
-              }}
             />
           </div>
           <div className="tablet:grid-col-6">
@@ -76,9 +73,6 @@ const InsuranceStep2 = () => {
               required
               errors={errors}
               register={register}
-              registerOptions={{
-                required: `${orderedInputNameToLabel["insurancePolicyNumber"]} is required`,
-              }}
             />
           </div>
         </div>

--- a/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.tsx
+++ b/src/app/form/(formSteps)/personal-details/1/PersonalDetailsStep1.tsx
@@ -79,9 +79,6 @@ const PersonalDetailsStep1 = () => {
                 required
                 errors={errors}
                 register={register}
-                registerOptions={{
-                  required: `${inputNameToLabel["firstName"]} is required`,
-                }}
               />
             </div>
             <div className="tablet:grid-col-4">
@@ -98,9 +95,6 @@ const PersonalDetailsStep1 = () => {
                 required
                 errors={errors}
                 register={register}
-                registerOptions={{
-                  required: `${inputNameToLabel["lastName"]} is required`,
-                }}
               />
             </div>
           </Fieldset>
@@ -125,8 +119,7 @@ const PersonalDetailsStep1 = () => {
             required
             errors={errors}
             register={register}
-            registerOptions={{
-              required: `${inputNameToLabel["socialSecurityNumber"]} is required`,
+            additionalRegisterOptions={{
               pattern: {
                 value: /\d{3}-\d{2}-\d{4}/,
                 message: "Entered value does not match Social Security Number format",
@@ -149,8 +142,7 @@ const PersonalDetailsStep1 = () => {
             required
             errors={errors}
             register={register}
-            registerOptions={{
-              required: `${inputNameToLabel["email"]} is required`,
+            additionalRegisterOptions={{
               pattern: {
                 value: /\S+@\S+\.\S+/,
                 message: "Entered value does not match email format",
@@ -168,8 +160,7 @@ const PersonalDetailsStep1 = () => {
             required
             errors={errors}
             register={register}
-            registerOptions={{
-              required: `${inputNameToLabel["phoneNumber"]} is required`,
+            additionalRegisterOptions={{
               pattern: {
                 value: /\d{3}-\d{3}-\d{4}/,
                 message: "Entered value does not match phone number format",

--- a/src/app/form/(formSteps)/personal-details/3/PersonalDetailsStep3.tsx
+++ b/src/app/form/(formSteps)/personal-details/3/PersonalDetailsStep3.tsx
@@ -60,14 +60,14 @@ const PersonalDetailsStep3 = () => {
               required
               errors={errors}
               register={register}
-              registerOptions={{
+              additionalRegisterOptions={{
                 required: true,
                 minLength: {
                   value: 10,
                   message: `${orderedInputNameToLabel["npiNumber"]} must have 10 digits`,
                 },
               }}
-              customErrorMessages={[
+              jsxErrorMessage={[
                 {
                   type: "required",
                   message: (

--- a/src/app/form/(formSteps)/training/1/TrainingStep1.tsx
+++ b/src/app/form/(formSteps)/training/1/TrainingStep1.tsx
@@ -110,7 +110,7 @@ const TrainingStep1 = () => {
                 aria-describedby="nameOfTrainingOrganizationAlert"
                 errors={errors}
                 register={register}
-                registerOptions={{
+                additionalRegisterOptions={{
                   required: `This question is required`,
                 }}
               />
@@ -188,9 +188,6 @@ const TrainingStep1 = () => {
                 required
                 errors={errors}
                 register={register}
-                registerOptions={{
-                  required: `${orderedInputNameToLabel["instructorFirstName"]} is required`,
-                }}
               />
             </div>
             <div className="tablet:grid-col-6">
@@ -200,9 +197,6 @@ const TrainingStep1 = () => {
                 required
                 errors={errors}
                 register={register}
-                registerOptions={{
-                  required: `${orderedInputNameToLabel["instructorLastName"]} is required`,
-                }}
               />
             </div>
           </div>
@@ -216,8 +210,7 @@ const TrainingStep1 = () => {
                 required
                 errors={errors}
                 register={register}
-                registerOptions={{
-                  required: `${orderedInputNameToLabel["instructorEmail"]} is required`,
+                additionalRegisterOptions={{
                   pattern: {
                     value: /\S+@\S+\.\S+/,
                     message: "Entered value does not match email format",
@@ -239,7 +232,7 @@ const TrainingStep1 = () => {
                 pattern="\d{3}-\d{3}-\d{4}"
                 errors={errors}
                 register={register}
-                registerOptions={{
+                additionalRegisterOptions={{
                   pattern: {
                     value: /\d{3}-\d{3}-\d{4}/,
                     message: "Entered value does not match phone number format",


### PR DESCRIPTION
## Link to issue

This commit contributes to #[375](https://github.com/newjersey/doula-pm/issues/375).

## What was done?
This commit cleans up some of our input components, by
- Encapsulating registering a default error message for `required`, in `<DoulaTextInput/>` and `<DoulaTextInputMask/>`
    - These components now only have to pass in the `required` attribute if the input is required, and the component will include a default error message if the field was not filled in
    - The default error message can be overridden by passing in `additionalRegisterProps`
- Renaming `s/customErrorMessages/jsxErrorMessage`, to make it clearer what that prop actually does
- Cleaning up logic for some conditionally applied aria attributes

There are no user-facing changes.

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/humanservices/dmahs/info/doulahelp
- Try to submit without filling in all required inputs. The error messages should show up and behave as expected
