### PR TITLE
[newjersey/doula-pm#428] Add typechecking to cypress test files

### DIFF
--- a/cypress/e2e/fillAndDownloadApplication.cy.ts
+++ b/cypress/e2e/fillAndDownloadApplication.cy.ts
@@ -22,7 +22,7 @@ import { testFields as screening2TestFields } from "@/app/form/(formSteps)/scree
 import { testFields as screening3TestFields } from "@/app/form/(formSteps)/screening/3/testFields";
 import { path1TestFields as training1TestFields } from "@/app/form/(formSteps)/training/1/testFields";
 import type { PdfFfsIndividual } from "@/app/form/_utils/fillPdf/ffsIndividual/fillFfsIndividual";
-import { type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { type TestField } from "@/app/form/_utils/testUtils/testFields";
 import { PDFCheckBox, PDFDocument, PDFTextField } from "pdf-lib";
 
 export const formPages = [

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,13 +1,20 @@
 {
-  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["cypress"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "types": ["node", "cypress"],
+    "skipLibCheck": true,
+
+    "noEmit": true,
+    "strict": true,
+
     "baseUrl": ".",
     "paths": {
       "@/*": ["../src/*"],
       "@form/*": ["../src/app/form/*"]
     }
   },
-  "include": ["./**/*.ts", "./**/*.tsx"],
-  "exclude": []
+  "include": ["./**/*.ts", "./**/*.tsx"]
 }

--- a/src/app/form/(formSteps)/business/1/testFields.ts
+++ b/src/app/form/(formSteps)/business/1/testFields.ts
@@ -2,7 +2,7 @@ import {
   createTestField,
   createTestFields,
   type TestField,
-} from "@/app/form/_utils/testUtils/sharedTests";
+} from "@/app/form/_utils/testUtils/testFields";
 
 const businessAddressQuestion = "What is your business address?";
 

--- a/src/app/form/(formSteps)/business/2/testFields.ts
+++ b/src/app/form/(formSteps)/business/2/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/testFields";
 
 const noHasUncollectedDebt: TestField = createTestField({
   name: "No",

--- a/src/app/form/(formSteps)/business/3/testFields.ts
+++ b/src/app/form/(formSteps)/business/3/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/testFields";
 
 const noHasBeenExcludedFromMedicaid: TestField = createTestField({
   name: "No",

--- a/src/app/form/(formSteps)/business/4/testFields.ts
+++ b/src/app/form/(formSteps)/business/4/testFields.ts
@@ -2,7 +2,7 @@ import {
   createTestField,
   createTestFields,
   type TestField,
-} from "@/app/form/_utils/testUtils/sharedTests";
+} from "@/app/form/_utils/testUtils/testFields";
 
 const currentYear: number = new Date().getFullYear();
 

--- a/src/app/form/(formSteps)/insurance/1/InsuranceStep1.test.tsx
+++ b/src/app/form/(formSteps)/insurance/1/InsuranceStep1.test.tsx
@@ -15,8 +15,8 @@ import {
   testInvalidField,
   testRequiredField,
   testSaveFieldsToDataStore,
-  type TestField,
 } from "@/app/form/_utils/testUtils/sharedTests";
+import { type TestField } from "@/app/form/_utils/testUtils/testFields";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/src/app/form/(formSteps)/insurance/1/testFields.ts
+++ b/src/app/form/(formSteps)/insurance/1/testFields.ts
@@ -2,7 +2,7 @@ import {
   createTestField,
   createTestFields,
   type TestField,
-} from "@/app/form/_utils/testUtils/sharedTests";
+} from "@/app/form/_utils/testUtils/testFields";
 
 const currentYear: number = new Date().getFullYear();
 

--- a/src/app/form/(formSteps)/insurance/2/testFields.ts
+++ b/src/app/form/(formSteps)/insurance/2/testFields.ts
@@ -2,7 +2,7 @@ import {
   createTestField,
   createTestFields,
   type TestField,
-} from "@/app/form/_utils/testUtils/sharedTests";
+} from "@/app/form/_utils/testUtils/testFields";
 
 const insuranceAddressGroupName =
   "Insurance address This is the office location of your insurance carrier.";

--- a/src/app/form/(formSteps)/legal/1/testFields.ts
+++ b/src/app/form/(formSteps)/legal/1/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/testFields";
 
 export const noIsEmployedByNj: TestField = createTestField({
   name: "No",

--- a/src/app/form/(formSteps)/legal/2/testFields.ts
+++ b/src/app/form/(formSteps)/legal/2/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/testFields";
 
 export const noHasCrimeCharge: TestField = createTestField({
   name: "No",

--- a/src/app/form/(formSteps)/legal/3/testFields.ts
+++ b/src/app/form/(formSteps)/legal/3/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/testFields";
 
 export const noHasDisqualification: TestField = createTestField({
   name: "No",

--- a/src/app/form/(formSteps)/personal/1/PersonalStep1.test.tsx
+++ b/src/app/form/(formSteps)/personal/1/PersonalStep1.test.tsx
@@ -10,12 +10,12 @@ import {
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  type TestField,
   testFillFromDataStore,
   testInvalidField,
   testRequiredField,
   testSaveFieldsToDataStore,
 } from "@/app/form/_utils/testUtils/sharedTests";
+import type { TestField } from "@/app/form/_utils/testUtils/testFields";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/src/app/form/(formSteps)/personal/1/testFields.ts
+++ b/src/app/form/(formSteps)/personal/1/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/testFields";
 
 const dateOfBirthMonthField = createTestField({
   name: "Month *",

--- a/src/app/form/(formSteps)/personal/2/PersonalStep2.test.tsx
+++ b/src/app/form/(formSteps)/personal/2/PersonalStep2.test.tsx
@@ -20,11 +20,11 @@ import {
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
   testConditionalRender,
-  type TestField,
   testFillFromDataStore,
   testRequiredField,
   testSaveFieldsToDataStore,
 } from "@/app/form/_utils/testUtils/sharedTests";
+import type { TestField } from "@/app/form/_utils/testUtils/testFields";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/src/app/form/(formSteps)/personal/2/testFields.ts
+++ b/src/app/form/(formSteps)/personal/2/testFields.ts
@@ -2,7 +2,7 @@ import {
   createTestField,
   createTestFields,
   type TestField,
-} from "@/app/form/_utils/testUtils/sharedTests";
+} from "@/app/form/_utils/testUtils/testFields";
 
 export const mailingAddressQuestion =
   "Mailing address We will send official mail here. It can be your home address.";

--- a/src/app/form/(formSteps)/personal/3/PersonalStep3.test.tsx
+++ b/src/app/form/(formSteps)/personal/3/PersonalStep3.test.tsx
@@ -8,12 +8,12 @@ import {
 import type { DataStore } from "@/app/form/_utils/dataStore";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  type TestField,
   testFillFromDataStore,
   testInvalidField,
   testRequiredField,
   testSaveFieldsToDataStore,
 } from "@/app/form/_utils/testUtils/sharedTests";
+import type { TestField } from "@/app/form/_utils/testUtils/testFields";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/src/app/form/(formSteps)/personal/3/testFields.ts
+++ b/src/app/form/(formSteps)/personal/3/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, createTestFields } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, createTestFields } from "@/app/form/_utils/testUtils/testFields";
 
 export const npiNumberField = createTestField({
   name: "National Provider Identifier (NPI) *",

--- a/src/app/form/(formSteps)/personal/4/PersonalStep4.test.tsx
+++ b/src/app/form/(formSteps)/personal/4/PersonalStep4.test.tsx
@@ -14,12 +14,12 @@ import type { DataStore } from "@/app/form/_utils/dataStore";
 import { getInputField } from "@/app/form/_utils/testUtils/fillInputs";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
 import {
-  type TestField,
   testFillFromDataStore,
   testInvalidField,
   testRequiredField,
   testSaveFieldsToDataStore,
 } from "@/app/form/_utils/testUtils/sharedTests";
+import type { TestField } from "@/app/form/_utils/testUtils/testFields";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/src/app/form/(formSteps)/personal/4/testFields.ts
+++ b/src/app/form/(formSteps)/personal/4/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, createTestFields } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, createTestFields } from "@/app/form/_utils/testUtils/testFields";
 
 export const directDepositDetailsFields = createTestFields([
   {

--- a/src/app/form/(formSteps)/screening/1/testFields.ts
+++ b/src/app/form/(formSteps)/screening/1/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/testFields";
 
 export const yesIsSoleProprietor: TestField = createTestField({
   name: "Yes",

--- a/src/app/form/(formSteps)/screening/2/testFields.ts
+++ b/src/app/form/(formSteps)/screening/2/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/testFields";
 
 const noEverHadEmployees = createTestField({
   name: "No",

--- a/src/app/form/(formSteps)/screening/3/testFields.ts
+++ b/src/app/form/(formSteps)/screening/3/testFields.ts
@@ -1,4 +1,4 @@
-import { createTestField, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestField, type TestField } from "@/app/form/_utils/testUtils/testFields";
 
 const noHaveOtherBusinessOwnerNextYear = createTestField({
   name: "No",

--- a/src/app/form/(formSteps)/training/1/TrainingStep1.test.tsx
+++ b/src/app/form/(formSteps)/training/1/TrainingStep1.test.tsx
@@ -17,8 +17,8 @@ import {
   testFillFromDataStore,
   testRequiredField,
   testSaveFieldsToDataStore,
-  type TestField,
 } from "@/app/form/_utils/testUtils/sharedTests";
+import type { TestField } from "@/app/form/_utils/testUtils/testFields";
 import { fillField } from "@form/_utils/testUtils/fillInputs";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/src/app/form/(formSteps)/training/1/testFields.ts
+++ b/src/app/form/(formSteps)/training/1/testFields.ts
@@ -2,7 +2,7 @@ import {
   createTestField,
   createTestFields,
   type TestField,
-} from "@/app/form/_utils/testUtils/sharedTests";
+} from "@/app/form/_utils/testUtils/testFields";
 
 const trainingAddressGroupName = "What is the address of your training organization? *";
 

--- a/src/app/form/_utils/testUtils/sharedTests.ts
+++ b/src/app/form/_utils/testUtils/sharedTests.ts
@@ -13,82 +13,14 @@ import {
   type FieldToFill,
   type FieldToGet,
 } from "@/app/form/_utils/testUtils/fillInputs";
+import type { TestField } from "@/app/form/_utils/testUtils/testFields";
 import type { Screen } from "@testing-library/dom";
 import userEvent, { type UserEvent } from "@testing-library/user-event";
 import type { Mock } from "vitest";
 
-type TestFieldParameters = {
-  name: string | RegExp;
-  dataStoreKey: string;
-  required: boolean;
-  withinGroupName?: string;
-  prerequisiteField?: TestField;
-  alternateRequiredFieldError?: string;
-} & (
-  | {
-      role?: "textbox" | "combobox" | "radio";
-      testValue: string;
-      expectedValue?: string;
-    }
-  | {
-      role: "checkbox";
-    }
-);
-
-export type TestField = {
-  name: string | RegExp;
-  dataStoreKey: string;
-  required: boolean;
-  requiredErrorMessage: string;
-  withinGroupName?: string;
-  prerequisiteField?: TestField;
-  role: "textbox" | "combobox" | "radio" | "checkbox";
-  testValue: string;
-  expectedValue: string;
-};
-
 type RenderFunction = (dataStore?: DataStore) => {
   mockUpdateDataStore: Mock;
   pathname: string;
-};
-
-export const createTestField = (field: TestFieldParameters): TestField => {
-  const commonTestFields = {
-    name: field.name,
-    dataStoreKey: field.dataStoreKey,
-    required: field.required,
-    requiredErrorMessage:
-      field.alternateRequiredFieldError ??
-      (field.role === "radio"
-        ? "This question is required"
-        : `${field.name.toString().replace(" *", "")} is required`),
-    withinGroupName: field.withinGroupName,
-    prerequisiteField: field.prerequisiteField,
-  };
-
-  if (field.role === "checkbox") {
-    return {
-      ...commonTestFields,
-      role: field.role,
-      testValue: "true",
-      expectedValue: "true",
-    };
-  }
-
-  return {
-    ...commonTestFields,
-    role: field.role ?? "textbox",
-    testValue: field.testValue,
-    expectedValue: field.expectedValue ?? field.testValue,
-  };
-};
-
-export const createTestFields = (fields: Array<TestFieldParameters>): Array<TestField> => {
-  const testFields: Array<TestField> = [];
-  for (const field of fields) {
-    testFields.push(createTestField(field));
-  }
-  return testFields;
 };
 
 const clickNextButton = async (pathname: string, user: UserEvent, screen: Screen) => {

--- a/src/app/form/_utils/testUtils/testFields.ts
+++ b/src/app/form/_utils/testUtils/testFields.ts
@@ -1,0 +1,68 @@
+type TestFieldParameters = {
+  name: string | RegExp;
+  dataStoreKey: string;
+  required: boolean;
+  withinGroupName?: string;
+  prerequisiteField?: TestField;
+  alternateRequiredFieldError?: string;
+} & (
+  | {
+      role?: "textbox" | "combobox" | "radio";
+      testValue: string;
+      expectedValue?: string;
+    }
+  | {
+      role: "checkbox";
+    }
+);
+
+export type TestField = {
+  name: string | RegExp;
+  dataStoreKey: string;
+  required: boolean;
+  requiredErrorMessage: string;
+  withinGroupName?: string;
+  prerequisiteField?: TestField;
+  role: "textbox" | "combobox" | "radio" | "checkbox";
+  testValue: string;
+  expectedValue: string;
+};
+
+export const createTestField = (field: TestFieldParameters): TestField => {
+  const commonTestFields = {
+    name: field.name,
+    dataStoreKey: field.dataStoreKey,
+    required: field.required,
+    requiredErrorMessage:
+      field.alternateRequiredFieldError ??
+      (field.role === "radio"
+        ? "This question is required"
+        : `${field.name.toString().replace(" *", "")} is required`),
+    withinGroupName: field.withinGroupName,
+    prerequisiteField: field.prerequisiteField,
+  };
+
+  if (field.role === "checkbox") {
+    return {
+      ...commonTestFields,
+      role: field.role,
+      testValue: "true",
+      expectedValue: "true",
+    };
+  }
+
+  return {
+    ...commonTestFields,
+    role: field.role ?? "textbox",
+    testValue: field.testValue,
+    expectedValue: field.expectedValue ?? field.testValue,
+  };
+};
+
+export const createTestFields = (fields: Array<TestFieldParameters>): Array<TestField> => {
+  const testFields: Array<TestField> = [];
+  for (const field of fields) {
+    testFields.push(createTestField(field));
+  }
+  return testFields;
+};

--- a/src/app/form/components/DoulaForm.test.tsx
+++ b/src/app/form/components/DoulaForm.test.tsx
@@ -6,7 +6,7 @@ import {
   getInputField,
 } from "@/app/form/_utils/testUtils/fillInputs";
 import { renderWithProviders } from "@/app/form/_utils/testUtils/renderWithProviders";
-import { createTestFields, type TestField } from "@/app/form/_utils/testUtils/sharedTests";
+import { createTestFields, type TestField } from "@/app/form/_utils/testUtils/testFields";
 import { DoulaForm } from "@/app/form/components/DoulaForm";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,5 +4,9 @@
     "strict": true // https://github.com/mightyiam/eslint-config-love/issues/481#issuecomment-747475360
   },
   // https://stackoverflow.com/questions/72027949/why-does-vite-create-two-typescript-config-files-tsconfig-json-and-tsconfig-nod
-  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./cypress/tsconfig.json" }
+  ]
 }


### PR DESCRIPTION
## Link to issue

This commit contributes to newjersey/doula-pm#428.

## What was done?
Previously, a `tsconfig.json` was defined in `/cypress`, but not actually used. Type violations in e.g. `fillAndDownloadApplication.cy.ts` would not fail `npm run typecheck`.

This commit wires up type checking for cypress test files. As part of doing so, this commit refactors to break off `TestField` definitions and utility functions in `sharedTests.ts`, into a separate `src/app/form/_utils/testUtils/testFields.ts` file.

Some context for breaking up `sharedTests.ts` is that there are three potential sources of the `expect()` function:
1. cypress (chai)
2. vitest (or jest, if using instead)
3. testing-library/jest-dom, which provides additional functions like `toHaveAccessibleDescription()` on `expect()`

Two separate processes run for e2e testing. The application process that spins up the webapp, and the cypress process that runs the test against the webapp. For this cypress process, e.g. code executed in `fillAndDownloadApplication.cy.ts`, the `expect` is a cypress chai expect, with syntax like `expect(pageCount).to.equal(39);`.

Previously, `fillAndDownloadApplication.cy.ts` would `import { type TestField } from "@/app/form/_utils/testUtils/sharedTests";`. However, `sharedTests.ts` also contains code like `expect(input).toHaveFocus();`. These `expect()`s are meant to be run in the unit test process, which uses vitest + testing-library/jest-dom definitions of `expect()`. Since the cypress process uses the cypress global expect, type checking complains that if one were to run the code in that file, `.toHaveFocus()` another functions don't actually exist on the cypress `expect()`. Runtime-wise this is not a problem because we don't run that code during cypress testing, we just import the file in order to use the `TestField` type definition.

This commit thus separates out code relating to `TestField`, away from the testing utility function code. `fillAndDownloadApplication.cy.ts` now imports from `src/app/form/_utils/testUtils/testFields.ts` which does not contain any `expect()` statements.


## How should a reviewer test?

- Locally, run `npm install` then `npm run dev`.
- Open `cypress/e2e/fillAndDownloadApplication.cy.ts`, and add `const a: string = 1;`, which is a type violation
- Run `npm run typecheck`. The time check should fail
