### PR TITLE
[newjersey/doula-pm#226] Refactor error focus interface

### DIFF
--- a/src/app/form/(formSteps)/business/1/BusinessStep1.tsx
+++ b/src/app/form/(formSteps)/business/1/BusinessStep1.tsx
@@ -28,7 +28,7 @@ const orderedInputNameToLabel: { [key in keyof Business1Data]: string } = {
   businessZip: "ZIP Code",
 };
 
-const mayHaveThreeOrMoreErrors = true;
+const showErrorSummary = true;
 const BusinessStep1 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -47,7 +47,7 @@ const BusinessStep1 = () => {
       businessState: getDefaultValue(dataStore, "businessState") ?? "NJ",
       businessZip: getDefaultValue(dataStore, "businessZip") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
   const businessAddressSameAsOtherAddress = watch("businessAddressSameAsOtherAddress");
   const businessZip = watch("businessZip");
@@ -76,11 +76,11 @@ const BusinessStep1 = () => {
 
   return (
     <DoulaForm<Business1Data>
-      orderedInputNames={Object.keys(orderedInputNameToLabel) as Array<FieldPath<Business1Data>>}
       errors={errors}
       setFocus={setFocus}
+      manualFocusOrder={Object.keys(orderedInputNameToLabel) as Array<FieldPath<Business1Data>>}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/business/2/BusinessStep2.tsx
+++ b/src/app/form/(formSteps)/business/2/BusinessStep2.tsx
@@ -9,7 +9,7 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { useForm } from "react-hook-form";
 
-const mayHaveThreeOrMoreErrors = false;
+const showErrorSummary = false;
 const BusinessStep2 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -22,7 +22,7 @@ const BusinessStep2 = () => {
       hasUncollectedDebt: getDefaultBoolean(dataStore, "hasUncollectedDebt"),
       isSubjectToPaymentSuspension: getDefaultBoolean(dataStore, "isSubjectToPaymentSuspension"),
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
   const hasUncollectedDebt = watch("hasUncollectedDebt");
   const isSubjectToPaymentSuspension = watch("isSubjectToPaymentSuspension");
@@ -31,7 +31,7 @@ const BusinessStep2 = () => {
     <DoulaForm<Business2Data>
       errors={errors}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/business/3/BusinessStep3.tsx
+++ b/src/app/form/(formSteps)/business/3/BusinessStep3.tsx
@@ -9,7 +9,7 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { useForm } from "react-hook-form";
 
-const mayHaveThreeOrMoreErrors = false;
+const showErrorSummary = false;
 const BusinessStep3 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -22,7 +22,7 @@ const BusinessStep3 = () => {
       hasBeenExcludedFromMedicaid: getDefaultBoolean(dataStore, "hasBeenExcludedFromMedicaid"),
       hasBeenSuspendedFromMedicaid: getDefaultBoolean(dataStore, "hasBeenSuspendedFromMedicaid"),
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
   const hasBeenExcludedFromMedicaid = watch("hasBeenExcludedFromMedicaid");
   const hasBeenSuspendedFromMedicaid = watch("hasBeenSuspendedFromMedicaid");
@@ -31,7 +31,7 @@ const BusinessStep3 = () => {
     <DoulaForm<Business3Data>
       errors={errors}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/business/4/BusinessStep4.tsx
+++ b/src/app/form/(formSteps)/business/4/BusinessStep4.tsx
@@ -10,7 +10,7 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { useForm } from "react-hook-form";
 
-const orderedInputNames: Array<keyof Business4Data> = [
+const manualFocusOrder: Array<keyof Business4Data> = [
   "hasFiledBankruptcy",
   "pastBankruptcyMonth",
   "pastBankruptcyDay",
@@ -21,7 +21,7 @@ const orderedInputNames: Array<keyof Business4Data> = [
   "futureBankruptcyYear",
 ];
 
-const mayHaveThreeOrMoreErrors = true;
+const showErrorSummary = true;
 const BusinessStep4 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -41,7 +41,7 @@ const BusinessStep4 = () => {
       futureBankruptcyDay: getDefaultValue(dataStore, "futureBankruptcyDay") ?? "",
       futureBankruptcyYear: getDefaultValue(dataStore, "futureBankruptcyYear") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
   const hasFiledBankruptcy = watch("hasFiledBankruptcy");
   const mightFileBankruptcy = watch("mightFileBankruptcy");
@@ -50,11 +50,11 @@ const BusinessStep4 = () => {
 
   return (
     <DoulaForm<Business4Data>
-      orderedInputNames={orderedInputNames}
       errors={errors}
       handleSubmit={handleSubmit}
       setFocus={setFocus}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      manualFocusOrder={manualFocusOrder}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/components/DoulaAddress.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddress.test.tsx
@@ -78,13 +78,13 @@ const TestForm = (
   const testZip = watch("testZip");
   return (
     <DoulaForm<TestFormData>
-      orderedInputNames={
+      errors={errors}
+      handleSubmit={handleSubmit}
+      setFocus={setFocus}
+      manualFocusOrder={
         Object.keys(testFormOrderedInputNameToLabel) as Array<FieldPath<TestFormData>>
       }
-      errors={errors}
-      setFocus={setFocus}
-      handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={true}
+      showErrorSummary={true}
     >
       <DoulaAddress
         {...props}

--- a/src/app/form/(formSteps)/components/DoulaDateInput.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaDateInput.test.tsx
@@ -30,11 +30,11 @@ const TestForm = (props: Omit<DoulaDateInputProps<TestFormData>, "errors" | "reg
   });
   return (
     <DoulaForm<TestFormData>
-      orderedInputNames={["testMonth", "testDay", "testYear"]}
+      manualFocusOrder={["testMonth", "testDay", "testYear"]}
       errors={errors}
       setFocus={setFocus}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={true}
+      showErrorSummary={true}
     >
       <DoulaDateInput {...props} errors={errors} register={register} />
       <FormProgressButtons />

--- a/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextInput.test.tsx
@@ -80,7 +80,7 @@ describe("DoulaTextInput", () => {
         <DoulaForm<TestFormData>
           errors={errors}
           handleSubmit={handleSubmit}
-          mayHaveThreeOrMoreErrors={false}
+          showErrorSummary={false}
         >
           <DoulaTextInput name="testInput" label="Test label" numericOnly register={register} />
         </DoulaForm>

--- a/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaTextareaCharacterCount.test.tsx
@@ -189,11 +189,11 @@ describe("DoulaTextareaCharacterCount", () => {
       });
       return (
         <DoulaForm<TestFormData>
-          orderedInputNames={["testInput"]}
           errors={errors}
-          setFocus={setFocus}
           handleSubmit={handleSubmit}
-          mayHaveThreeOrMoreErrors={true}
+          setFocus={setFocus}
+          manualFocusOrder={["testInput"]}
+          showErrorSummary={true}
         >
           <DoulaTextareaCharacterCount
             name="testInput"

--- a/src/app/form/(formSteps)/insurance/1/InsuranceStep1.tsx
+++ b/src/app/form/(formSteps)/insurance/1/InsuranceStep1.tsx
@@ -17,7 +17,7 @@ const inputNameToLabel = {
   insuranceAggregateAmount: "Amount per aggregate",
 } as const;
 
-const orderedInputNames: Array<keyof Insurance1Data> = [
+const manualFocusOrder: Array<keyof Insurance1Data> = [
   "insuranceStartDateMonth",
   "insuranceStartDateDay",
   "insuranceStartDateYear",
@@ -29,7 +29,7 @@ const orderedInputNames: Array<keyof Insurance1Data> = [
 ];
 
 const InsuranceStep1 = () => {
-  const mayHaveThreeOrMoreErrors = true;
+  const showErrorSummary = true;
   const { dataStore } = useDataStore();
   const {
     register,
@@ -47,18 +47,18 @@ const InsuranceStep1 = () => {
       insuranceOccurenceAmount: getDefaultValue(dataStore, "insuranceOccurenceAmount") ?? "",
       insuranceAggregateAmount: getDefaultValue(dataStore, "insuranceAggregateAmount") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
 
   const currentYear: number = new Date().getFullYear();
 
   return (
     <DoulaForm<Insurance1Data>
-      orderedInputNames={orderedInputNames}
       errors={errors}
-      setFocus={setFocus}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      setFocus={setFocus}
+      manualFocusOrder={manualFocusOrder}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/insurance/2/InsuranceStep2.tsx
+++ b/src/app/form/(formSteps)/insurance/2/InsuranceStep2.tsx
@@ -20,7 +20,7 @@ const orderedInputNameToLabel: { [key in keyof Insurance2Data]: string } = {
   insuranceZip: "ZIP Code",
 };
 
-const mayHaveThreeOrMoreErrors = true;
+const showErrorSummary = true;
 
 const InsuranceStep2 = () => {
   const { dataStore } = useDataStore();
@@ -40,17 +40,17 @@ const InsuranceStep2 = () => {
       insuranceState: getDefaultValue(dataStore, "insuranceState") ?? "NJ",
       insuranceZip: getDefaultValue(dataStore, "insuranceZip") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
   const insuranceZip = watch("insuranceZip");
 
   return (
     <DoulaForm<Insurance2Data>
-      orderedInputNames={Object.keys(orderedInputNameToLabel) as Array<FieldPath<Insurance2Data>>}
       errors={errors}
-      setFocus={setFocus}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      setFocus={setFocus}
+      manualFocusOrder={Object.keys(orderedInputNameToLabel) as Array<FieldPath<Insurance2Data>>}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/legal/1/LegalStep1.tsx
+++ b/src/app/form/(formSteps)/legal/1/LegalStep1.tsx
@@ -9,15 +9,15 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { useForm } from "react-hook-form";
 
-const orderedInputNames: Array<keyof Legal1Data & string> = [
+const manualFocusOrder: Array<keyof Legal1Data & string> = [
   "isEmployedByNj",
   "employedByNjExplanation",
   "hasProvidedMedicaidServices",
   "medicaidServicesExplanation",
 ];
 
-const mayHaveThreeOrMoreErrors = true;
-
+const showErrorSummary = false;
+const manuallySetErrorFocus = true;
 const LegalStep1 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -33,7 +33,7 @@ const LegalStep1 = () => {
       hasProvidedMedicaidServices: getDefaultBoolean(dataStore, "hasProvidedMedicaidServices"),
       medicaidServicesExplanation: getDefaultValue(dataStore, "medicaidServicesExplanation") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !manuallySetErrorFocus,
   });
 
   const isEmployedByNj = watch("isEmployedByNj");
@@ -41,11 +41,11 @@ const LegalStep1 = () => {
 
   return (
     <DoulaForm<Legal1Data>
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
       errors={errors}
       handleSubmit={handleSubmit}
       setFocus={setFocus}
-      orderedInputNames={orderedInputNames}
+      manualFocusOrder={manualFocusOrder}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/legal/2/LegalStep2.tsx
+++ b/src/app/form/(formSteps)/legal/2/LegalStep2.tsx
@@ -10,14 +10,16 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { useForm } from "react-hook-form";
 
-const orderedInputNames: Array<keyof Legal2Data> = [
+const manualFocusOrder: Array<keyof Legal2Data> = [
   "hasCrimeCharge",
   "crimeChargeExplanation",
   "hadLicenseSuspended",
   "licenseSuspendedExplanation",
 ];
 
-const mayHaveThreeOrMoreErrors = true;
+const showErrorSummary = false;
+const manuallySetErrorFocus = true;
+
 const LegalStep2 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -33,18 +35,18 @@ const LegalStep2 = () => {
       hadLicenseSuspended: getDefaultBoolean(dataStore, "hadLicenseSuspended"),
       licenseSuspendedExplanation: getDefaultValue(dataStore, "licenseSuspendedExplanation") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !manuallySetErrorFocus,
   });
   const hasCrimeCharge = watch("hasCrimeCharge");
   const hadLicenseSuspended = watch("hadLicenseSuspended");
 
   return (
     <DoulaForm<Legal2Data>
-      orderedInputNames={orderedInputNames}
       errors={errors}
       handleSubmit={handleSubmit}
       setFocus={setFocus}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      manualFocusOrder={manualFocusOrder}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/legal/3/LegalStep3.tsx
+++ b/src/app/form/(formSteps)/legal/3/LegalStep3.tsx
@@ -10,14 +10,16 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { useForm } from "react-hook-form";
 
-const orderedInputNames: Array<keyof Legal3Data> = [
+const manualFocusOrder: Array<keyof Legal3Data> = [
   "hasDisqualification",
   "disqualificationExplanation",
   "hasCompanyInvolvement",
   "companyInvolvementExplanation",
 ];
 
-const mayHaveThreeOrMoreErrors = true;
+const showErrorSummary = false;
+const manuallySetErrorFocus = true;
+
 const LegalStep3 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -34,18 +36,18 @@ const LegalStep3 = () => {
       companyInvolvementExplanation:
         getDefaultValue(dataStore, "companyInvolvementExplanation") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !manuallySetErrorFocus,
   });
   const hasDisqualification = watch("hasDisqualification");
   const hasCompanyInvolvement = watch("hasCompanyInvolvement");
 
   return (
     <DoulaForm<Legal3Data>
-      orderedInputNames={orderedInputNames}
       errors={errors}
       handleSubmit={handleSubmit}
       setFocus={setFocus}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      manualFocusOrder={manualFocusOrder}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/personal/1/PersonalStep1.tsx
+++ b/src/app/form/(formSteps)/personal/1/PersonalStep1.tsx
@@ -21,7 +21,7 @@ const inputNameToLabel = {
   phoneNumber: "Phone number",
 } as const;
 
-const orderedInputNames: Array<keyof Personal1Data> = [
+const manualFocusOrder: Array<keyof Personal1Data> = [
   "firstName",
   "middleName",
   "lastName",
@@ -33,7 +33,7 @@ const orderedInputNames: Array<keyof Personal1Data> = [
   "phoneNumber",
 ];
 
-const mayHaveThreeOrMoreErrors = true;
+const showErrorSummary = true;
 const PersonalStep1 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -54,7 +54,7 @@ const PersonalStep1 = () => {
       email: getDefaultValue(dataStore, "email") ?? "",
       phoneNumber: getDefaultValue(dataStore, "phoneNumber") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
 
   const phoneNumber = watch("phoneNumber");
@@ -62,11 +62,11 @@ const PersonalStep1 = () => {
 
   return (
     <DoulaForm<Personal1Data>
-      orderedInputNames={orderedInputNames}
       errors={errors}
-      setFocus={setFocus}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      setFocus={setFocus}
+      manualFocusOrder={manualFocusOrder}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/personal/2/PersonalStep2.tsx
+++ b/src/app/form/(formSteps)/personal/2/PersonalStep2.tsx
@@ -25,7 +25,7 @@ const orderedInputNameToLabel: { [key in keyof Personal2Data]: string } = {
   billingZip: "ZIP Code",
 };
 
-const mayHaveThreeOrMoreErrors = true;
+const showErrorSummary = true;
 const PersonalStep2 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -49,7 +49,7 @@ const PersonalStep2 = () => {
       billingState: getDefaultValue(dataStore, "billingState") ?? "NJ",
       billingZip: getDefaultValue(dataStore, "billingZip") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
 
   const zip = watch("zip");
@@ -58,11 +58,11 @@ const PersonalStep2 = () => {
 
   return (
     <DoulaForm<Personal2Data>
-      orderedInputNames={Object.keys(orderedInputNameToLabel) as Array<FieldPath<Personal2Data>>}
       errors={errors}
-      setFocus={setFocus}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      setFocus={setFocus}
+      manualFocusOrder={Object.keys(orderedInputNameToLabel) as Array<FieldPath<Personal2Data>>}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/personal/3/PersonalStep3.tsx
+++ b/src/app/form/(formSteps)/personal/3/PersonalStep3.tsx
@@ -17,7 +17,7 @@ const orderedInputNameToLabel: { [key in keyof Personal3Data]: string } = {
   medicareProviderId: "Medicare provider ID",
 };
 
-const mayHaveThreeOrMoreErrors = false;
+const showErrorSummary = false;
 const PersonalStep3 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -31,7 +31,7 @@ const PersonalStep3 = () => {
       upinNumber: getDefaultValue(dataStore, "upinNumber") ?? "",
       medicareProviderId: getDefaultValue(dataStore, "medicareProviderId") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
 
   const npiNumber = watch("npiNumber");
@@ -39,7 +39,7 @@ const PersonalStep3 = () => {
     <DoulaForm<Personal3Data>
       errors={errors}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/screening/1/ScreeningStep1.tsx
+++ b/src/app/form/(formSteps)/screening/1/ScreeningStep1.tsx
@@ -15,7 +15,7 @@ const orderedInputNameToLabel = {
     "Do you manage your business as an individual doula operating as a Sole Proprietor?",
 };
 
-const mayHaveThreeOrMoreErrors = false;
+const showErrorSummary = false;
 const ScreeningStep1 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -31,7 +31,7 @@ const ScreeningStep1 = () => {
     <DoulaForm<Screening1Data>
       errors={errors}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/screening/2/ScreeningStep2.tsx
+++ b/src/app/form/(formSteps)/screening/2/ScreeningStep2.tsx
@@ -10,7 +10,7 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { useForm } from "react-hook-form";
 
-const mayHaveThreeOrMoreErrors = false;
+const showErrorSummary = false;
 const ScreeningStep2 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -30,7 +30,7 @@ const ScreeningStep2 = () => {
     <DoulaForm<Screening2Data>
       errors={errors}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/screening/3/ScreeningStep3.tsx
+++ b/src/app/form/(formSteps)/screening/3/ScreeningStep3.tsx
@@ -10,7 +10,7 @@ import { DoulaForm } from "@/app/form/components/DoulaForm";
 import FormProgressButtons from "@form/(formSteps)/components/FormProgressButtons";
 import { useForm } from "react-hook-form";
 
-const mayHaveThreeOrMoreErrors = false;
+const showErrorSummary = false;
 const ScreeningStep3 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -33,7 +33,7 @@ const ScreeningStep3 = () => {
     <DoulaForm<Screening3Data>
       errors={errors}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/(formSteps)/training/1/TrainingStep1.tsx
+++ b/src/app/form/(formSteps)/training/1/TrainingStep1.tsx
@@ -30,7 +30,7 @@ const orderedInputNameToLabel: { [key in FieldPath<TrainingData>]: string } = {
   instructorPhoneNumber: "Phone number",
 };
 
-const mayHaveThreeOrMoreErrors = true;
+const showErrorSummary = true;
 const TrainingStep1 = () => {
   const { dataStore } = useDataStore();
   const {
@@ -54,7 +54,7 @@ const TrainingStep1 = () => {
       instructorEmail: getDefaultValue(dataStore, "instructorEmail") ?? "",
       instructorPhoneNumber: getDefaultValue(dataStore, "instructorPhoneNumber") ?? "",
     },
-    shouldFocusError: !mayHaveThreeOrMoreErrors,
+    shouldFocusError: !showErrorSummary,
   });
   const stateApprovedTraining = watch("stateApprovedTraining");
   const trainingZip = watch("trainingZip");
@@ -63,11 +63,11 @@ const TrainingStep1 = () => {
 
   return (
     <DoulaForm<TrainingData>
-      orderedInputNames={Object.keys(orderedInputNameToLabel) as Array<FieldPath<TrainingData>>}
       errors={errors}
-      setFocus={setFocus}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={mayHaveThreeOrMoreErrors}
+      setFocus={setFocus}
+      manualFocusOrder={Object.keys(orderedInputNameToLabel) as Array<FieldPath<TrainingData>>}
+      showErrorSummary={showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">

--- a/src/app/form/components/DoulaForm.test.tsx
+++ b/src/app/form/components/DoulaForm.test.tsx
@@ -20,7 +20,7 @@ interface DoulaFormTestData {
   field3: string | null;
 }
 
-const DoulaFormTestPage = (props: { mayHaveThreeOrMoreErrors: boolean }) => {
+const DoulaFormTestPage = (props: { showErrorSummary: boolean }) => {
   const {
     register,
     handleSubmit,
@@ -32,16 +32,16 @@ const DoulaFormTestPage = (props: { mayHaveThreeOrMoreErrors: boolean }) => {
       field2: "",
       field3: "",
     },
-    shouldFocusError: !props.mayHaveThreeOrMoreErrors,
+    shouldFocusError: !props.showErrorSummary,
   });
 
   return (
     <DoulaForm<DoulaFormTestData>
-      orderedInputNames={["field1", "field2", "field3"]}
       errors={errors}
-      setFocus={setFocus}
       handleSubmit={handleSubmit}
-      mayHaveThreeOrMoreErrors={props.mayHaveThreeOrMoreErrors}
+      setFocus={setFocus}
+      manualFocusOrder={["field1", "field2", "field3"]}
+      showErrorSummary={props.showErrorSummary}
     >
       <div className="grid-row grid-gap-3 margin-top-3 margin-bottom-5">
         <div className="desktop:grid-col-8">
@@ -107,7 +107,7 @@ describe("submission behavior", () => {
 
   it("saves fields to the data store and routes to the next step on submit", async () => {
     const { mockUpdateDataStore } = renderWithProviders(
-      <DoulaFormTestPage mayHaveThreeOrMoreErrors={true} />,
+      <DoulaFormTestPage showErrorSummary={true} />,
       "/form/personal/2",
     );
     const user = userEvent.setup();
@@ -124,7 +124,7 @@ describe("submission behavior", () => {
   it("does not save fields to the data store and does not route on error", async () => {
     const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
     const { mockUpdateDataStore } = renderWithProviders(
-      <DoulaFormTestPage mayHaveThreeOrMoreErrors={true} />,
+      <DoulaFormTestPage showErrorSummary={true} />,
       "/form/personal/2",
     );
     const user = userEvent.setup();
@@ -148,14 +148,11 @@ describe("error summary", () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  describe("when mayHaveThreeOrMoreErrors is true", () => {
+  describe("when showErrorSummary is true", () => {
     it("shows an error summary if there are 3 or more errors", async () => {
       const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
       const user = userEvent.setup();
-      renderWithProviders(
-        <DoulaFormTestPage mayHaveThreeOrMoreErrors={true} />,
-        "/form/personal/2",
-      );
+      renderWithProviders(<DoulaFormTestPage showErrorSummary={true} />, "/form/personal/2");
       await user.click(screen.getByRole("button", { name: "Next" }));
 
       const focusedElement = document.activeElement as HTMLElement;
@@ -191,10 +188,7 @@ describe("error summary", () => {
     it("does not show an error summary if there are fewer than 3 errors, instead it focuses on the first error", async () => {
       const mockSendGAEvent = jest.spyOn(nextThirdPartiesGoogle, "sendGAEvent");
       const user = userEvent.setup();
-      renderWithProviders(
-        <DoulaFormTestPage mayHaveThreeOrMoreErrors={true} />,
-        "/form/personal/2",
-      );
+      renderWithProviders(<DoulaFormTestPage showErrorSummary={true} />, "/form/personal/2");
       await user.type(
         screen.getByRole("textbox", {
           name: "Label 1 *",
@@ -229,13 +223,10 @@ describe("error summary", () => {
     });
   });
 
-  describe("when mayHaveThreeOrMoreErrors is false", () => {
+  describe("when showErrorSummary is false", () => {
     it("does not show an error summary if there are 3 errors, instead it focuses on the first error", async () => {
       const user = userEvent.setup();
-      renderWithProviders(
-        <DoulaFormTestPage mayHaveThreeOrMoreErrors={false} />,
-        "/form/personal/2",
-      );
+      renderWithProviders(<DoulaFormTestPage showErrorSummary={false} />, "/form/personal/2");
 
       await user.click(screen.getByRole("button", { name: "Next" }));
 
@@ -256,10 +247,7 @@ describe("error summary", () => {
     async ({ name }) => {
       const labelWithoutAsterisk = name.toString().replace(" *", "");
       const user = userEvent.setup();
-      renderWithProviders(
-        <DoulaFormTestPage mayHaveThreeOrMoreErrors={true} />,
-        "/form/personal/2",
-      );
+      renderWithProviders(<DoulaFormTestPage showErrorSummary={true} />, "/form/personal/2");
       await user.click(screen.getByRole("button", { name: "Next" }));
       await user.click(screen.getByRole("link", { name: `${labelWithoutAsterisk} is required` }));
 

--- a/src/app/form/components/DoulaForm.tsx
+++ b/src/app/form/components/DoulaForm.tsx
@@ -16,18 +16,26 @@ import { useNavigate } from "react-router";
 
 type DoulaFormProps<T extends FieldValues> =
   | {
-      orderedInputNames: Array<FieldPath<T>>;
       errors: FieldErrors<T>;
-      setFocus: UseFormSetFocus<T>;
       handleSubmit: UseFormHandleSubmit<T, T>;
       children: React.ReactNode;
-      mayHaveThreeOrMoreErrors: true;
+      setFocus: UseFormSetFocus<T>;
+      manualFocusOrder: Array<FieldPath<T>>;
+      showErrorSummary: true;
     }
   | {
       errors: FieldErrors<T>;
       handleSubmit: UseFormHandleSubmit<T, T>;
       children: React.ReactNode;
-      mayHaveThreeOrMoreErrors: false;
+      showErrorSummary: false;
+    }
+  | {
+      errors: FieldErrors<T>;
+      handleSubmit: UseFormHandleSubmit<T, T>;
+      children: React.ReactNode;
+      setFocus: UseFormSetFocus<T>;
+      manualFocusOrder: Array<FieldPath<T>>;
+      showErrorSummary: false;
     };
 
 export const DoulaForm = <T extends FieldValues>(props: DoulaFormProps<T>) => {
@@ -60,13 +68,13 @@ export const DoulaForm = <T extends FieldValues>(props: DoulaFormProps<T>) => {
         type: errors[name]?.type,
       });
     }
-    if (props.mayHaveThreeOrMoreErrors) {
+    if ("manualFocusOrder" in props) {
       if (Object.keys(errors).length >= 3) {
         setShouldSummarizeErrors(true);
         errorSummaryRef.current?.focus();
       } else {
         setShouldSummarizeErrors(false);
-        for (const inputName of props.orderedInputNames) {
+        for (const inputName of props.manualFocusOrder) {
           const fieldPath = inputName as FieldPath<T>;
           if (errors[fieldPath] !== undefined) {
             props.setFocus(fieldPath);
@@ -82,7 +90,7 @@ export const DoulaForm = <T extends FieldValues>(props: DoulaFormProps<T>) => {
     <div>
       {isDataLoaded && (
         <Form onSubmit={onSubmitHandler} className="maxw-full" noValidate>
-          {props.mayHaveThreeOrMoreErrors && (
+          {props.showErrorSummary && (
             <div className={`grid-row grid-gap-3 ${shouldSummarizeErrors && "margin-top-3"}`}>
               <div className="desktop:grid-col-8">
                 <ErrorSummary<T>


### PR DESCRIPTION
## Link to issue

This commit contributes to newjersey/doula-pm#226.

## What was done?
react-hook-form has built-in functionality that keeps track of the order of inputs on the page, as determined by the order in which react-hook-form's `register` function is called on the component. It then has built-in functionality that sets focus on the first input with an error, if there is an error on submission.

Previously, we have overriden this behavior via the `mayHaveThreeOrMoreErrors` prop on `DoulaForm`. The prop was named as such, because it is otherwise not intuitive for a developer that potentially having three or more simultaneous errors -> need to show error summary -> need to manually set focus. The flip side is that the naming was not intuitive for what `mayHaveThreeOrMoreErrors` would control.

Additionally, we began using this prop in pages that did not have three or more errors, but where we needed to manually the focus order because react-hook-form would infer the order incorrectly. Specifically, when an input is conditionally rendered in between other inputs on the page, react-hook-form infers it as coming _after_ the other inputs, since `register` is only called on that input after it appears, despite it appearing between other inputs.

This commit thus refactors the `DoulaFormProps` interface to hopefully make these meanings and implications clearer. It:

- Renames `s/mayHaveThreeOrMoreErrors/showErrorSummary`
- Renames `s/orderedInputNames/manualFocusOrder`
- Enables `manualFocusOrder` to be set even when `showErrorSummary` is false, for situations where there may not be an error summary, but we want to manually set focus order due to conditionally rendered inputs
- It still enforces that `manualFocusOrder` must be set when `showErrorSummary` is true
- The three or more errors -> show error summary reasoning is no longer indicated in code

## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`
- This is an internal refactor with no user-facing implications
- Review `src/app/form/components/DoulaForm.tsx` for understandability and correctness