### PR TITLE
[newjersey/doula-pm#342] Pull out reusable address state and zip code components

### DIFF
--- a/src/app/form/(formSteps)/components/DoulaAddress.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddress.test.tsx
@@ -3,7 +3,7 @@ import {
   type DoulaAddressProps,
 } from "@/app/form/(formSteps)/components/DoulaAddress";
 import FormProgressButtons from "@/app/form/(formSteps)/components/FormProgressButtons";
-import { fillAllInputsExcept, getInputField } from "@/app/form/_utils/testUtils/fillInputs";
+import { getInputField } from "@/app/form/_utils/testUtils/fillInputs";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import { DoulaForm } from "@/app/form/components/DoulaForm";
 import { render, screen } from "@testing-library/react";
@@ -24,35 +24,6 @@ const testFormOrderedInputNameToLabel = {
   testState: "State",
   testZip: "ZIP Code",
 };
-
-const allInputFields = [
-  {
-    name: "Street address *",
-    dataStoreKey: "testStreetAddress1",
-    role: "textbox" as const,
-    testValue: "55 Cherry St",
-  },
-  {
-    name: "Street address line 2",
-    dataStoreKey: "testStreetAddress2",
-    role: "textbox" as const,
-    testValue: "Apt 4",
-  },
-  { name: "City *", dataStoreKey: "testCity", role: "textbox" as const, testValue: "Newark" },
-  {
-    name: "State *",
-    dataStoreKey: "testState",
-    role: "combobox" as const,
-    testValue: "Pennsylvania",
-    expectedValue: "PA",
-  },
-  {
-    name: "ZIP Code *",
-    dataStoreKey: "testZip",
-    role: "textbox" as const,
-    testValue: "08609",
-  },
-];
 
 const TestForm = (
   props: Omit<
@@ -199,57 +170,6 @@ describe("DoulaAddress", () => {
       "autocomplete",
       "shipping postal-code",
     );
-  });
-
-  it("displays an error message if zip has fewer than five digits", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(
-      <TestForm
-        fieldsetProps={{
-          legend: "What is your address?",
-        }}
-        addressKeys={{
-          streetAddress1: "testStreetAddress1",
-          streetAddress2: "testStreetAddress2",
-          city: "testCity",
-          state: "testState",
-          zip: "testZip",
-        }}
-      />,
-      "/form/personal/2",
-    );
-    await fillAllInputsExcept(screen, user, allInputFields, new Set(["testZip"]));
-    const zipInput = await getInputField(screen, { name: "ZIP Code *" });
-    await user.type(zipInput, "1");
-    await user.click(screen.getByRole("button", { name: "Next" }));
-
-    expect(zipInput).toHaveAccessibleDescription("ZIP Code must have five digits");
-  });
-
-  it("prevents non-numeric inputs in ZIP Code", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(
-      <TestForm
-        fieldsetProps={{
-          legend: "What is your address?",
-        }}
-        addressKeys={{
-          streetAddress1: "testStreetAddress1",
-          streetAddress2: "testStreetAddress2",
-          city: "testCity",
-          state: "testState",
-          zip: "testZip",
-        }}
-      />,
-      "/form/personal/2",
-    );
-    const zipInput = await getInputField(screen, { name: "ZIP Code *" });
-    await user.type(zipInput, "aaa");
-    expect(zipInput).toHaveValue("");
-    await user.type(zipInput, "!!");
-    expect(zipInput).toHaveValue("");
-    await user.type(zipInput, "11");
-    expect(zipInput).toHaveValue("11");
   });
 
   it("displays error messages that includes a prefix if provided", async () => {

--- a/src/app/form/(formSteps)/components/DoulaAddress.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddress.tsx
@@ -1,9 +1,9 @@
+import { DoulaAddressState } from "@/app/form/(formSteps)/components/DoulaAddressState";
+import { DoulaAddressZip } from "@/app/form/(formSteps)/components/DoulaAddressZip";
 import DoulaTextInput from "@/app/form/(formSteps)/components/DoulaTextInput";
-import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
 import { formatInputErrorLabel } from "@/app/form/(formSteps)/components/utils/doulaInput";
-import { AddressState, addressStateToName } from "@/app/form/_utils/inputFields/addressState";
 import { typecheckAutocomplete } from "@/app/form/_utils/types/autocomplete";
-import { Fieldset, Label, Select, type FieldsetProps } from "@trussworks/react-uswds";
+import { Fieldset, type FieldsetProps } from "@trussworks/react-uswds";
 import type { FieldErrors, FieldPath, FieldValues, UseFormRegister } from "react-hook-form";
 
 export interface DoulaAddressProps<T extends FieldValues> {
@@ -74,46 +74,22 @@ export const DoulaAddress = <T extends FieldValues>(props: DoulaAddressProps<T>)
       </div>
       <div className="grid-row grid-gap">
         <div className="mobile-lg:grid-col-6">
-          <Label htmlFor={props.addressKeys.state} requiredMarker>
-            {props.orderedInputNameToLabel[props.addressKeys.state]}
-          </Label>
-          <Select
-            className="usa-select"
-            id={props.addressKeys.state}
-            {...(props.autocomplete !== undefined && {
-              autoComplete: typecheckAutocomplete(`${props.autocomplete} address-level1`),
-            })}
-            required
-            {...props.register(props.addressKeys.state)}
-          >
-            {Object.keys(AddressState).map((state) => (
-              <option key={state} value={state}>
-                {addressStateToName[state as keyof typeof AddressState]}
-              </option>
-            ))}
-          </Select>
+          <DoulaAddressState
+            name={props.addressKeys.state}
+            label={props.orderedInputNameToLabel[props.addressKeys.state]}
+            autocomplete={props.autocomplete}
+            register={props.register}
+          />
         </div>
         <div className="mobile-lg:grid-col-4">
-          <DoulaTextInputMask
-            className="usa-input--medium"
+          <DoulaAddressZip
             name={props.addressKeys.zip}
             label={props.orderedInputNameToLabel[props.addressKeys.zip]}
-            {...(props.autocomplete !== undefined && {
-              autoComplete: typecheckAutocomplete(`${props.autocomplete} postal-code`),
-            })}
             value={props.zipValue ?? ""}
-            mask="#####"
-            pattern="\d{5}"
-            required
+            autocomplete={props.autocomplete}
+            errorLabelPrefix={props.errorLabelPrefix}
             errors={props.errors}
             register={props.register}
-            additionalRegisterOptions={{
-              required: `${formatInputErrorLabel(props.orderedInputNameToLabel[props.addressKeys.zip], props.errorLabelPrefix, true)} is required`,
-              minLength: {
-                value: 5,
-                message: `${formatInputErrorLabel(props.orderedInputNameToLabel[props.addressKeys.zip], props.errorLabelPrefix, true)} must have five digits`,
-              },
-            }}
           />
         </div>
       </div>

--- a/src/app/form/(formSteps)/components/DoulaAddressState.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddressState.test.tsx
@@ -1,0 +1,65 @@
+import { DoulaAddressState } from "@/app/form/(formSteps)/components/DoulaAddressState";
+import FormProgressButtons from "@/app/form/(formSteps)/components/FormProgressButtons";
+import { getInputField } from "@/app/form/_utils/testUtils/fillInputs";
+import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
+import { DoulaForm } from "@/app/form/components/DoulaForm";
+import { render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+
+describe("<DoulaAddressState />", () => {
+  it("renders the input with a label", () => {
+    const mockRegister = jest.fn();
+    render(<DoulaAddressState name={"testState"} label={"State"} register={mockRegister} />);
+
+    expect(mockRegister).toHaveBeenCalledWith("testState");
+    const input = screen.getByRole("combobox", { name: "State *" });
+    expect(input).toBeInTheDocument();
+  });
+
+  it("sets autocomplete if provided", () => {
+    render(
+      <DoulaAddressState
+        name={"testState"}
+        label={"State"}
+        autocomplete={"shipping"}
+        register={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole("combobox", { name: "State *" })).toHaveAttribute(
+      "autocomplete",
+      "shipping address-level1",
+    );
+  });
+
+  it("is able to default to NJ", async () => {
+    interface TestFormData {
+      testState: string;
+    }
+    const TestForm = () => {
+      const {
+        register,
+        handleSubmit,
+        formState: { errors },
+      } = useForm<TestFormData>({
+        defaultValues: {
+          testState: "NJ",
+        },
+      });
+      return (
+        <DoulaForm<TestFormData>
+          errors={errors}
+          handleSubmit={handleSubmit}
+          showErrorSummary={false}
+        >
+          <DoulaAddressState name={"testState"} label={"State"} register={register} />
+          <FormProgressButtons />
+        </DoulaForm>
+      );
+    };
+    renderWithProviders(<TestForm />, "/form/personal/1");
+
+    const input = await getInputField(screen, { name: "State *", role: "combobox" });
+    expect(input).toHaveDisplayValue("New Jersey");
+    expect(input).toHaveValue("NJ");
+  });
+});

--- a/src/app/form/(formSteps)/components/DoulaAddressState.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddressState.tsx
@@ -1,0 +1,36 @@
+import { AddressState, addressStateToName } from "@/app/form/_utils/inputFields/addressState";
+import { typecheckAutocomplete } from "@/app/form/_utils/types/autocomplete";
+import { Label, Select } from "@trussworks/react-uswds";
+import type { FieldPath, FieldValues, UseFormRegister } from "react-hook-form";
+
+export interface DoulaAddressStateProps<T extends FieldValues> {
+  name: FieldPath<T>;
+  label: string;
+  autocomplete?: "shipping";
+  register: UseFormRegister<T>;
+}
+
+export const DoulaAddressState = <T extends FieldValues>(props: DoulaAddressStateProps<T>) => {
+  return (
+    <>
+      <Label htmlFor={props.name} requiredMarker>
+        {props.label}
+      </Label>
+      <Select
+        className="usa-select"
+        id={props.name}
+        {...(props.autocomplete !== undefined && {
+          autoComplete: typecheckAutocomplete(`${props.autocomplete} address-level1`),
+        })}
+        required
+        {...props.register(props.name)}
+      >
+        {Object.keys(AddressState).map((state) => (
+          <option key={state} value={state}>
+            {addressStateToName[state as keyof typeof AddressState]}
+          </option>
+        ))}
+      </Select>
+    </>
+  );
+};

--- a/src/app/form/(formSteps)/components/DoulaAddressZip.test.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddressZip.test.tsx
@@ -1,0 +1,78 @@
+import { DoulaAddressZip } from "@/app/form/(formSteps)/components/DoulaAddressZip";
+import FormProgressButtons from "@/app/form/(formSteps)/components/FormProgressButtons";
+import { getInputField } from "@/app/form/_utils/testUtils/fillInputs";
+import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
+import { DoulaForm } from "@/app/form/components/DoulaForm";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+
+interface TestFormData {
+  testZip: string;
+}
+const TestForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+  } = useForm<TestFormData>({
+    defaultValues: {
+      testZip: "NJ",
+    },
+  });
+  const testZip = watch("testZip");
+  return (
+    <DoulaForm<TestFormData> errors={errors} handleSubmit={handleSubmit} showErrorSummary={false}>
+      <DoulaAddressZip
+        name={"testZip"}
+        label={"ZIP Code"}
+        value={testZip}
+        errors={errors}
+        register={register}
+      />
+      <FormProgressButtons />
+    </DoulaForm>
+  );
+};
+
+describe("<DoulaAddressZip />", () => {
+  it("sets autocomplete if provided", () => {
+    render(
+      <DoulaAddressZip
+        name={"testZip"}
+        label={"ZIP Code"}
+        value={""}
+        autocomplete={"shipping"}
+        errors={{}}
+        register={jest.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox", { name: "ZIP Code *" })).toHaveAttribute(
+      "autocomplete",
+      "shipping postal-code",
+    );
+  });
+
+  it("displays an error message if zip has fewer than five digits", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TestForm />, "/form/personal/1");
+    const zipInput = await getInputField(screen, { name: "ZIP Code *" });
+    await user.type(zipInput, "1");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(zipInput).toHaveAccessibleDescription("ZIP Code must have five digits");
+  });
+
+  it("prevents non-numeric inputs in ZIP Code", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TestForm />, "/form/personal/1");
+    const zipInput = await getInputField(screen, { name: "ZIP Code *" });
+    await user.type(zipInput, "aaa");
+    expect(zipInput).toHaveValue("");
+    await user.type(zipInput, "!!");
+    expect(zipInput).toHaveValue("");
+    await user.type(zipInput, "11");
+    expect(zipInput).toHaveValue("11");
+  });
+});

--- a/src/app/form/(formSteps)/components/DoulaAddressZip.tsx
+++ b/src/app/form/(formSteps)/components/DoulaAddressZip.tsx
@@ -1,0 +1,40 @@
+import DoulaTextInputMask from "@/app/form/(formSteps)/components/DoulaTextInputMask";
+import { formatInputErrorLabel } from "@/app/form/(formSteps)/components/utils/doulaInput";
+import { typecheckAutocomplete } from "@/app/form/_utils/types/autocomplete";
+import type { FieldErrors, FieldPath, FieldValues, UseFormRegister } from "react-hook-form";
+
+export interface DoulaAddressZipProps<T extends FieldValues> {
+  name: FieldPath<T>;
+  label: string;
+  value: string;
+  autocomplete?: "shipping";
+  errorLabelPrefix?: string;
+  errors: FieldErrors<T>;
+  register: UseFormRegister<T>;
+}
+
+export const DoulaAddressZip = <T extends FieldValues>(props: DoulaAddressZipProps<T>) => {
+  return (
+    <DoulaTextInputMask
+      className="usa-input--medium"
+      name={props.name}
+      label={props.label}
+      {...(props.autocomplete !== undefined && {
+        autoComplete: typecheckAutocomplete(`${props.autocomplete} postal-code`),
+      })}
+      value={props.value ?? ""}
+      mask="#####"
+      pattern="\d{5}"
+      required
+      errors={props.errors}
+      register={props.register}
+      additionalRegisterOptions={{
+        required: `${formatInputErrorLabel(props.label, props.errorLabelPrefix, true)} is required`,
+        minLength: {
+          value: 5,
+          message: `${formatInputErrorLabel(props.label, props.errorLabelPrefix, true)} must have five digits`,
+        },
+      }}
+    />
+  );
+};


### PR DESCRIPTION
## Link to issue

This commit contributes to newjersey/doula-pm#342.

## What was done?
This commit pulls out reusable components for address state and zip code. This is done in anticipation of personal details 4, which requires state and zip code inputs but not a full address with street 1 and street 2. The feature does also require a City address input, but City is straightforward enough that there's not much to encapsulate.


## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- This is an internal refactor, with no user-facing changes
- Go to http://localhost:3000/humanservices/dmahs/info/doulahelp. The form should work.
