### PR TITLE
[newjersey/doula-pm#335] Pull out utility functions for filling in yes/no pdf checkboxes

### DIFF
--- a/src/app/form/_utils/fillPdf/ffsIndividual/page21.test.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page21.test.ts
@@ -41,18 +41,6 @@ describe("Page 21 - disclosure of ownership and control interest statement", () 
   });
 
   describe("Filed for bankruptcy in the past 7 years", () => {
-    it("throws an UnexpectedFormDataError when hasFiledBankruptcy is true but pastBankruptcyDate is null", () => {
-      const testFunction = () =>
-        mapFfsIndividualFields(
-          generateFormData({
-            hasFiledBankruptcy: true,
-            pastBankruptcyDate: null,
-          }),
-        );
-      expect(testFunction).toThrow(UnexpectedFormDataError);
-      expect(testFunction).toThrow("hasFiledBankruptcy true, but pastBankruptcyDate is null.");
-    });
-
     it("checks the No checkbox when formData.hasFiledBankruptcy is false", () => {
       const yesPdfKey = "fd452filedbankruptcypastsevenyearsyes";
       const noPdfKey = "fd452filedbankruptcypastsevenyearsno";
@@ -87,18 +75,6 @@ describe("Page 21 - disclosure of ownership and control interest statement", () 
   });
 
   describe("Possibility of filing for bankruptcy in the next year", () => {
-    it("throws an UnexpectedFormDataError when mightFileBankruptcy is true but futureBankruptcyDate is null", () => {
-      const testFunction = () =>
-        mapFfsIndividualFields(
-          generateFormData({
-            mightFileBankruptcy: true,
-            futureBankruptcyDate: null,
-          }),
-        );
-      expect(testFunction).toThrow(UnexpectedFormDataError);
-      expect(testFunction).toThrow("mightFileBankruptcy true, but futureBankruptcyDate is null.");
-    });
-
     it("checks the No checkbox when formData.mightFileBankruptcy is false", () => {
       const yesPdfKey = "fd452filedbankruptcywithinyearyes";
       const noPdfKey = "fd452filedbankruptcywithinyearno";

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page21.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page21.ts
@@ -1,5 +1,6 @@
 import { UnexpectedFormDataError } from "@/app/form/_utils/fillPdf/ffsIndividual/errors";
 import { formatDate } from "@/app/form/_utils/fillPdf/formatters";
+import { mapYesNoExplainYesFields } from "@/app/form/_utils/fillPdf/mappers";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
 // Page 21 - disclosure of ownership and control interest statement
@@ -38,40 +39,6 @@ export interface PdfFfsIndividualPage21 {
   fd452filedbankruptcywithinyeardate: string;
 }
 
-const getPastBankruptcyFields = (formData: FormData) => {
-  if (formData.hasFiledBankruptcy === true) {
-    if (formData.pastBankruptcyDate === null) {
-      throw new UnexpectedFormDataError(
-        `hasFiledBankruptcy true, but pastBankruptcyDate is ${formData.pastBankruptcyDate}.`,
-      );
-    }
-    return {
-      fd452filedbankruptcypastsevenyearsyes: true,
-      fd452filedbankruptcypastsevenyearsdate: formatDate(formData.pastBankruptcyDate),
-    };
-  }
-  return {
-    fd452filedbankruptcypastsevenyearsno: true,
-  };
-};
-
-const getFutureBankruptcyFields = (formData: FormData) => {
-  if (formData.mightFileBankruptcy === true) {
-    if (formData.futureBankruptcyDate === null) {
-      throw new UnexpectedFormDataError(
-        `mightFileBankruptcy true, but futureBankruptcyDate is ${formData.futureBankruptcyDate}.`,
-      );
-    }
-    return {
-      fd452filedbankruptcywithinyearyes: true,
-      fd452filedbankruptcywithinyeardate: formatDate(formData.futureBankruptcyDate),
-    };
-  }
-  return {
-    fd452filedbankruptcywithinyearno: true,
-  };
-};
-
 export const getPage21Fields = (formData: FormData): Partial<PdfFfsIndividualPage21> => {
   if (formData.isSupportedSoleProprietor !== true) {
     throw new UnexpectedFormDataError(
@@ -79,11 +46,31 @@ export const getPage21Fields = (formData: FormData): Partial<PdfFfsIndividualPag
     );
   }
 
+  const pastBankruptcyFields = mapYesNoExplainYesFields<PdfFfsIndividualPage21>(
+    formData.hasFiledBankruptcy,
+    formData.pastBankruptcyDate ? formatDate(formData.pastBankruptcyDate) : null,
+    {
+      yesPdfKey: "fd452filedbankruptcypastsevenyearsyes",
+      noPdfKey: "fd452filedbankruptcypastsevenyearsno",
+      yesExplanationPdfKey: "fd452filedbankruptcypastsevenyearsdate",
+    },
+  );
+
+  const futureBankruptcyFields = mapYesNoExplainYesFields<PdfFfsIndividualPage21>(
+    formData.mightFileBankruptcy,
+    formData.futureBankruptcyDate ? formatDate(formData.futureBankruptcyDate) : null,
+    {
+      yesPdfKey: "fd452filedbankruptcywithinyearyes",
+      noPdfKey: "fd452filedbankruptcywithinyearno",
+      yesExplanationPdfKey: "fd452filedbankruptcywithinyeardate",
+    },
+  );
+
   return {
     fd452ownershiphealthcareproviderno: true,
     fd452ownershipchangeno: true,
     fd452ownershipchangewithinyearno: true,
-    ...getPastBankruptcyFields(formData),
-    ...getFutureBankruptcyFields(formData),
+    ...pastBankruptcyFields,
+    ...futureBankruptcyFields,
   };
 };

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page23.test.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page23.test.ts
@@ -39,7 +39,7 @@ describe("Page 23 - disclosure of ownership and control interest statement", () 
         }),
       );
       expect(pdfFields[pdfKey]).toEqual(true);
-      expect(pdfFields[oppositePdfKey]).toEqual(false);
+      expect(pdfFields[oppositePdfKey]).toEqual(undefined);
     });
 
     it("checks the Yes checkbox when formData.hasDisclosableEvent is true", () => {
@@ -52,7 +52,7 @@ describe("Page 23 - disclosure of ownership and control interest statement", () 
         }),
       );
       expect(pdfFields[pdfKey]).toEqual(true);
-      expect(pdfFields[oppositePdfKey]).toEqual(false);
+      expect(pdfFields[oppositePdfKey]).toEqual(undefined);
     });
   });
 });

--- a/src/app/form/_utils/fillPdf/ffsIndividual/page23.ts
+++ b/src/app/form/_utils/fillPdf/ffsIndividual/page23.ts
@@ -1,4 +1,5 @@
 import { UnexpectedFormDataError } from "@/app/form/_utils/fillPdf/ffsIndividual/errors";
+import { mapYesNoFields } from "@/app/form/_utils/fillPdf/mappers";
 import { type FormData } from "@form/_utils/fillPdf/form";
 
 // Page 23 - disclosure of ownership and control interest statement
@@ -44,10 +45,17 @@ export interface PdfFfsIndividualPage23 {
 
 export const getPage23Fields = (formData: FormData): Partial<PdfFfsIndividualPage23> => {
   if (formData.isSupportedSoleProprietor === true) {
+    const hasDisclosableEventFields = mapYesNoFields<PdfFfsIndividualPage23>(
+      formData.hasDisclosableEvent,
+      {
+        yesPdfKey: "fd452disclosableeventyyes",
+        noPdfKey: "fd452disclosableeventno",
+      },
+    );
+
     return {
       fd452increasedbedcapacityno: true,
-      fd452disclosableeventyyes: formData.hasDisclosableEvent,
-      fd452disclosableeventno: !formData.hasDisclosableEvent,
+      ...hasDisclosableEventFields,
     };
   } else {
     throw new UnexpectedFormDataError(

--- a/src/app/form/_utils/fillPdf/mappers.test.ts
+++ b/src/app/form/_utils/fillPdf/mappers.test.ts
@@ -1,0 +1,69 @@
+import { UnexpectedFormDataError } from "@/app/form/_utils/fillPdf/ffsIndividual/errors";
+import { mapYesNoExplainYesFields, mapYesNoFields } from "@/app/form/_utils/fillPdf/mappers";
+
+interface TestPdfFields {
+  hasDoneThisYes: boolean;
+  hasDoneThisNo: boolean;
+  explainWhyYes: string;
+}
+
+describe("mapYesNoFields", () => {
+  it("maps to yesPdfKey when isYes is true", () => {
+    expect(
+      mapYesNoFields<TestPdfFields>(true, {
+        yesPdfKey: "hasDoneThisYes",
+        noPdfKey: "hasDoneThisNo",
+      }),
+    ).toEqual({
+      hasDoneThisYes: true,
+    });
+  });
+  it("maps to noPdfKey when isYes is false", () => {
+    expect(
+      mapYesNoFields<TestPdfFields>(false, {
+        yesPdfKey: "hasDoneThisYes",
+        noPdfKey: "hasDoneThisNo",
+      }),
+    ).toEqual({
+      hasDoneThisNo: true,
+    });
+  });
+});
+
+describe("mapYesNoExplainYesFields", () => {
+  it("throws an UnexpectedFormDataError when isYes is true but yesExplanation is not provided", () => {
+    const testFunction = () =>
+      mapYesNoExplainYesFields<TestPdfFields>(true, null, {
+        yesPdfKey: "hasDoneThisYes",
+        noPdfKey: "hasDoneThisNo",
+        yesExplanationPdfKey: "explainWhyYes",
+      });
+    expect(testFunction).toThrow(UnexpectedFormDataError);
+    expect(testFunction).toThrow(
+      "hasDoneThisYes is checked, but missing explanation for explainWhyYes field.",
+    );
+  });
+
+  it("maps to yes and yesExplanation pdf keys when isYes is true", () => {
+    const mappedFields = mapYesNoExplainYesFields<TestPdfFields>(true, "Test explanation", {
+      yesPdfKey: "hasDoneThisYes",
+      noPdfKey: "hasDoneThisNo",
+      yesExplanationPdfKey: "explainWhyYes",
+    });
+    expect(mappedFields).toEqual({
+      hasDoneThisYes: true,
+      explainWhyYes: "Test explanation",
+    });
+  });
+
+  it("maps to noPdfKey when isYes is false", () => {
+    const mappedFields = mapYesNoExplainYesFields<TestPdfFields>(false, null, {
+      yesPdfKey: "hasDoneThisYes",
+      noPdfKey: "hasDoneThisNo",
+      yesExplanationPdfKey: "explainWhyYes",
+    });
+    expect(mappedFields).toEqual({
+      hasDoneThisNo: true,
+    });
+  });
+});

--- a/src/app/form/_utils/fillPdf/mappers.ts
+++ b/src/app/form/_utils/fillPdf/mappers.ts
@@ -1,0 +1,46 @@
+import { UnexpectedFormDataError } from "@/app/form/_utils/fillPdf/ffsIndividual/errors";
+
+type NoInfer<T> = [T][T extends unknown ? 0 : never];
+
+interface YesNoPdfFields<T> {
+  yesPdfKey: keyof NoInfer<T>;
+  noPdfKey: keyof NoInfer<T>;
+}
+interface YesNoExplainYesPdfFields<T> extends YesNoPdfFields<T> {
+  yesExplanationPdfKey: keyof NoInfer<T>;
+}
+
+export const mapYesNoFields = <
+  T = "Must specify PdfField type T, e.g. mapYesNoFields<PdfFfsIndividualPage23>()",
+>(
+  isYes: boolean,
+  pdfFields: YesNoPdfFields<T>,
+) => {
+  if (isYes === true) {
+    return { [pdfFields.yesPdfKey]: true };
+  }
+  return { [pdfFields.noPdfKey]: true };
+};
+
+export const mapYesNoExplainYesFields = <
+  T = "Must specify PdfField type T, e.g. mapYesNoExplainYesFields<PdfFfsIndividualPage23>()",
+>(
+  isYes: boolean,
+  yesExplanation: string | null,
+  pdfFields: YesNoExplainYesPdfFields<T>,
+) => {
+  if (isYes === true) {
+    if (yesExplanation === null) {
+      throw new UnexpectedFormDataError(
+        `${pdfFields.yesPdfKey.toString()} is checked, but missing explanation for ${pdfFields.yesExplanationPdfKey.toString()} field.`,
+      );
+    }
+    return {
+      [pdfFields.yesPdfKey]: true,
+      [pdfFields.yesExplanationPdfKey]: yesExplanation,
+    };
+  }
+  return {
+    [pdfFields.noPdfKey]: true,
+  };
+};


### PR DESCRIPTION
## Link to issue

This commit contributes to newjersey/doula-pm#335.

## What was done?
This commit creates and uses reusable functions to fill the following patterns in the pdf:
- Yes/No checkboxes, i.e. only one should be selected
- Yes/No checkboxes, with an additional single field to explain if Yes is checked

This refactor makes us less likely to make the mistake of e.g. forgetting the `!` in `fd452disclosableeventno: !formData.hasDisclosableEvent`, and accidentally filling in both checkboxes at the same time. The reusable functions enforce that yes and no are mutually exclusive, and encapsulate throwing an error if yes is selected but there is no explanation.

## How should a reviewer test?

- This is an internal refactor with no user-facing changes. Review for readability, etc.
