### PR TITLE
[newjersey/doula-pm#66] Automatically post on a linked issue when an amplify branch is deployed on a PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 ## Link to issue
 
+This commit resolves newjersey/doula-pm#
+
 ## What was done?
 
 - Explain the implementation goals being solved or the feature with the reviewer in mind

--- a/.github/workflows/add_amplify_comment.yml
+++ b/.github/workflows/add_amplify_comment.yml
@@ -1,0 +1,41 @@
+name: add-amplify-comment
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  add-amplify-comment:
+    if: contains(github.head_ref, 'amplify')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get linked issues
+        id: get-linked-issues
+        env:
+          GH_TOKEN: ${{ secrets.DOULA_PM_ISSUE_COMMENT_TOKEN }}
+        run: |
+          echo "LINKED_ISSUES=$(gh api graphql -F owner='newjersey' -F repo='doula-medicaid' -F pr=${{ github.event.number }} -f query='
+            query ($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  closingIssuesReferences(first: 100) {
+                    nodes {
+                      number
+                    }
+                  }
+                }
+              }
+            }
+          ' --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number' | xargs)" >> $GITHUB_OUTPUT
+
+      - name: Comment issue with amplify link
+        env:
+          GH_TOKEN: ${{ secrets.DOULA_PM_ISSUE_COMMENT_TOKEN }}
+          LINKED_ISSUES: ${{ steps.get-linked-issues.outputs.LINKED_ISSUES }}
+        run: |
+          for issueNum in $(echo $LINKED_ISSUES); do
+            gh issue comment $issueNum --repo newjersey/doula-pm --body "https://github.com/newjersey/doula-medicaid/pull/${{ github.event.number }} is being deployed to https://${{ github.head_ref }}.${{ secrets.AMPLIFY_APP_ID }}.amplifyapp.com/humanservices/dmahs/info/doulahelp and should be available in 6 minutes.
+            
+            Check build status at https://us-east-1.console.aws.amazon.com/amplify/apps/${{ secrets.AMPLIFY_APP_ID }}/branches/${{ github.head_ref }}/deployments
+            This is an automated message from add_amplify_comment.yml"
+          done

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Second, run the development server:
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open
+[http://localhost:3000/humanservices/dmahs/info/doulahelp](http://localhost:3000/humanservices/dmahs/info/doulahelp)
+with your browser to see the result.
 
 ## Running tests
 


### PR DESCRIPTION
## Link to issue

This commit resolves newjersey/doula-pm#66.

## What was done?
When we deploy a branch with `amplify` in a branch name, it automatically spins up an amplify deployment. This allows PMs to preview the PR before it is merged into main. However, the amplify URL is annoying to assemble. We need to get the branch name, the amplify app id, and then `/humanservices/dmahs/info/doulahelp`.

This repository is public. Although the amplify deployment is protected by amplify's auth, it's still not ideal to share the amplify deployment URL on this public repo.

This commit adds an automation to post on a PR's linked issue (which is on a private repo), with the amplify deployment URL when one is deployed.

## How should a reviewer test?

- Go to the linked issue (right sidebar, "Development"), and see that a comment has been posted.
<img width="374" height="187" alt="image" src="https://github.com/user-attachments/assets/53a1b7a0-5f11-4243-aef1-c6817a78994b" />
