### PR TITLE
[newjersey/doula-pm#376] Fix back-to-back deployments causing downtime

### DIFF
--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -83,7 +83,7 @@ export class CdkStack extends cdk.Stack {
         taskDefinition,
         serviceName: "doula-assistant-service",
         desiredCount: 1,
-        minHealthyPercent: 0,
+        minHealthyPercent: 100,
         maxHealthyPercent: 200,
         loadBalancerName: "doula-assistant-alb",
         publicLoadBalancer: false, // Internal ALB


### PR DESCRIPTION
## Link to issue

This commit resolves newjersey/doula-pm#376.

## What was done?
[This stackoverflow post](https://stackoverflow.com/questions/34840137/how-do-i-deploy-updated-docker-images-to-amazon-ecs-tasks/48572274) was my initial guidance when setting this up. It was unclear whether `minHealthyPercent` should be set to 0 or 100, the stackoverflow post seems to have conflicting recommendations from different people.

It seems like `minHealthyPercent` should be set to 100, to ensure that at least one container is always up, and there is therefore no downtime. I have confirmed that despite the comment in [this answer](https://stackoverflow.com/questions/34840137/how-do-i-deploy-updated-docker-images-to-amazon-ecs-tasks/48572274#answer-62329417), `minHealthyPercent: 100` it does seem to allow a new task to be deployed.

This commit changes `minHealthyPercent` from 0 to 100, preventing the website from going down if `aws ecs update-service --cluster doula-assistant-cluster --service doula-assistant-service --force-new-deployment` is run twice within a couple-minutes timeframe.

However, this change does cause that if the command is run multiple times within the couple-minutes timeframe, that only the first command is registered and subsequent commands are ignored. In practice, if we had a series of production-deployed commits like "Fix 1", "Actually fix 1", "Really fix fix 1", that only the first one might get deployed. Subsequent commits what need to wait for the changed triggered by the first `--force-new-deployment` to propagate, and then run it again. https://github.com/newjersey/doula-pm/issues/348 would help with this situation.

