### PR TITLE
[newjersey/doula-pm#347] Pin the environment variables used in jest tests to those in `.env.test-production-flags`

### DIFF
--- a/.env.test-production-flags
+++ b/.env.test-production-flags
@@ -1,3 +1,2 @@
-# Requires copying to an .env.test or .env.test.local to be loaded when running with NODE_ENV=test
 NEXT_PUBLIC_FLAG_TEST=0
 NEXT_PUBLIC_FLAG_LEGAL=0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cypress:run": "cypress run",
     "cypress:run:productionFlags": "cypress run --env PRODUCTION_FLAGS=true",
     "cypress:gui": "cypress open",
-    "test": "jest",
+    "test": "env $(cat .env.test-production-flags | xargs) jest",
     "typecheck": "tsc --noemit",
     "configureVpc": "npx tsx scripts/configureVpc.ts",
     "cdk:deploy": "npx cdk deploy DoulaAssistantStack"

--- a/src/app/form/(formSteps)/legal/1/LegalStep1.test.tsx
+++ b/src/app/form/(formSteps)/legal/1/LegalStep1.test.tsx
@@ -6,7 +6,7 @@ describe("<LegalStep1 />", () => {
   const oldProcessEnv = process.env;
 
   beforeEach(() => {
-    jest.resetModules(); // Clears the cache
+    jest.resetModules();
     process.env = { ...oldProcessEnv, NEXT_PUBLIC_FLAG_LEGAL: "1" };
   });
 

--- a/src/app/form/components/ProgressBar.test.tsx
+++ b/src/app/form/components/ProgressBar.test.tsx
@@ -23,6 +23,31 @@ describe("<ProgressBar />", () => {
     expect(sections[5]).toHaveTextContent("not completed");
   });
 
+  describe("when NEXT_PUBLIC_FLAG_LEGAL is set", () => {
+    const oldProcessEnv = process.env;
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...oldProcessEnv, NEXT_PUBLIC_FLAG_LEGAL: "1" };
+    });
+    afterEach(() => {
+      process.env = oldProcessEnv;
+    });
+
+    it("shows the legal section ", () => {
+      renderWithProviders(routes, "/form/business/1");
+      const progressSection = screen.getByRole("generic", { name: /progress/i });
+      const sections = within(progressSection).getAllByRole("listitem");
+      expect(sections.length).toEqual(7);
+      expect(sections[0]).toHaveTextContent("Screening");
+      expect(sections[1]).toHaveTextContent("Insurance");
+      expect(sections[2]).toHaveTextContent("Training");
+      expect(sections[3]).toHaveTextContent("Personal");
+      expect(sections[4]).toHaveTextContent("Business");
+      expect(sections[5]).toHaveTextContent("Legal");
+      expect(sections[6]).toHaveTextContent("Review");
+    });
+  });
+
   it("shows the progress bar and page title but not the heading or required indicator when shouldShowProgressHeadingAndRequiredMessage is false", async () => {
     renderWithProviders(routes, "/form/review");
     const name = "Review";


### PR DESCRIPTION
## Link to issue

This commit resolves newjersey/doula-pm#347.

## What was done?
Previously, jest tests would run using any shell environment variables present. In a local development environment, we don't typically set any shell environment variables, our flags use the .env files instead. The local jest tests run with no vars from .env files set.

However, on Amplify, we set the feature flags (e.g. `NEXT_PUBLIC_FLAG_LEGAL`), not through .env files, but by exported shell environment variables. This causes jest tests run in the Amplify environment to run with any flag set for that environment. That sounds nice in theory, but our test need to know the environment that they are running in in order to have the correct assertion/expectation.

This commit sets `npm run test` to run with the shell environment variables exported from the `.env.test-production-flags` file.

This commit also adds an additional test to the progress bar, to test that the legal section is present when `NEXT_PUBLIC_FLAG_LEGAL` is set.


## How should a reviewer test?

- Locally, run `npm install` then `npm run test`.
- Run `export NEXT_PUBLIC_FLAG_LEGAL=1`. This causes 7 sections to appear in the progress bar, including the legal section, when going to http://localhost:3000/humanservices/dmahs/info/doulahelp/form/screening/1
- Run `npx jest`, the old version of the `npm run test` command. Tests in `src/app/form/components/ProgressBar.test.tsx` should fail, saying that there are 7 sections in the progress bar instead of the expected 6.
    - For good measure, one can `console.log(process.env.NEXT_PUBLIC_FLAG_LEGAL);` and see that the value is `1`
- Run `npm run test`, the current version of the `npm run test` command. Tests should pass.
    - This new `npm run test` sets the environment variables to those in the `.env.test-production-flags` file, overriding any `export NEXT_PUBLIC_FLAG_LEGAL=1` value that might be in the shell environment
    - A `console.log(process.env.NEXT_PUBLIC_FLAG_LEGAL);` should show the value as 0
