### PR TITLE
[newjersey/doula-pm#449] Fix cypress flake

### DIFF
--- a/cypress/e2e/fillAndDownloadApplication.cy.ts
+++ b/cypress/e2e/fillAndDownloadApplication.cy.ts
@@ -77,7 +77,7 @@ const testFieldsArePrepopulated = (
   for (const _ of formPages.slice(0, -1)) {
     cy.contains("button", "Next").click();
   }
-  cy.contains("button", "Review").click();
+  cy.contains("button", "Review", { timeout: 8000 }).click();
   cy.url().should("eq", `${Cypress.config("baseUrl")}/form/review`);
 };
 

--- a/cypress/e2e/utils/testFillApplication.ts
+++ b/cypress/e2e/utils/testFillApplication.ts
@@ -100,7 +100,7 @@ export const testFillApplication = (
     if (index !== formPages.length - 1) {
       cy.contains("button", "Next").click();
     } else {
-      cy.contains("button", "Review").click();
+      cy.contains("button", "Review", { timeout: 8000 }).click();
     }
   }
   cy.url().should("eq", `${Cypress.config("baseUrl")}/form/review`);


### PR DESCRIPTION
## Link to issue

This commit contributes to newjersey/doula-pm#449.

## What was done?
Double the time out for finding and clicking the "Review" button. Not this will actually fix it - it's actually suspicious that the review button of all things is failing. Nte that this is not the download button that is taking a while, but the Review button on http://localhost:3000/humanservices/dmahs/info/doulahelp/form/legal/3.

Instances of test flakes include
- https://github.com/newjersey/doula-medicaid/actions/runs/21052538874/job/60541817814
- https://github.com/newjersey/doula-medicaid/actions/runs/21100841356/job/60684799143
- https://github.com/newjersey/doula-medicaid/actions/runs/20831026325/job/59844961303?pr=448


## How should a reviewer test?

- Haven't actually got in this to flake locally :/
