### PR TITLE
[newjersey/doula-pm#320] Update landing page text to say to read the entire application

### DIFF
--- a/src/app/form/(formSteps)/welcome/WelcomeSection.tsx
+++ b/src/app/form/(formSteps)/welcome/WelcomeSection.tsx
@@ -133,25 +133,31 @@ const WelcomeSection = () => {
       <div className="grid-row">
         <ProcessList>
           <ProcessListItem>
-            <ProcessListHeading type="h3">Complete your FFS application packet</ProcessListHeading>
+            <ProcessListHeading type="h3">
+              Click “Start Now” to begin your Fee-For-Service (FFS) application process
+            </ProcessListHeading>
             <p>
-              Gather the{" "}
-              <a
-                href="https://www.nj.gov/humanservices/dmahs/info/NJFC_Doula_Steps.pdf"
-                target="_blank"
-                rel="noopener"
-                className="usa-link"
-              >
-                <span className="usa-sr-only">opens in a new tab.</span>
-                required documents
-              </a>
-              , we&apos;ll guide you through the FFS application on this website.
+              This website will help you complete your FFS application forms in just 20 minutes
+              using language that is easy to understand.
             </p>
           </ProcessListItem>
           <ProcessListItem>
-            <ProcessListHeading type="h3">Email your FFS application packet</ProcessListHeading>
+            <ProcessListHeading type="h3">
+              Download, review, and sign your application
+            </ProcessListHeading>
             <p>
-              Send forms to{" "}
+              You should review, make any updates, and sign your downloaded application forms before
+              you submit. Follow instructions on the cover page of your downloaded application
+              packet.
+            </p>
+          </ProcessListItem>
+          <ProcessListItem>
+            <ProcessListHeading type="h3">
+              Email your signed application and attached documents
+            </ProcessListHeading>
+            <p>
+              This website will not submit your application. Email your completed application packet
+              to{" "}
               <a href="mailto:mahs.doulaguide@dhs.nj.gov" target="_blank" rel="noopener">
                 mahs.doulaguide@dhs.nj.gov
               </a>{" "}
@@ -164,30 +170,33 @@ const WelcomeSection = () => {
               >
                 njmmisproviderenrollment@gainwelltechnologies.com
               </a>{" "}
-              simultaneously. Keep an eye on your inbox!
+              simultaneously.
             </p>
           </ProcessListItem>
           <ProcessListItem>
             <ProcessListHeading type="h3">
-              Free background check and fingerprinting
+              Complete your free background check and fingerprinting
             </ProcessListHeading>
             <p>
-              After you submit your FFS application, a Doula Guide will email instructions to
-              complete this step in a local office and submit your receipt.
+              After you submit your application, a Doula Guide will email instructions to complete
+              this step in a local office. You will submit the receipt.
             </p>
           </ProcessListItem>
           <ProcessListItem>
             <ProcessListHeading type="h3">Receive your NJ Medicaid ID</ProcessListHeading>
             <p>
-              Once we approve your FFS application, we will send you a letter with your NJ Medicaid
-              ID.
+              Once Gainwell approves your application, you will receive a letter with your NJ
+              Medicaid ID.
             </p>
           </ProcessListItem>
           <ProcessListItem>
             <ProcessListHeading type="h3">
               Apply to Managed Care Organizations (MCOs)
             </ProcessListHeading>
-            <p>Once you receive your NJ Medicaid ID, you can apply to the MCOs.</p>
+            <p>
+              Once you receive your NJ Medicaid ID, you can apply to contract with any Managed Care
+              Organization (MCO).
+            </p>
           </ProcessListItem>
         </ProcessList>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,7 +62,7 @@ abbr[title] {
   .welcome-page .usa-process-list {
     display: grid;
     grid-template-columns: repeat(auto-fit, 1fr);
-    grid-template-rows: repeat(5, 1fr);
+    grid-template-rows: repeat(6, 1fr);
     grid-auto-flow: column;
   }
 


### PR DESCRIPTION
## Link to issue

This commit resolves #[320](https://github.com/newjersey/doula-pm/issues/320).

## What was done?

Update landing page text, per [the figma](https://www.figma.com/design/2R3VxYvZQYsaIxBcWoA1kL/Doula-Prototypes?node-id=5158-16554&t=8ClBCn5YQIFehbIP-4).

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/humanservices/dmahs/info/doulahelp
- See that the landing page text matches [the figma](https://www.figma.com/design/2R3VxYvZQYsaIxBcWoA1kL/Doula-Prototypes?node-id=5158-16554&t=8ClBCn5YQIFehbIP-4)

## Screenshots (for visual changes)

<details>
<summary>Before</summary>

<img width="965" height="641" alt="image" src="https://github.com/user-attachments/assets/d7c51f60-c5f9-4ad7-90fe-167740c22eb3" />

<img width="528" height="946" alt="image" src="https://github.com/user-attachments/assets/72078706-915c-42ce-9fd9-8003d017b5b4" />


</details>


<details>
<summary>After</summary>

<img width="1049" height="788" alt="image" src="https://github.com/user-attachments/assets/b3088a0e-c966-456f-b741-59c8d9485593" />

<img width="528" alt="image" src="https://github.com/user-attachments/assets/de639db1-87bc-42d1-a8a0-d86d54b33d18" />


</details>