### PR TITLE
[newjersey/doula-pm#378] Update header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout({
                   <Image className="nj-banner__header-seal" src={njStateSeal} alt="NJ flag"></Image>
                 </div>
                 <div className="grid-col-fill">
-                  <a href="https://nj.gov" target="_blank" rel="noopener" className="usa-link">
+                  <a href="https://nj.gov" target="_blank" rel="noopener">
                     <span className="usa-sr-only">opens in a new tab.</span>
                     Official Site of the State of New Jersey
                   </a>
@@ -49,14 +49,13 @@ export default function RootLayout({
                 <div className="grid-col-auto">
                   <div className="text-white">
                     <ul>
-                      <li>Governor Phil Murphy &bull; Lt. Governor Tahesha Way</li>
                       <li>
-                        <a
-                          href="https://nj.gov/subscribe/"
-                          target="_blank"
-                          rel="noopener"
-                          className="usa-link"
-                        >
+                        <a href="https://nj.gov/governor/" target="_blank" rel="noopener">
+                          Governor Phil Murphy &bull; Lt. Governor Tahesha Way
+                        </a>
+                      </li>
+                      <li>
+                        <a href="https://nj.gov/subscribe/" target="_blank" rel="noopener">
                           <svg
                             className="usa-icon nj-banner__mail-icon bottom-neg-2px margin-right-05"
                             aria-hidden="true"


### PR DESCRIPTION
## Link to issue

This commit resolves newjersey/doula-pm#378.

## What was done?
This commit:
- Removes the visited purple from banner links
- Adds a link to the names for the Governor and Lt. Governor in the banner

## Accessibility
- [x] I have made sure this works with a screenreader!
- [x] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/humanservices/dmahs/info/doulahelp


## Screenshots (for visual changes)
<img width="1274" height="668" alt="image" src="https://github.com/user-attachments/assets/ae200537-5eae-474f-95a1-ef0258747ed4" />