### PR TITLE
[newjersey/doula-pm#335] Improve cypress test run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ npm run dev:test
 # Then run cypress tests with `[productionFlags]` in their name
 npm run cypress:run:productionFlags
 
-# cypress:gui can be run normally, and the GUI lets you select which test to run
+# To run with cypress GUI
+npm run cypress:gui:productionFlags
 ```
 
 The local file may need to be updated if you want to turn flags back on again

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cypress:run": "cypress run",
     "cypress:run:productionFlags": "cypress run --env PRODUCTION_FLAGS=true",
     "cypress:gui": "cypress open",
+    "cypress:gui:productionFlags": "cypress open --env PRODUCTION_FLAGS=true",
     "test": "env $(cat .env.test-production-flags | xargs) jest",
     "typecheck": "tsc --noemit",
     "configureVpc": "npx tsx scripts/configureVpc.ts",


### PR DESCRIPTION
## Link to issue

This commit contributes to newjersey/doula-pm#335.

## What was done?
This commit updates package.json to add the command `npm run cypress:gui:productionFlags`, to open the cypress gui and allow running tests that have `[productionFlags]` in their name.
