### PR TITLE
[newjersey/doula-pm#375] Add textarea component with character count limit

### DIFF
--- a/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.test.tsx
@@ -1,0 +1,220 @@
+import DoulaTextareaCharacterCount from "@/app/form/(formSteps)/components/DoulaTextareaCharacterCount";
+import FormProgressButtons from "@/app/form/(formSteps)/components/FormProgressButtons";
+import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
+import { DoulaForm } from "@/app/form/components/DoulaForm";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+
+describe("DoulaTextareaCharacterCount", () => {
+  it("renders the input with a label", () => {
+    const mockRegister = jest.fn();
+    render(
+      <DoulaTextareaCharacterCount
+        name="testInput"
+        label="Test label"
+        maxLength={10}
+        register={mockRegister}
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toBeInTheDocument();
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("describes the input with a string hint", () => {
+    render(
+      <DoulaTextareaCharacterCount
+        name="testInput"
+        label="Test label"
+        hint="Test hint"
+        maxLength={10}
+        register={jest.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toHaveAccessibleDescription("Test hint");
+  });
+
+  it("describes the input with the provided describedby", () => {
+    render(
+      <>
+        <DoulaTextareaCharacterCount
+          name="testInput"
+          label="Test label"
+          aria-describedby="anotherDescriptonID"
+          maxLength={10}
+          register={jest.fn()}
+        />
+        <span id="anotherDescriptonID">Additional description</span>
+      </>,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).toHaveAccessibleDescription("Additional description");
+  });
+
+  it("sets appropriate attributes when the input is required", () => {
+    const mockRegister = jest.fn();
+    render(
+      <DoulaTextareaCharacterCount
+        name="testInput"
+        label="Test label"
+        required
+        maxLength={10}
+        register={mockRegister}
+      />,
+    );
+
+    expect(mockRegister).toHaveBeenCalledWith(
+      "testInput",
+      expect.objectContaining({ required: "Test label is required" }),
+    );
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAttribute("required");
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("shows an error message and sets appropriate attributes when there is an error for the input", () => {
+    render(
+      <DoulaTextareaCharacterCount
+        name="testInput"
+        label="Test label"
+        required
+        maxLength={10}
+        errors={{
+          testInput: {
+            type: "required",
+            message: "This field has a custom required error message",
+          },
+        }}
+        register={jest.fn()}
+        additionalRegisterOptions={{
+          required: "This field has a custom required error message",
+        }}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAccessibleDescription("This field has a custom required error message");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("does not show an error message if there is no error for the input", () => {
+    render(
+      <DoulaTextareaCharacterCount<{ testInput: string; otherInput: string }>
+        name="testInput"
+        label="Test label"
+        maxLength={10}
+        errors={{
+          otherInput: {
+            type: "required",
+            message: "This other field is required",
+          },
+        }}
+        register={jest.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(input).not.toHaveAttribute("aria-invalid");
+    expect(input).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("describes the input with the hint, the error message, and the aria-describedby when all are present", () => {
+    render(
+      <>
+        <DoulaTextareaCharacterCount
+          name="testInput"
+          label="Test label"
+          hint="Test hint"
+          aria-describedby="anotherDescriptonID"
+          required
+          maxLength={10}
+          errors={{
+            testInput: {
+              type: "required",
+              message: "This field has a custom required error message",
+            },
+          }}
+          register={jest.fn()}
+          additionalRegisterOptions={{
+            required: "This field has a custom required error message",
+          }}
+        />
+        <span id="anotherDescriptonID">Additional description</span>
+      </>,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label *" });
+    expect(input).toHaveAccessibleDescription(
+      "This field has a custom required error message Test hint Additional description",
+    );
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("updates the character count as the input changes", async () => {
+    // Not exhaustively testing this, because this is handles by the trussworks library component that we are using. Just making sure that the functionality still works.
+    const user = userEvent.setup();
+    render(
+      <DoulaTextareaCharacterCount
+        name="testInput"
+        label="Test label"
+        maxLength={5}
+        register={jest.fn()}
+      />,
+    );
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    expect(screen.getByText("5 characters allowed")).toBeInTheDocument();
+    await user.type(input, "12345");
+    expect(screen.getByText("0 characters left")).toBeInTheDocument();
+    await user.type(input, "6");
+    expect(screen.getByText("1 character over limit")).toBeInTheDocument();
+  });
+
+  it("displays an error message if max length is exceeded", async () => {
+    interface TestFormData {
+      testInput: string;
+    }
+
+    const TestForm = () => {
+      const {
+        register,
+        handleSubmit,
+        formState: { errors },
+        setFocus,
+      } = useForm<TestFormData>({
+        defaultValues: {
+          testInput: "",
+        },
+      });
+      return (
+        <DoulaForm<TestFormData>
+          orderedInputNames={["testInput"]}
+          errors={errors}
+          setFocus={setFocus}
+          handleSubmit={handleSubmit}
+          mayHaveThreeOrMoreErrors={true}
+        >
+          <DoulaTextareaCharacterCount
+            name="testInput"
+            label="Test label"
+            maxLength={10}
+            errors={errors}
+            register={register}
+          />
+          <FormProgressButtons />
+        </DoulaForm>
+      );
+    };
+
+    const user = userEvent.setup();
+    renderWithProviders(<TestForm />, "/form/insurance/1");
+
+    const input = screen.getByRole("textbox", { name: "Test label" });
+    await user.type(input, "12345678901");
+
+    expect(screen.getByText("1 character over limit")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    expect(input).toHaveAccessibleDescription("Test label must be 10 characters or less");
+  });
+});

--- a/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.tsx
@@ -1,0 +1,107 @@
+import { ErrorMessage } from "@/app/form/(formSteps)/components/ErrorMessage";
+import { Hint } from "@/app/form/(formSteps)/components/Hint";
+import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
+import {
+  CharacterCount,
+  InputGroup,
+  InputPrefix,
+  Label,
+  type TextareaCharacterCountProps,
+} from "@trussworks/react-uswds";
+import type {
+  FieldErrors,
+  FieldPath,
+  FieldValues,
+  RegisterOptions,
+  UseFormRegister,
+} from "react-hook-form";
+
+type wrappedAttributes = "getMessage" | "name" | "required";
+type internallySetAttributes = "id" | "validationStatus" | "aria-invalid";
+
+export interface DoulaTextareaCharacterCountProps<T extends FieldValues>
+  extends Omit<TextareaCharacterCountProps, wrappedAttributes | internallySetAttributes> {
+  name: FieldPath<T>;
+  label: React.ReactNode;
+  hint?: string;
+  inputPrefix?: string;
+  required?: boolean;
+  errors?: FieldErrors<T>;
+  register: UseFormRegister<T>;
+  additionalRegisterOptions?: RegisterOptions<T>;
+}
+
+const DoulaTextareaCharacterCount = <T extends FieldValues>(
+  props: DoulaTextareaCharacterCountProps<T>,
+) => {
+  const {
+    name,
+    label,
+    hint,
+    inputPrefix,
+    "aria-describedby": ariaDescribedby,
+    required,
+    errors,
+    register,
+    additionalRegisterOptions,
+    ...otherProps
+  } = props;
+
+  const hasError = errors !== undefined && errors[name] !== undefined;
+  const internallySetProps: Partial<TextareaCharacterCountProps> = {};
+
+  const describedby = formatDescribedBy(name, errors, hint, ariaDescribedby);
+  if (describedby !== "") {
+    internallySetProps["aria-describedby"] = describedby;
+  }
+
+  if (hasError) {
+    internallySetProps.error = true;
+    internallySetProps["aria-invalid"] = "true" as const;
+  }
+
+  // To override this, pass in additionalRegisterOptions
+  const requiredRegisterOption = required === true ? { required: `${label} is required` } : {};
+
+  let input = (
+    <CharacterCount
+      id={name}
+      required={required}
+      isTextArea={true}
+      {...internallySetProps}
+      {...otherProps}
+      {...register(name, {
+        ...requiredRegisterOption,
+        maxLength: {
+          value: otherProps.maxLength,
+          message: `${label} must be ${otherProps.maxLength} characters or less`,
+        },
+        ...additionalRegisterOptions,
+      })}
+    />
+  );
+
+  if (inputPrefix) {
+    input = (
+      <InputGroup error={hasError}>
+        <InputPrefix>{inputPrefix}</InputPrefix>
+        {input}
+      </InputGroup>
+    );
+  }
+
+  return (
+    <>
+      <Label htmlFor={name} requiredMarker={required}>
+        {label}
+      </Label>
+      {hint !== undefined && <Hint name={name} hint={hint} />}
+      {input}
+      {errors !== undefined && errors[name] !== undefined && (
+        <ErrorMessage name={name} errors={errors} />
+      )}
+    </>
+  );
+};
+
+export default DoulaTextareaCharacterCount;

--- a/src/app/form/components/DoulaForm.test.tsx
+++ b/src/app/form/components/DoulaForm.test.tsx
@@ -1,3 +1,4 @@
+import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
 import FormProgressButtons from "@/app/form/(formSteps)/components/FormProgressButtons";
 import {
   fillAllInputs,
@@ -10,8 +11,7 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import * as nextThirdPartiesGoogle from "@next/third-parties/google";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Label, TextInput } from "@trussworks/react-uswds";
-import { useForm, type FieldPath } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import * as router from "react-router";
 
 interface DoulaFormTestData {
@@ -19,12 +19,6 @@ interface DoulaFormTestData {
   field2: string | null;
   field3: string | null;
 }
-
-const orderedInputNameToLabel = {
-  field1: "Label 1",
-  field2: "Label 2",
-  field3: "Label 3",
-};
 
 const DoulaFormTestPage = (props: { mayHaveThreeOrMoreErrors: boolean }) => {
   const {
@@ -43,9 +37,7 @@ const DoulaFormTestPage = (props: { mayHaveThreeOrMoreErrors: boolean }) => {
 
   return (
     <DoulaForm<DoulaFormTestData>
-      orderedInputNames={
-        Object.keys(orderedInputNameToLabel) as Array<FieldPath<DoulaFormTestData>>
-      }
+      orderedInputNames={["field1", "field2", "field3"]}
       errors={errors}
       setFocus={setFocus}
       handleSubmit={handleSubmit}
@@ -54,72 +46,27 @@ const DoulaFormTestPage = (props: { mayHaveThreeOrMoreErrors: boolean }) => {
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">
           <h2 className="font-heading-md">Doula Form Test</h2>
-          <Label htmlFor="field1" requiredMarker>
-            {orderedInputNameToLabel["field1"]}
-          </Label>
-          <div id="field1Hint" className="usa-hint">
-            Field 1
-          </div>
-          <TextInput
-            id="field1"
-            type="text"
+          <DoulaTextInput
+            name="field1"
+            label="Label 1"
             required
-            validationStatus={errors.field1 ? "error" : undefined}
-            aria-invalid={errors.field1 ? "true" : "false"}
-            aria-describedby={errors.field1 && "field1ErrorMessage"}
-            {...register("field1", {
-              required: `${orderedInputNameToLabel["field1"]} is required`,
-            })}
+            errors={errors}
+            register={register}
           />
-          {errors.field1 && (
-            <span id="field1ErrorMessage" className="usa-error-message">
-              {errors.field1.message}
-            </span>
-          )}
-          <Label htmlFor="field2" requiredMarker>
-            {orderedInputNameToLabel["field2"]}
-          </Label>
-          <div id="field1Hint" className="usa-hint">
-            Field 2
-          </div>
-          <TextInput
-            id="field2"
-            type="text"
+          <DoulaTextInput
+            name="field2"
+            label="Label 2"
             required
-            validationStatus={errors.field2 ? "error" : undefined}
-            aria-invalid={errors.field2 ? "true" : "false"}
-            aria-describedby={errors.field2 && "field2ErrorMessage"}
-            {...register("field2", {
-              required: `${orderedInputNameToLabel["field2"]} is required`,
-            })}
+            errors={errors}
+            register={register}
           />
-          {errors.field2 && (
-            <span id="field2ErrorMessage" className="usa-error-message">
-              {errors.field2.message}
-            </span>
-          )}
-          <Label htmlFor="field3" requiredMarker>
-            {orderedInputNameToLabel["field3"]}
-          </Label>
-          <div id="field1Hint" className="usa-hint">
-            Field 3
-          </div>
-          <TextInput
-            id="field3"
-            type="text"
+          <DoulaTextInput
+            name="field3"
+            label="Label 3"
             required
-            validationStatus={errors.field3 ? "error" : undefined}
-            aria-invalid={errors.field3 ? "true" : "false"}
-            aria-describedby={errors.field3 && "field3ErrorMessage"}
-            {...register("field3", {
-              required: `${orderedInputNameToLabel["field3"]} is required`,
-            })}
+            errors={errors}
+            register={register}
           />
-          {errors.field3 && (
-            <span id="field3ErrorMessage" className="usa-error-message">
-              {errors.field3.message}
-            </span>
-          )}
         </div>
       </div>
       <FormProgressButtons />


### PR DESCRIPTION
## Link to issue

This commit resolves newjersey/doula-pm#375.

Testing github actions resolves This commit resolves newjersey/doula-pm#376.

## What was done?
This commit adds a reusable textarea component that has a character count limit.

The behavior mirrors that of https://design-system.service.gov.uk/components/character-count/error/, where there are two pieces of information after an error on submission: 
- The number of characters remaining/exceeded. This updates on every user input, and is debounced for screenreaders via aria-live. The input is not described-by this.
- After submission, an error state that the input needs to be a fixed number of characters or less. The input is described-by this error state.
See [this discussion](https://njcio.slack.com/archives/C077L9USK4Z/p1764621966049059?thread_ts=1764607507.545009&cid=C077L9USK4Z) for more.

It also cleans up `DoulaForm.test.tsx` to reflect patterns that we use in the codebase today.

## Accessibility
- [x] I have made sure this works with a screenreader!
    - [x] Tested on NVDA
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Find a page (e.g., `src/app/form/(formSteps)/insurance/2/InsuranceStep2.tsx`) with a `<DoulaTextInput`. Change it to `<DoulaTextareaCharacterCount`, update the import, and add a maxLength prop, e.g. `maxLength={10}`
- Go to the corresponding page. e.g., http://localhost:3000/humanservices/dmahs/info/doulahelp/form/insurance/2
- Poke around with the component, and try to break it
    - Exceed the number of allowed characters, and try to submit
    - Test out with three or more errors on the entire page
    - Test out with fewer than three errors on the entire page
    - Use a screen reader for all of the above

## Screenshots (for visual changes)

These are just screenshots to demonstrate the component, on code that is not the code shown here. The component is not actually included in any code here.

<details>
<summary>Screenshots</summary>

<img width="494" height="343" alt="image" src="https://github.com/user-attachments/assets/b2c86117-237d-4254-8835-77c060e901b8" />
<img width="505" height="353" alt="image" src="https://github.com/user-attachments/assets/2b5c4553-88ca-4ef1-a760-ba6345cf0ffb" />

After submission
<img width="1025" height="630" alt="image" src="https://github.com/user-attachments/assets/82abe511-b9b5-446b-8ef8-2c0ddf098f46" />

</details>
