### PR TITLE
[newjersey/doula-pm#347] Add example legal test

### DIFF
--- a/src/app/form/(formSteps)/legal/1/LegalStep1.test.tsx
+++ b/src/app/form/(formSteps)/legal/1/LegalStep1.test.tsx
@@ -1,0 +1,23 @@
+import LegalStep1 from "@/app/form/(formSteps)/legal/1/LegalStep1";
+import type { DataStore } from "@/app/form/_utils/dataStore";
+import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
+
+describe("<LegalStep1 />", () => {
+  const oldProcessEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules(); // Clears the cache
+    process.env = { ...oldProcessEnv, NEXT_PUBLIC_FLAG_LEGAL: "1" };
+  });
+
+  afterAll(() => {
+    process.env = oldProcessEnv;
+  });
+
+  const renderFunction = (dataStore: DataStore = {}) =>
+    renderWithProviders(<LegalStep1 />, "/form/legal/1", dataStore);
+
+  it("renders", async () => {
+    renderFunction();
+  });
+});

--- a/src/app/form/_utils/formProgress.ts
+++ b/src/app/form/_utils/formProgress.ts
@@ -10,76 +10,80 @@ export interface FormProgress {
   section: Section;
   step?: number;
 }
-export const progressBarSections: Array<Section> = [
-  {
-    id: "screening",
-    name: "Screening",
-    numSteps: 3,
-    shouldShowProgressBar: true,
-    shouldShowProgressHeadingAndRequiredMessage: true,
-  },
-  {
-    id: "insurance",
-    name: "Insurance",
-    numSteps: 2,
-    shouldShowProgressBar: true,
-    shouldShowProgressHeadingAndRequiredMessage: true,
-  },
-  {
-    id: "training",
-    name: "Training",
-    numSteps: 1,
-    shouldShowProgressBar: true,
-    shouldShowProgressHeadingAndRequiredMessage: true,
-  },
-  {
-    id: "personal",
-    name: "Personal",
-    numSteps: 3,
-    shouldShowProgressBar: true,
-    shouldShowProgressHeadingAndRequiredMessage: true,
-  },
-  {
-    id: "business",
-    name: "Business",
-    numSteps: 4,
-    shouldShowProgressBar: true,
-    shouldShowProgressHeadingAndRequiredMessage: true,
-  },
-  ...(process.env.NEXT_PUBLIC_FLAG_LEGAL === "1"
-    ? [
-        {
-          id: "legal",
-          name: "Legal",
-          numSteps: 3,
-          shouldShowProgressBar: true,
-          shouldShowProgressHeadingAndRequiredMessage: true,
-        },
-      ]
-    : []),
-  {
-    id: "review",
-    name: "Review",
-    shouldShowProgressBar: true,
-    shouldShowProgressHeadingAndRequiredMessage: false,
-  },
-];
+export const getProgressBarSections = (): Array<Section> => {
+  return [
+    {
+      id: "screening",
+      name: "Screening",
+      numSteps: 3,
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: true,
+    },
+    {
+      id: "insurance",
+      name: "Insurance",
+      numSteps: 2,
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: true,
+    },
+    {
+      id: "training",
+      name: "Training",
+      numSteps: 1,
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: true,
+    },
+    {
+      id: "personal",
+      name: "Personal",
+      numSteps: 3,
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: true,
+    },
+    {
+      id: "business",
+      name: "Business",
+      numSteps: 4,
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: true,
+    },
+    ...(process.env.NEXT_PUBLIC_FLAG_LEGAL === "1"
+      ? [
+          {
+            id: "legal",
+            name: "Legal",
+            numSteps: 3,
+            shouldShowProgressBar: true,
+            shouldShowProgressHeadingAndRequiredMessage: true,
+          },
+        ]
+      : []),
+    {
+      id: "review",
+      name: "Review",
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: false,
+    },
+  ];
+};
 
-export const allSections: Array<Section> = [
-  {
-    id: "welcome",
-    name: "Welcome",
-    shouldShowProgressBar: false,
-    shouldShowProgressHeadingAndRequiredMessage: false,
-  },
-].concat(progressBarSections);
+export const getAllSections = (): Array<Section> => {
+  return [
+    {
+      id: "welcome",
+      name: "Welcome",
+      shouldShowProgressBar: false,
+      shouldShowProgressHeadingAndRequiredMessage: false,
+    },
+  ].concat(getProgressBarSections());
+};
 
 export const getCurrentFormProgress = (pathname: string): FormProgress => {
   const pathParts = pathname.split("/");
   if (pathParts[0] !== "" || pathParts[1] !== "form") {
     throw new Error(`Unexpected route ${pathname}`);
   }
-  const currentSection = allSections.find((section) => pathParts[2].endsWith(section.id));
+  const currentSection = getAllSections().find((section) => pathParts[2].endsWith(section.id));
   if (currentSection === undefined) {
     throw new Error(`Section not found for ${pathname}`);
   }
@@ -123,7 +127,6 @@ export const getNextFormProgress = (
     return {
       section: allSections[nextSectionIndex],
       ...(allSections[nextSectionIndex].numSteps !== undefined && { step: 1 }),
-      // step: allSteps[nextSectionIndex].numSteps === undefined ? null : 1,
     };
   }
 };

--- a/src/app/form/_utils/formProgressRouting.ts
+++ b/src/app/form/_utils/formProgressRouting.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  allSections,
+  getAllSections,
   getCurrentFormProgress,
   getNextFormProgress,
   getPreviousFormProgress,
@@ -18,8 +18,8 @@ export interface FormProgressPosition {
 export const useFormProgressPosition = (): FormProgressPosition => {
   const pathname = usePathname();
   const current = getCurrentFormProgress(pathname);
-  const next = getNextFormProgress(current, allSections);
-  const previous = getPreviousFormProgress(current, allSections);
+  const next = getNextFormProgress(current, getAllSections());
+  const previous = getPreviousFormProgress(current, getAllSections());
   return { current, next, previous };
 };
 

--- a/src/app/form/components/ProgressBar.tsx
+++ b/src/app/form/components/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import { getCurrentFormProgress, progressBarSections } from "@form/_utils/formProgress";
+import { getCurrentFormProgress, getProgressBarSections } from "@form/_utils/formProgress";
 import { RequiredMarker } from "@trussworks/react-uswds";
 import { usePathname } from "next/navigation";
 
@@ -7,14 +7,14 @@ type CompletionState = "complete" | "current" | "incomplete";
 export const ProgressBar = () => {
   const pathname = usePathname();
   const { section: currentSection, step: currentStep } = getCurrentFormProgress(pathname);
-  const currentSectionIndex = progressBarSections.findIndex(
+  const currentSectionIndex = getProgressBarSections().findIndex(
     (sections) => sections.id === currentSection.id,
   );
 
   return (
     <div className="usa-step-indicator" aria-label="progress">
       <ol className="usa-step-indicator__segments">
-        {progressBarSections.map((section, sectionIndex) => {
+        {getProgressBarSections().map((section, sectionIndex) => {
           let completionState: CompletionState;
           switch (true) {
             case sectionIndex < currentSectionIndex:


### PR DESCRIPTION
## Link to issue

This commit resolves newjersey/doula-pm#347.

## What was done?
This commit enables testing with `NEXT_PUBLIC_FLAG_LEGAL` set to `"1"`, and includes an example legal test to stub this. It does so by changing the `getProgressBarSections` and `allSections` variables that define what sections we have, from being variables that are evaluated at file-read time, to functions that are evaluated dynamically.

Mocking `process.env` is done as suggested in https://stackoverflow.com/questions/48033841/test-process-env-with-jest/58953365.


## How should a reviewer test?

- Locally, run `npm install`
- Run `npm test -- --runTestsByPath "src/app/form/(formSteps)/legal/1/LegalStep1.test.tsx"`, and the test should pass