### PR TITLE
[newjersey/doula-pm#335] Update DoulaTextareaCharacterCount component default error messages

### DIFF
--- a/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.test.tsx
@@ -69,7 +69,7 @@ describe("DoulaTextareaCharacterCount", () => {
 
     expect(mockRegister).toHaveBeenCalledWith(
       "testInput",
-      expect.objectContaining({ required: "Test label is required" }),
+      expect.objectContaining({ required: "This question is required" }),
     );
     const input = screen.getByRole("textbox", { name: "Test label *" });
     expect(input).toHaveAttribute("required");
@@ -215,6 +215,8 @@ describe("DoulaTextareaCharacterCount", () => {
 
     expect(screen.getByText("1 character over limit")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Next" }));
-    expect(input).toHaveAccessibleDescription("Test label must be 10 characters or less");
+    expect(input).toHaveAccessibleDescription(
+      "Character limit exceeded. Please edit and try again.",
+    );
   });
 });

--- a/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.tsx
@@ -1,13 +1,7 @@
 import { ErrorMessage } from "@/app/form/(formSteps)/components/ErrorMessage";
 import { Hint } from "@/app/form/(formSteps)/components/Hint";
 import { formatDescribedBy } from "@/app/form/(formSteps)/components/utils/doulaInput";
-import {
-  CharacterCount,
-  InputGroup,
-  InputPrefix,
-  Label,
-  type TextareaCharacterCountProps,
-} from "@trussworks/react-uswds";
+import { CharacterCount, Label, type TextareaCharacterCountProps } from "@trussworks/react-uswds";
 import type {
   FieldErrors,
   FieldPath,
@@ -24,7 +18,7 @@ export interface DoulaTextareaCharacterCountProps<T extends FieldValues>
   name: FieldPath<T>;
   label: React.ReactNode;
   hint?: string;
-  inputPrefix?: string;
+  inputClassName?: string;
   required?: boolean;
   errors?: FieldErrors<T>;
   register: UseFormRegister<T>;
@@ -38,8 +32,8 @@ const DoulaTextareaCharacterCount = <T extends FieldValues>(
     name,
     label,
     hint,
-    inputPrefix,
     "aria-describedby": ariaDescribedby,
+    inputClassName,
     required,
     errors,
     register,
@@ -61,34 +55,26 @@ const DoulaTextareaCharacterCount = <T extends FieldValues>(
   }
 
   // To override this, pass in additionalRegisterOptions
-  const requiredRegisterOption = required === true ? { required: `${label} is required` } : {};
+  const requiredRegisterOption = required === true ? { required: "This question is required" } : {};
 
-  let input = (
+  const input = (
     <CharacterCount
       id={name}
       required={required}
       isTextArea={true}
       {...internallySetProps}
       {...otherProps}
+      className={inputClassName}
       {...register(name, {
         ...requiredRegisterOption,
         maxLength: {
           value: otherProps.maxLength,
-          message: `${label} must be ${otherProps.maxLength} characters or less`,
+          message: "Character limit exceeded. Please edit and try again.",
         },
         ...additionalRegisterOptions,
       })}
     />
   );
-
-  if (inputPrefix) {
-    input = (
-      <InputGroup error={hasError}>
-        <InputPrefix>{inputPrefix}</InputPrefix>
-        {input}
-      </InputGroup>
-    );
-  }
 
   return (
     <>


### PR DESCRIPTION
## Link to issue

This commit contributes to newjersey/doula-pm#335.

## What was done?
This commit updates the default error messages for `<DoulaTextareaCharacterCount />` to use those that we would like for our application.

It also:
- Removes the `inputPrefix` functionality, which is not needed for this component (it was used to add a `$` to textarea)
- Adds functionality to set css className on the input node specifically


## How should a reviewer test?

- The component is not currently used