### PR TITLE
[newjersey/doula-pm#368] Change last button from Next to Review

### DIFF
--- a/cypress/e2e/fillAndDownloadApplication.ts
+++ b/cypress/e2e/fillAndDownloadApplication.ts
@@ -66,7 +66,7 @@ export const baseFormPages = [
 ];
 
 export const fillAndDownloadApplication = (
-  baseFormPages: Array<{ url: string; fields: TestField[]; titleName: string }>,
+  formPages: Array<{ url: string; fields: TestField[]; titleName: string }>,
 ) => {
   /**
    * Test one field per page, and one of every type of field. Leaving unit individual-page tests to
@@ -95,7 +95,7 @@ export const fillAndDownloadApplication = (
   cy.title().should("eq", `Welcome ${titleEnding}`);
   cy.contains("Start now").click();
 
-  for (const formPage of baseFormPages) {
+  for (const [index, formPage] of formPages.entries()) {
     cy.url().should("eq", `${Cypress.config("baseUrl")}${formPage.url}`);
     cy.window().its("scrollY").should("equal", 0); // The page view should be at the top
     cy.title().should("eq", `${formPage.titleName} ${titleEnding}`);
@@ -115,12 +115,16 @@ export const fillAndDownloadApplication = (
         }
       }
     });
-    cy.contains("Next").click();
+    if (index !== formPages.length - 1) {
+      cy.contains("button", "Next").click();
+    } else {
+      cy.contains("button", "Review").click();
+    }
   }
   cy.url().should("eq", `${Cypress.config("baseUrl")}/form/review`);
 
   // Test clicking previous, and prepopulation
-  for (const formPage of baseFormPages.reverse()) {
+  for (const formPage of formPages.reverse()) {
     cy.contains("Previous").click();
     cy.url().should("eq", `${Cypress.config("baseUrl")}${formPage.url}`);
     cy.window().its("scrollY").should("equal", 0);
@@ -143,9 +147,10 @@ export const fillAndDownloadApplication = (
     });
   }
 
-  for (const _ of baseFormPages) {
-    cy.contains("Next").click();
+  for (const _ of formPages.slice(0, -1)) {
+    cy.contains("button", "Next").click();
   }
+  cy.contains("button", "Review").click();
 
   cy.url().should("eq", `${Cypress.config("baseUrl")}/form/review`);
   cy.title().should("eq", `Review ${titleEnding}`);

--- a/src/app/form/(formSteps)/components/FormProgressButtons.tsx
+++ b/src/app/form/(formSteps)/components/FormProgressButtons.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getAllSections, isFinalFormProgress } from "@/app/form/_utils/formProgress";
 import { formatFormProgressUrl, useFormProgressPosition } from "@form/_utils/formProgressRouting";
 import { sendGAEvent } from "@next/third-parties/google";
 import { Button, ButtonGroup } from "@trussworks/react-uswds";
@@ -29,7 +30,7 @@ const FormProgressButtons = (props: { overrideClassNames?: string }) => {
         className="margin-top-0"
         onClick={() => sendGAEvent("event", "progressNext")}
       >
-        Next
+        {isFinalFormProgress(formProgressPosition.next, getAllSections()) ? "Review" : "Next"}
       </Button>,
     );
   }

--- a/src/app/form/_utils/formProgress.test.ts
+++ b/src/app/form/_utils/formProgress.test.ts
@@ -2,6 +2,7 @@ import {
   getCurrentFormProgress,
   getNextFormProgress,
   getPreviousFormProgress,
+  isFinalFormProgress,
 } from "@form/_utils/formProgress";
 
 describe("getCurrentFormProgress", () => {
@@ -96,8 +97,8 @@ describe("getPreviousFormProgress", () => {
   });
 });
 
-describe("getNextStep and getPreviousStep", () => {
-  it("gets the correct next and previous steps when transitioning within a section", () => {
+describe("getNextFormProgress and getPreviousFormProgress", () => {
+  it("gets the correct next and previous form progress when transitioning within a section", () => {
     const section = {
       id: "section1",
       name: "Section 1",
@@ -205,11 +206,82 @@ describe("getNextStep and getPreviousStep", () => {
       },
     },
   ])(
-    "gets the correct next and previous steps when transitioning between sections and $name",
+    "gets the correct next and previous form progress when transitioning between sections and $name",
     ({ firstFormProgress, secondFormProgress }) => {
       const allSections = [firstFormProgress.section, secondFormProgress.section];
       expect(getNextFormProgress(firstFormProgress, allSections)).toEqual(secondFormProgress);
       expect(getPreviousFormProgress(secondFormProgress, allSections)).toEqual(firstFormProgress);
     },
   );
+});
+
+describe("isFinalFormProgress", () => {
+  const otherSection = {
+    id: "otherSection",
+    name: "Other section",
+    shouldShowProgressBar: true,
+    shouldShowProgressHeadingAndRequiredMessage: true,
+  };
+
+  it("returns true when the form progress is final and has steps", () => {
+    const sectionWithSteps = {
+      id: "sectionWithSteps",
+      name: "Section with steps",
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: true,
+      numSteps: 2,
+    };
+    const allSections = [otherSection, sectionWithSteps];
+    const currentFormProgress = {
+      section: sectionWithSteps,
+      step: 2,
+    };
+    expect(isFinalFormProgress(currentFormProgress, allSections)).toEqual(true);
+  });
+
+  it("returns true when the form progress is final and has no steps", () => {
+    const sectionWithoutSteps = {
+      id: "sectionWithoutSteps",
+      name: "Section without steps",
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: true,
+    };
+
+    const allSections = [otherSection, sectionWithoutSteps];
+    const currentFormProgress = {
+      section: sectionWithoutSteps,
+    };
+    expect(isFinalFormProgress(currentFormProgress, allSections)).toEqual(true);
+  });
+
+  it("returns false when the form progress is not final and has steps", () => {
+    const sectionWithSteps = {
+      id: "sectionWithSteps",
+      name: "Section with steps",
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: true,
+      numSteps: 2,
+    };
+    const allSections = [sectionWithSteps, otherSection];
+    const currentFormProgress = {
+      section: sectionWithSteps,
+      step: 2,
+    };
+    expect(isFinalFormProgress(currentFormProgress, allSections)).toEqual(false);
+  });
+
+  it("returns false when the form progress is not final and has no steps", () => {
+    const sectionWithoutSteps = {
+      id: "sectionWithoutSteps",
+      name: "Section without steps",
+      shouldShowProgressBar: true,
+      shouldShowProgressHeadingAndRequiredMessage: true,
+    };
+
+    const allSections = [sectionWithoutSteps, otherSection];
+    const currentFormProgress = {
+      section: sectionWithoutSteps,
+    };
+    expect(isFinalFormProgress(currentFormProgress, allSections)).toEqual(false);
+  });
 });

--- a/src/app/form/_utils/formProgress.ts
+++ b/src/app/form/_utils/formProgress.ts
@@ -119,8 +119,8 @@ export const getNextFormProgress = (
     const currentSectionIndex = allSections.findIndex(
       (section) => section.id === currentStep.section.id,
     );
-    const isFinalStep = currentSectionIndex === allSections.length - 1;
-    if (isFinalStep) {
+    const isFinalSection = currentSectionIndex === allSections.length - 1;
+    if (isFinalSection) {
       return null;
     }
     const nextSectionIndex = currentSectionIndex + 1;
@@ -162,4 +162,21 @@ export const getPreviousFormProgress = (
       }),
     };
   }
+};
+
+export const isFinalFormProgress = (
+  formProgress: FormProgress,
+  allSections: Array<Section>,
+): boolean => {
+  const currentSectionIndex = allSections.findIndex(
+    (section) => section.id === formProgress.section.id,
+  );
+  const isFinalSection = currentSectionIndex === allSections.length - 1;
+  if (
+    isFinalSection &&
+    (formProgress.step === undefined || formProgress.step === formProgress.section.numSteps)
+  ) {
+    return true;
+  }
+  return false;
 };

--- a/src/app/form/_utils/testUtils/renderWithProviders.tsx
+++ b/src/app/form/_utils/testUtils/renderWithProviders.tsx
@@ -25,5 +25,5 @@ export const renderWithProviders = (
       </PathnameContext.Provider>
     </AppRouterContext.Provider>,
   );
-  return { mockUpdateDataStore };
+  return { mockUpdateDataStore, pathname };
 };

--- a/src/app/form/_utils/testUtils/sharedTests.ts
+++ b/src/app/form/_utils/testUtils/sharedTests.ts
@@ -1,5 +1,11 @@
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import {
+  getAllSections,
+  getCurrentFormProgress,
+  getNextFormProgress,
+  isFinalFormProgress,
+} from "@/app/form/_utils/formProgress";
+import {
   fillAllInputs,
   fillAllInputsExcept,
   fillField,
@@ -35,7 +41,10 @@ export interface TestField {
   prerequisiteField?: TestField;
 }
 
-type RenderFunction = (dataStore?: DataStore) => { mockUpdateDataStore: jest.Mock };
+type RenderFunction = (dataStore?: DataStore) => {
+  mockUpdateDataStore: jest.Mock;
+  pathname: string;
+};
 
 export const createTestField = (field: TestFieldParameters): TestField => {
   return {
@@ -70,9 +79,18 @@ export const testSaveFieldsToDataStore = async (
   screen: Screen,
 ) => {
   const user = userEvent.setup();
-  const { mockUpdateDataStore } = renderFunction();
+  const { mockUpdateDataStore, pathname } = renderFunction();
   await fillAllInputs(screen, user, allFields);
-  await user.click(screen.getByRole("button", { name: "Next" }));
+
+  const allSections = getAllSections();
+  const nextFormProgress = getNextFormProgress(getCurrentFormProgress(pathname), allSections);
+  const submitButtonName =
+    nextFormProgress && isFinalFormProgress(nextFormProgress, allSections) ? "Review" : "Next";
+  await user.click(
+    screen.getByRole("button", {
+      name: submitButtonName,
+    }),
+  );
 
   const dataUpdates = Object.fromEntries(
     fieldsToTest.map((field) => [field.dataStoreKey, field.expectedValue]),
@@ -87,12 +105,16 @@ export const testRequiredField = async (
   screen: Screen,
 ) => {
   const user = userEvent.setup();
-  const { mockUpdateDataStore } = renderFunction();
+  const { mockUpdateDataStore, pathname } = renderFunction();
   await fillAllInputsExcept(screen, user, allFields, new Set([fieldToTest.dataStoreKey]));
   const input = await getInputField(screen, fieldToTest);
   expect(input).toBeRequired();
 
-  await user.click(screen.getByRole("button", { name: "Next" }));
+  const allSections = getAllSections();
+  const nextFormProgress = getNextFormProgress(getCurrentFormProgress(pathname), allSections);
+  const submitButtonName =
+    nextFormProgress && isFinalFormProgress(nextFormProgress, allSections) ? "Review" : "Next";
+  await user.click(screen.getByRole("button", { name: submitButtonName }));
   expect(input).toHaveAccessibleDescription(
     expect.stringContaining(fieldToTest.requiredErrorMessage),
   );
@@ -113,11 +135,15 @@ export const testInvalidField = async (
   focusedField?: FieldToGet,
 ) => {
   const user = userEvent.setup();
-  const { mockUpdateDataStore } = renderFunction();
+  const { mockUpdateDataStore, pathname } = renderFunction();
   await fillAllInputsExcept(screen, user, allFields, new Set([invalidField.dataStoreKey]));
   await fillField(screen, user, invalidField);
 
-  await user.click(screen.getByRole("button", { name: "Next" }));
+  const allSections = getAllSections();
+  const nextFormProgress = getNextFormProgress(getCurrentFormProgress(pathname), allSections);
+  const submitButtonName =
+    nextFormProgress && isFinalFormProgress(nextFormProgress, allSections) ? "Review" : "Next";
+  await user.click(screen.getByRole("button", { name: submitButtonName }));
   const input = await getInputField(screen, invalidField);
   expect(input).toHaveAccessibleDescription(expect.stringContaining(expectedErrorMessage));
   expect(input).toHaveAttribute("aria-invalid", "true");


### PR DESCRIPTION
## Link to issue

This commit resolves newjersey/doula-pm#368.

## What was done?
This commit changes the text of the last "Next" progress button before the final page, from "Next" to "Review".

## Accessibility
- [ ] I have made sure this works with a screenreader!
- [ ] I have checked this with the [WAVE extension](https://wave.webaim.org/extension/).

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Go to http://localhost:3000/humanservices/dmahs/info/doulahelp/form/legal/3
- The blue button should say "Review"

## Screenshots (for visual changes)

<details>
<summary>Before</summary>
<img width="1064" height="438" alt="image" src="https://github.com/user-attachments/assets/76f83e4c-1be9-4024-871e-60a41ca85734" />



</details>


<details>
<summary>After</summary>

<img width="1111" height="447" alt="image" src="https://github.com/user-attachments/assets/a4c0f932-741d-4bd9-ae6e-e2252ec564a7" />



</details>