### PR TITLE
[newjersey/doula-pm#413] Production stable DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Doula Medicaid
+# NJ Doula Assistant
+
+Helping doulas start the Fee-for-Service (FFS) application to become an NJ FamilyCare community
+doula.
+
+https://www.nj.gov/humanservices/dmahs/info/doulahelp
 
 ## Getting Started
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -78,19 +78,38 @@ were to run `cdk destroy` then `cdk create`. OIT requires that the VPC-internal 
 ALBs communicate over HTTPS. So, we manually generate and upload, then deploy a self-signed SSL cert
 to the internal and external ALBs.
 
-Thus, deploying the production stack for the first time is weirdly cyclical:
+Separately, production (like staging) has also set up a stable DNS
+`app.production-doula-vpc.dhs.nj.gov` that resolves within the VPC via a private hosted zone, and
+points to the internal ALB. It uses a DHS-provided SSL cert. The existence of both the random and
+the stable DNS is a matter of tech debt. We created the stable DNS, similar to staging, so that
+on-prem DHS servers could resolve the same public URL to the application, despite traffic not going
+through the public-facing firewall. However, as of writing we have yet to switch the VPC-external
+ALB to point to the stable DNS instead of the random one.
 
-1. First, deploy the cdk stack with a **http** internal ALB, replacing `<profile name>`.
+There is thus tech tebt in the architecture of this production stack. Additionally, to recreated it
+as it current is, the cloudformation stack needs to first be deployed before the random DNS is known
+and the self-signed SSL cert for external <-> internal ALB communication can be created. Deploying
+the production stack for the first time, in a way that recreates the current tech debt architecutre,
+is thus weirdly cyclical:
+
+1. Obtain the DHS-provided SSL certificate for `app.production-doula-vpc.dhs.nj.gov`. Manually
+   upload it to AWS Certificate Manager, and note the ARN.
+2. Obtain the IPs of the on-prem DNS servers.
+
+3. Deploy the cdk stack with a **http** internal ALB, replacing `<profile name>`,
+   `<comma-separated list of IPs of on-prem DNS servers>`, and `<stable DNS cert ARN>`. Due to the
+   http deployment, the stable DNS cert for `app.production-doula-vpc.dhs.nj.gov` won't be used, but
+   providing it works with how our `cdk-stack.ts` is structured.
 
    ```sh
-   npm run cdk:deploy -- --profile <profile name> --context env=production
+   npm run cdk:deploy -- --profile <profile name> --context env=production --context dnsIps=<comma-separated list of IPs of on-prem DNS servers> --context certificateArn=<stable DNS cert>
    ```
 
    This generates the random cloudformation-generated internal ALB DNS, e.g.
    internal-doula-assistant-alb-1234567890.us-east-1.elb.amazonaws.com, where `1234567890` is a
    random number. This is output as `DoulaAssistantStack.LoadBalancerUrl`.
 
-2. Using this DNS, create a self-signed SSL certificate, replacing `<load balancer domain>` and
+4. Using this DNS, create a self-signed SSL certificate, replacing `<load balancer domain>` and
    `<email>`. The load balancer domain is the SAN and not the common name because it is likely too
    long to fit the 64-character limit on common names. The SSL certificate can be self-signed
    because it's just used for TLS communication.
@@ -102,11 +121,12 @@ Thus, deploying the production stack for the first time is weirdly cyclical:
    Log into AWS Console, upload the certificate to AWS Certificate Manager, and obtain the
    certificate ARN.
 
-3. Then, deploy the cdk stack again but with **https**, and providing the certificate ARN. Replace
-   `<profile name>`, env `<production or staging>`, and `<certificate arn>`
+5. Then, deploy the cdk stack again but with **https**, and providing the certificate ARNs for both
+   the stable and random DNS. Replace `<profile name>`, env `<production or staging>`,
+   `<stable DNS cert ARN>`, and `<self-signed random DNS cert ARN>`
 
    ```sh
-   npm run cdk:deploy -- --profile <profile name> --context env=<production or staging> --context https=true --context certificateArn=<certificate arn>
+   npm run cdk:deploy -- --profile <profile name> --context env=<production or staging> --context https=true --context dnsIps=<comma-separated list of IPs of on-prem DNS servers> --context certificateArn=<stable DNS cert ARN> --context cfDnsCertificateArn=<self-signed random DNS cert ARN>
    ```
 
 Any subsequent cdk deployments should use use https.
@@ -116,15 +136,9 @@ The output `DoulaAssistantStack.LoadBalancerUrl` should be accessible from an
 
 ### Staging
 
-In staging, there is no public-facing firewall, or VPC-external ALB. Instead, on-prem DNS servers
-point to the DNS of the VPC-internal ALB. Unlike in production, the DNS of this VPC-internal ALB is
-stable, as configured by the private hosted zone within the VPC. This stable DNS does not change if
-one were to run `cdk destroy` then `cdk create`. This difference with production is a matter of tech
-debt. The stable DNS costs $200/mo, and we have yet to decided whether we would prefer the random,
-or the stable DNS.
-
-Accordingly, since the stable DNS is `app.staging-doula-vpc.dhs.nj.gov`, the internal ALB in staging
-uses a DHS-provided SSL cert, instead of a self-signed certificate as used in production.
+In staging, there is no public-facing firewall, or VPC-external ALB. Instead, we only have on-prem
+DNS servers point to the DNS of the VPC-internal ALB. We thus do not need the self-signed cert for
+the random cloudformation-generated DNS, and do not need an initial http deploy.
 
 To deploy staging,
 
@@ -135,7 +149,7 @@ To deploy staging,
    `<comma-separated list of IPs of on-prem DNS servers>`.
 
    ```sh
-   npm run cdk:deploy -- --profile <profile name> --context env=staging --context https=true --context certificateArn=<certificate arn> --context dnsIps=<comma-separated list of IPs of on-prem DNS servers>
+   npm run cdk:deploy -- --profile <profile name> --context env=staging --context https=true --context dnsIps=<comma-separated list of IPs of on-prem DNS servers> --context certificateArn=<certificate arn>
    ```
 
 4. Configure any additional firewall rules, etc, via OIT

--- a/lib/cdk-stack.ts
+++ b/lib/cdk-stack.ts
@@ -14,7 +14,7 @@ import * as targets from "aws-cdk-lib/aws-route53-targets";
 const VPC_NAME = "DHS-DMAHS-DoulaApp-*";
 const ECR_REPOSITORY_NAME = "doula-app";
 
-const STAGING_ENV_NAME = "staging";
+const PRODUCTION_ENV_NAME = "production";
 
 /** See docs/deployment.md */
 export class CdkStack extends cdk.Stack {
@@ -24,6 +24,7 @@ export class CdkStack extends cdk.Stack {
     const envName = this.node.tryGetContext("env");
     const isHttps = this.node.tryGetContext("https") == "true";
     const certificateArn = this.node.tryGetContext("certificateArn");
+    const cfDnsCertificateArn = this.node.tryGetContext("cfDnsCertificateArn");
 
     const dnsIps = this.node.tryGetContext("dnsIps");
 
@@ -89,11 +90,21 @@ export class CdkStack extends cdk.Stack {
         publicLoadBalancer: false, // Internal ALB
         listenerPort: isHttps ? 443 : 80,
         ...(isHttps && {
-          certificate: acm.Certificate.fromCertificateArn(this, "Certificate", certificateArn),
+          certificate: acm.Certificate.fromCertificateArn(
+            this,
+            "stableDnsCertificate",
+            certificateArn,
+          ),
         }),
         taskSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       },
     );
+
+    if (envName === PRODUCTION_ENV_NAME) {
+      fargateService.listener.addCertificates("CfGeneratedDnsCertificates", [
+        acm.Certificate.fromCertificateArn(this, "CfGeneratedDnsCertificate", cfDnsCertificateArn),
+      ]);
+    }
 
     fargateService.targetGroup.configureHealthCheck({
       path: "/humanservices/dmahs/info/doulahelp/api/health",
@@ -167,67 +178,59 @@ export class CdkStack extends cdk.Stack {
 
     let dnsName = fargateService.loadBalancer.loadBalancerDnsName;
 
-    if (envName === STAGING_ENV_NAME) {
-      if (dnsIps === undefined) {
-        throw new Error(
-          "A comma-delimited list of DNS IPs is required for this Route53 stable CNAME to be accessed from outside the VPC. Prod currently deploys the Route53 stuff, but does not actually use it. This difference between staging and prod is tech debt. See deployment.md",
-        );
-      }
+    const hostedZone = new route53.PrivateHostedZone(this, "DoulaPrivateZone", {
+      vpc,
+      zoneName: `${envName}-doula-vpc.dhs.nj.gov`,
+    });
 
-      const hostedZone = new route53.PrivateHostedZone(this, "DoulaPrivateZone", {
+    const aRecord = new route53.ARecord(this, "DoulaAlbARecord", {
+      zone: hostedZone,
+      recordName: "app",
+      target: route53.RecordTarget.fromAlias(
+        new targets.LoadBalancerTarget(fargateService.loadBalancer, {
+          evaluateTargetHealth: true,
+        }),
+      ),
+    });
+    dnsName = aRecord.domainName;
+
+    // For inbound DNS resolution traffic
+    const route53InboundEndpointSecurityGroup = new ec2.SecurityGroup(
+      this,
+      "Route53InboundEndpointSecurityGroup",
+      {
         vpc,
-        zoneName: `${envName}-doula-vpc.dhs.nj.gov`,
-      });
-
-      const aRecord = new route53.ARecord(this, "DoulaAlbARecord", {
-        zone: hostedZone,
-        recordName: "app",
-        target: route53.RecordTarget.fromAlias(
-          new targets.LoadBalancerTarget(fargateService.loadBalancer, {
-            evaluateTargetHealth: true,
-          }),
-        ),
-      });
-      dnsName = aRecord.domainName;
-
-      // For inbound DNS resolution traffic
-      const route53InboundEndpointSecurityGroup = new ec2.SecurityGroup(
-        this,
-        "Route53InboundEndpointSecurityGroup",
-        {
-          vpc,
-          allowAllOutbound: true,
-          description: "Security group for Route 53 inbound endpoint",
-        },
-      );
+        allowAllOutbound: true,
+        description: "Security group for Route 53 inbound endpoint",
+      },
+    );
+    route53InboundEndpointSecurityGroup.addIngressRule(
+      ec2.Peer.ipv4(vpc.vpcCidrBlock),
+      ec2.Port.tcp(53),
+    );
+    route53InboundEndpointSecurityGroup.addIngressRule(
+      ec2.Peer.ipv4(vpc.vpcCidrBlock),
+      ec2.Port.udp(53),
+    );
+    for (const dnsIp of dnsIps.split(",")) {
       route53InboundEndpointSecurityGroup.addIngressRule(
-        ec2.Peer.ipv4(vpc.vpcCidrBlock),
+        ec2.Peer.ipv4(`${dnsIp}/32`),
         ec2.Port.tcp(53),
       );
       route53InboundEndpointSecurityGroup.addIngressRule(
-        ec2.Peer.ipv4(vpc.vpcCidrBlock),
+        ec2.Peer.ipv4(`${dnsIp}/32`),
         ec2.Port.udp(53),
       );
-      for (const dnsIp of dnsIps.split(",")) {
-        route53InboundEndpointSecurityGroup.addIngressRule(
-          ec2.Peer.ipv4(`${dnsIp}/32`),
-          ec2.Port.tcp(53),
-        );
-        route53InboundEndpointSecurityGroup.addIngressRule(
-          ec2.Peer.ipv4(`${dnsIp}/32`),
-          ec2.Port.udp(53),
-        );
-      }
-      const subnetIds = vpc.privateSubnets.map((subnet) => subnet.subnetId);
-
-      // This costs $200/mo
-      new route53resolver.CfnResolverEndpoint(this, "DoulaInboundEndpoint", {
-        direction: "INBOUND",
-        // Two IP addresses for the endpoint are required
-        ipAddresses: [{ subnetId: subnetIds[0] }, { subnetId: subnetIds[1] }],
-        securityGroupIds: [route53InboundEndpointSecurityGroup.securityGroupId],
-      });
     }
+    const subnetIds = vpc.privateSubnets.map((subnet) => subnet.subnetId);
+
+    // This costs $200/mo
+    new route53resolver.CfnResolverEndpoint(this, "DoulaInboundEndpoint", {
+      direction: "INBOUND",
+      // Two IP addresses for the endpoint are required
+      ipAddresses: [{ subnetId: subnetIds[0] }, { subnetId: subnetIds[1] }],
+      securityGroupIds: [route53InboundEndpointSecurityGroup.securityGroupId],
+    });
 
     fargateService.taskDefinition.executionRole?.addManagedPolicy(
       iam.ManagedPolicy.fromAwsManagedPolicyName("service-role/AmazonECSTaskExecutionRolePolicy"),


### PR DESCRIPTION
## Link to issue

This commit contributes to newjersey/doula-pm#413.

## What was done?
This changes updates our cdk stack to use a stable DNS for production, in addition to the self-signed certificate for the random cloudformation-generated DNS. The reasoning for this is explained in the updated `deployment.md` docs.

It also updates the readme to include a link to the live site.
