### PR TITLE
Reintroduce removed `jiti` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "jest": "30.2.0",
         "jest-environment-jsdom": "30.2.0",
         "jest-expect-message": "1.1.3",
+        "jiti": "^2.6.1",
         "lint-staged": "latest",
         "prettier": "latest",
         "prettier-plugin-jsdoc": "1.8.0",
@@ -11048,8 +11049,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "jest": "30.2.0",
     "jest-environment-jsdom": "30.2.0",
     "jest-expect-message": "1.1.3",
+    "jiti": "2.6.1",
     "lint-staged": "latest",
     "prettier": "latest",
     "prettier-plugin-jsdoc": "1.8.0",


### PR DESCRIPTION
## What was done?
Previously, the jiti dependency was removed in https://github.com/newjersey/doula-medicaid/pull/433. Somehow the CI, including npm run lint, passed nonetheless.

However, subsequent attempts to run `npm run lint` led to an error that: `The 'jiti' library is required for loading TypeScript configuration files. Make sure to install it.`.

Per [these docs](https://eslint.org/docs/latest/use/configure/configuration-files#typescript-configuration-files), typescript configuration files are not natively supported for node.js and this `jiti` dependency is not automatically installed by eslint. The docs have jiti as a dev dependency, and it has been re-introduced as such.


It remains unclear why this was introduced as part of the eslint version bump in https://github.com/newjersey/doula-medicaid/commit/68fa9d2c9435b9085fd3163e5edf470d8b40bdc2. The old eslint version 9.23 [should have already required jiti](https://eslint.org/blog/2025/01/eslint-v9.18.0-released/#stable-typescript-configuration-file-support).

It seems like the general question of whether this jiti functionality should be bundled in to eslint/may be supported by later node versions is still a pretty cutting-edge topic https://github.com/eslint/eslint/issues/19357
