### PR TITLE
[newjersey/doula-pm#335] Legal steps pdf field typing

### DIFF
--- a/src/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual.ts
@@ -55,6 +55,7 @@ import {
   getPage8Fields,
   type PdfFfsIndividualPage8,
 } from "@/app/form/_utils/fillPdf/ffsIndividual/page8";
+import { getPage9Fields } from "@/app/form/_utils/fillPdf/ffsIndividual/page9";
 import { fillForm, type FormData } from "@form/_utils/fillPdf/form";
 
 export const FFS_INDIVIDUAL_PDF_NAME = "Fee For Service Application.pdf";
@@ -82,6 +83,7 @@ export const mapFfsIndividualFields = (formData: FormData): Partial<PdfFfsIndivi
     ...getPage5Fields(formData),
     ...getPage6Fields(formData),
     ...getPage8Fields(formData),
+    ...getPage9Fields(formData),
     ...getPage11Fields(formData),
     ...getPage13Fields(formData),
     ...getPage17Fields(formData),

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page9.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page9.ts
@@ -1,0 +1,32 @@
+import { type FormData } from "@form/_utils/fillPdf/form";
+
+// Page 9 - SECTION II – PROVIDER IDENTIFICATION
+export interface PdfFfsIndividualPage9 {
+  fd425approvedprovideryes: boolean;
+  fd425approvedproviderno: boolean;
+  fd425approvedprovideryesexplaination: string;
+  fd425licensesuspensionno: boolean;
+  fd425licensesuspensionyes: boolean;
+  fd425licensesuspensionyesexplaination: string;
+  fd425indictedyes: boolean;
+  fd425indictedno: boolean;
+  fd425indictedyesexplaination: string;
+  fd425programsuspensionsyes: boolean;
+  fd425programsuspensionsno: boolean;
+  fd425programsuspensionsyesexplaination: string;
+  fd425partnershipyes: boolean;
+  fd425partnershipno: boolean;
+  fd425partnershipyesexplaination: string;
+  fd425employedbystateofnjyes: boolean;
+  fd425employedbystateofnjno: boolean;
+  fd425employedbystateofnjyesexplaination: string;
+  fd425signatureofdoulaprov: string;
+  fd425printnamedoulaprov: string;
+  fd425titleofdoulaprov: string;
+  fd425signaturedateofdoulaprovfdate_af_date: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getPage9Fields = (formData: FormData): Partial<PdfFfsIndividualPage9> => {
+  return {};
+};


### PR DESCRIPTION
## Link to issue

This commit contributes to newjersey/doula-pm#335.

## What was done?
This commit fully types the pdf fields on page 9, per the fields in https://docs.google.com/spreadsheets/d/19uX45c7GUNMWNZjxOP1cA-CD8tTFzUkvB3HNhR47shw/edit?gid=297293428#gid=297293428 (page 8 without the cover page), in anticipation of the legal steps filling these pages out.

## How should a reviewer test?

- There are no user-facing changes, just a type definition and a stub function