### PR TITLE
[newjersey/doula-pm#393] Clean up refactor of e2e test github actions

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -27,12 +27,8 @@ jobs:
   end-to-end-test:
     uses: ./.github/workflows/end_to_end_test.yml
 
-  end-to-end-test-production-flags:
-    uses: ./.github/workflows/end_to_end_test_production_flags.yml
-
   deploy-prod:
-    needs:
-      [lint, typecheck, prettier, unit-tests, end-to-end-test, end-to-end-test-production-flags]
+    needs: [lint, typecheck, prettier, unit-tests, end-to-end-test]
     uses: ./.github/workflows/_deploy.yml
     secrets:
       aws_account_id: ${{ secrets.AWS_ACCOUNT_ID_PROD }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -27,12 +27,8 @@ jobs:
   end-to-end-test:
     uses: ./.github/workflows/end_to_end_test.yml
 
-  end-to-end-test-production-flags:
-    uses: ./.github/workflows/end_to_end_test_production_flags.yml
-
   deploy-staging:
-    needs:
-      [lint, typecheck, prettier, unit-tests, end-to-end-test, end-to-end-test-production-flags]
+    needs: [lint, typecheck, prettier, unit-tests, end-to-end-test]
     uses: ./.github/workflows/_deploy.yml
     secrets:
       aws_account_id: ${{ secrets.AWS_ACCOUNT_ID_DEV }}


### PR DESCRIPTION
## What was done?
In https://github.com/newjersey/doula-medicaid/pull/403, structure of github actions workflows were refactored for end-to-end tests, to allow us to add/remove end-to-end tests running with different `.env.test`s at will, within the our non-admin permissions on the github repo.

That refactor deleted the `./.github/workflows/end_to_end_test_production_flags.yml` file, but failed to delete its requirement in deploy_staging.yml and deploy_prod.yml. This commit fixes this.